### PR TITLE
Remove OIDS from `ag_label`

### DIFF
--- a/age--1.0.0.sql
+++ b/age--1.0.0.sql
@@ -48,9 +48,7 @@ CREATE TABLE ag_label (
   id label_id,
   kind label_kind,
   relation regclass NOT NULL
-) WITH (OIDS);
-
-CREATE UNIQUE INDEX ag_label_oid_index ON ag_label USING btree (oid);
+);
 
 CREATE UNIQUE INDEX ag_label_name_graph_index
 ON ag_label

--- a/src/backend/catalog/ag_label.c
+++ b/src/backend/catalog/ag_label.c
@@ -126,17 +126,6 @@ void delete_label(Oid relation)
     heap_close(ag_label, RowExclusiveLock);
 }
 
-Oid get_label_oid(const char *label_name, Oid label_graph)
-{
-    label_cache_data *cache_data;
-
-    cache_data = search_label_name_graph_cache(label_name, label_graph);
-    if (cache_data)
-        return cache_data->oid;
-    else
-        return InvalidOid;
-}
-
 int32 get_label_id(const char *label_name, Oid label_graph)
 {
     label_cache_data *cache_data;

--- a/src/include/catalog/ag_label.h
+++ b/src/include/catalog/ag_label.h
@@ -53,7 +53,6 @@
 #define Natts_ag_label 5
 
 #define ag_label_relation_id() ag_relation_id("ag_label", "table")
-#define ag_label_oid_index_id() ag_relation_id("ag_label_oid_index", "index")
 #define ag_label_name_graph_index_id() \
     ag_relation_id("ag_label_name_graph_index", "index")
 #define ag_label_graph_id_index_id() \
@@ -70,7 +69,6 @@ Oid insert_label(const char *label_name, Oid label_graph, int32 label_id,
                  char label_kind, Oid label_relation);
 void delete_label(Oid relation);
 
-Oid get_label_oid(const char *label_name, Oid label_graph);
 int32 get_label_id(const char *label_name, Oid label_graph);
 Oid get_label_relation(const char *label_name, Oid label_graph);
 char *get_label_relation_name(const char *label_name, Oid label_graph);
@@ -81,6 +79,6 @@ RangeVar *get_label_range_var(char *graph_name, Oid graph_oid, char *label_name)
 List *get_all_edge_labels_per_graph(EState *estate, Oid graph_oid);
 
 #define label_exists(label_name, label_graph) \
-    OidIsValid(get_label_oid(label_name, label_graph))
+    get_label_id(label_name, label_graph) != INVALID_LABEL_ID
 
 #endif

--- a/src/include/utils/ag_cache.h
+++ b/src/include/utils/ag_cache.h
@@ -33,7 +33,6 @@ typedef struct graph_cache_data
 // label_cache_data contains the same fields that ag_label catalog table has
 typedef struct label_cache_data
 {
-    Oid oid;
     NameData name;
     Oid graph;
     int32 id;
@@ -44,7 +43,6 @@ typedef struct label_cache_data
 // callers of these functions must not modify the returned struct
 graph_cache_data *search_graph_name_cache(const char *name);
 graph_cache_data *search_graph_namespace_cache(Oid namespace);
-label_cache_data *search_label_oid_cache(Oid oid);
 label_cache_data *search_label_name_graph_cache(const char *name, Oid graph);
 label_cache_data *search_label_graph_id_cache(Oid graph, int32 id);
 label_cache_data *search_label_relation_cache(Oid relation);


### PR DESCRIPTION
Although OIDS is defined, the only part that is actually used is the logic of determining the existence of the label.
However, this is eliminated because it can be implemented with other fields such as label_id.

In the case of upgrading this, OIDS may be removed using 'ALTER TABLE ag_label SET WITHOUT OIDS'.

related : https://github.com/apache/incubator-age/issues/20

```pgsql
DROP index ag_label_oid_index;
ALTER TABLE ag_label SET WITHOUT OIDS;
```