### PR TITLE
Remove OIDS from `ag_graph`

### DIFF
--- a/age--1.0.0.sql
+++ b/age--1.0.0.sql
@@ -24,12 +24,14 @@
 -- catalog tables
 --
 
+CREATE DOMAIN graphoid AS int NOT NULL CHECK (VALUE > 0);
+CREATE SEQUENCE ag_graph_id_seq START 1;
+
 CREATE TABLE ag_graph (
+  id graphoid PRIMARY KEY DEFAULT nextval('ag_graph_id_seq'),
   name name NOT NULL,
   namespace regnamespace NOT NULL
-) WITH (OIDS);
-
-CREATE UNIQUE INDEX ag_graph_oid_index ON ag_graph USING btree (oid);
+);
 
 CREATE UNIQUE INDEX ag_graph_name_index ON ag_graph USING btree (name);
 
@@ -44,7 +46,7 @@ CREATE DOMAIN label_kind AS "char" NOT NULL CHECK (VALUE = 'v' OR VALUE = 'e');
 
 CREATE TABLE ag_label (
   name name NOT NULL,
-  graph oid NOT NULL,
+  graph graphoid NOT NULL,
   id label_id,
   kind label_kind,
   relation regclass NOT NULL
@@ -348,7 +350,7 @@ IMMUTABLE
 PARALLEL SAFE
 AS 'MODULE_PATHNAME';
 
-CREATE FUNCTION ag_catalog._label_name(graph_oid oid, graphid)
+CREATE FUNCTION ag_catalog._label_name(graph_oid int, graphid)
 RETURNS cstring
 LANGUAGE c
 STABLE

--- a/regress/expected/catalog.out
+++ b/regress/expected/catalog.out
@@ -29,9 +29,9 @@ NOTICE:  graph "g" has been created
 (1 row)
 
 SELECT * FROM ag_graph WHERE name = 'g';
- name | namespace 
-------+-----------
- g    | g
+ id | name | namespace 
+----+------+-----------
+  2 | g    | g
 (1 row)
 
 -- create a label to test drop_label()
@@ -120,9 +120,9 @@ NOTICE:  graph "GraphB" has been created
 
 -- Show GraphA's construction to verify case is preserved.
 SELECT * FROM ag_graph WHERE name = 'GraphA';
-  name  | namespace 
---------+-----------
- GraphA | "GraphA"
+ id |  name  | namespace 
+----+--------+-----------
+  3 | GraphA | "GraphA"
 (1 row)
 
 SELECT nspname FROM pg_namespace WHERE nspname = 'GraphA';
@@ -141,9 +141,9 @@ NOTICE:  graph "GraphA" renamed to "GraphX"
 
 -- Show GraphX's construction to verify case is preserved.
 SELECT * FROM ag_graph WHERE name = 'GraphX';
-  name  | namespace 
---------+-----------
- GraphX | "GraphX"
+ id |  name  | namespace 
+----+--------+-----------
+  3 | GraphX | "GraphX"
 (1 row)
 
 SELECT nspname FROM pg_namespace WHERE nspname = 'GraphX';
@@ -154,8 +154,8 @@ SELECT nspname FROM pg_namespace WHERE nspname = 'GraphX';
 
 -- Verify there isn't a graph GraphA anymore.
 SELECT * FROM ag_graph WHERE name = 'GraphA';
- name | namespace 
-------+-----------
+ id | name | namespace 
+----+------+-----------
 (0 rows)
 
 SELECT * FROM pg_namespace WHERE nspname = 'GraphA';

--- a/src/backend/catalog/ag_graph.c
+++ b/src/backend/catalog/ag_graph.c
@@ -39,16 +39,21 @@
 static Oid get_graph_namespace(const char *graph_name);
 
 // INSERT INTO ag_catalog.ag_graph VALUES (graph_name, nsp_id)
-Oid insert_graph(const Name graph_name, const Oid nsp_id)
+graphoid insert_graph(const Name graph_name, const Oid nsp_id)
 {
     Datum values[Natts_ag_graph];
     bool nulls[Natts_ag_graph];
     Relation ag_graph;
     HeapTuple tuple;
-    Oid graph_oid;
+    graphoid graph_oid;
 
     AssertArg(graph_name);
     AssertArg(OidIsValid(nsp_id));
+
+    graph_oid = get_next_graph_oid();
+
+    values[Anum_ag_graph_oid - 1] = graph_oid;
+    nulls[Anum_ag_graph_oid - 1] = false;
 
     values[Anum_ag_graph_name - 1] = NameGetDatum(graph_name);
     nulls[Anum_ag_graph_name - 1] = false;
@@ -64,7 +69,7 @@ Oid insert_graph(const Name graph_name, const Oid nsp_id)
      * CatalogTupleInsert() is originally for PostgreSQL's catalog. However,
      * it is used at here for convenience.
      */
-    graph_oid = CatalogTupleInsert(ag_graph, tuple);
+    CatalogTupleInsert(ag_graph, tuple);
 
     heap_close(ag_graph, RowExclusiveLock);
 
@@ -149,7 +154,7 @@ void update_graph_name(const Name graph_name, const Name new_name)
     heap_close(ag_graph, RowExclusiveLock);
 }
 
-Oid get_graph_oid(const char *graph_name)
+graphoid get_graph_oid(const char *graph_name)
 {
     graph_cache_data *cache_data;
 
@@ -157,7 +162,7 @@ Oid get_graph_oid(const char *graph_name)
     if (cache_data)
         return cache_data->oid;
     else
-        return InvalidOid;
+        return INVALID_AG_GRAPH_OID;
 }
 
 static Oid get_graph_namespace(const char *graph_name)

--- a/src/backend/commands/graph_commands.c
+++ b/src/backend/commands/graph_commands.c
@@ -362,7 +362,7 @@ List *get_graphnames(void)
 
         slot_getallattrs(slot);
 
-        str = DatumGetCString(slot->tts_values[0]);
+        str = DatumGetCString(slot->tts_values[Anum_ag_graph_name - 1]);
         graphnames = lappend(graphnames, str);
     }
 

--- a/src/backend/commands/label_commands.c
+++ b/src/backend/commands/label_commands.c
@@ -81,7 +81,7 @@ static Constraint *build_not_null_constraint(void);
 static Constraint *build_properties_default(void);
 static void alter_sequence_owned_by_for_label(RangeVar *seq_range_var,
                                               char *rel_name);
-static int32 get_new_label_id(Oid graph_oid, Oid nsp_id);
+static int32 get_new_label_id(graphoid graph_oid, Oid nsp_id);
 static void change_label_id_default(char *graph_name, char *label_name,
                                     char *schema_name, char *seq_name,
                                     Oid relid);
@@ -112,7 +112,7 @@ Datum create_vlabel(PG_FUNCTION_ARGS)
     char *graph;
     Name graph_name;
     char *graph_name_str;
-    Oid graph_oid;
+    graphoid graph_oid;
     List *parent;
 
     RangeVar *rv;
@@ -192,7 +192,7 @@ Datum create_elabel(PG_FUNCTION_ARGS)
     char *graph;
     Name graph_name;
     char *graph_name_str;
-    Oid graph_oid;
+    graphoid graph_oid;
     List *parent;
 
     RangeVar *rv;
@@ -263,7 +263,7 @@ Oid create_label(char *graph_name, char *label_name, char label_type,
                  List *parents)
 {
     graph_cache_data *cache_data;
-    Oid graph_oid;
+    graphoid graph_oid;
     Oid nsp_id;
     char *schema_name;
     char *rel_name;
@@ -661,7 +661,7 @@ static void alter_sequence_owned_by_for_label(RangeVar *seq_range_var,
     CommandCounterIncrement();
 }
 
-static int32 get_new_label_id(Oid graph_oid, Oid nsp_id)
+static int32 get_new_label_id(graphoid graph_oid, Oid nsp_id)
 {
     Oid seq_id;
     int cnt;
@@ -683,7 +683,9 @@ static int32 get_new_label_id(Oid graph_oid, Oid nsp_id)
         label_id = nextval_internal(seq_id, true);
         Assert(label_id_is_valid(label_id));
         if (!label_id_exists(graph_oid, label_id))
-            return (int32)label_id;
+        {
+            return (int32) label_id;
+        }
     }
 
     ereport(ERROR, (errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
@@ -702,7 +704,7 @@ Datum drop_label(PG_FUNCTION_ARGS)
     bool force;
     char *graph_name_str;
     graph_cache_data *cache_data;
-    Oid graph_oid;
+    graphoid graph_oid;
     Oid nsp_id;
     char *label_name_str;
     Oid label_relation;

--- a/src/backend/executor/cypher_utils.c
+++ b/src/backend/executor/cypher_utils.c
@@ -167,7 +167,7 @@ TupleTableSlot *populate_edge_tts(
  * Find out if the entity still exists. This is for 'implicit' deletion
  * of an entity.
  */
-bool entity_exists(EState *estate, Oid graph_oid, graphid id)
+bool entity_exists(EState *estate, graphoid graph_oid, graphid id)
 {
     label_cache_data *label;
     ScanKeyData scan_keys[1];

--- a/src/backend/nodes/cypher_outfuncs.c
+++ b/src/backend/nodes/cypher_outfuncs.c
@@ -303,7 +303,7 @@ void out_cypher_create_target_nodes(StringInfo str, const ExtensibleNode *node)
 
     WRITE_NODE_FIELD(paths);
     WRITE_INT32_FIELD(flags);
-    WRITE_OID_FIELD(graph_oid);
+    WRITE_INT32_FIELD(graph_oid);
 }
 
 // serialization function for the cypher_create_path ExtensibleNode.
@@ -370,7 +370,7 @@ void out_cypher_delete_information(StringInfo str, const ExtensibleNode *node)
     WRITE_NODE_FIELD(delete_items);
     WRITE_INT32_FIELD(flags);
     WRITE_STRING_FIELD(graph_name);
-    WRITE_OID_FIELD(graph_oid);
+    WRITE_INT32_FIELD(graph_oid);
     WRITE_BOOL_FIELD(detach);
 }
 
@@ -389,7 +389,7 @@ void out_cypher_merge_information(StringInfo str, const ExtensibleNode *node)
     DEFINE_AG_NODE(cypher_merge_information);
 
     WRITE_INT32_FIELD(flags);
-    WRITE_OID_FIELD(graph_oid);
+    WRITE_INT32_FIELD(graph_oid);
     WRITE_INT32_FIELD(merge_function_attr);
     WRITE_NODE_FIELD(path);
 }

--- a/src/backend/nodes/cypher_readfuncs.c
+++ b/src/backend/nodes/cypher_readfuncs.c
@@ -179,7 +179,7 @@ void read_cypher_create_target_nodes(struct ExtensibleNode *node)
 
     READ_NODE_FIELD(paths);
     READ_INT_FIELD(flags);
-    READ_OID_FIELD(graph_oid);
+    READ_INT_FIELD(graph_oid);
 }
 
 /*
@@ -261,7 +261,7 @@ void read_cypher_delete_information(struct ExtensibleNode *node)
     READ_NODE_FIELD(delete_items);
     READ_INT_FIELD(flags);
     READ_STRING_FIELD(graph_name);
-    READ_OID_FIELD(graph_oid);
+    READ_INT_FIELD(graph_oid);
     READ_BOOL_FIELD(detach);
 }
 
@@ -286,7 +286,7 @@ void read_cypher_merge_information(struct ExtensibleNode *node)
     READ_LOCALS(cypher_merge_information);
 
     READ_INT_FIELD(flags);
-    READ_OID_FIELD(graph_oid);
+    READ_INT_FIELD(graph_oid);
     READ_INT_FIELD(merge_function_attr);
     READ_NODE_FIELD(path);
 }

--- a/src/backend/parser/cypher_analyze.c
+++ b/src/backend/parser/cypher_analyze.c
@@ -58,11 +58,12 @@ static const char *expr_get_const_cstring(Node *expr, const char *source_str);
 static int get_query_location(const int location, const char *source_str);
 static Query *analyze_cypher(List *stmt, ParseState *parent_pstate,
                              const char *query_str, int query_loc,
-                             char *graph_name, Oid graph_oid, Param *params);
+                             char *graph_name, graphoid graph_oid,
+                             Param *params);
 static Query *analyze_cypher_and_coerce(List *stmt, RangeTblFunction *rtfunc,
                                         ParseState *parent_pstate,
                                         const char *query_str, int query_loc,
-                                        char *graph_name, Oid graph_oid,
+                                        char *graph_name, graphoid graph_oid,
                                         Param *params);
 
 void post_parse_analyze_init(void)
@@ -271,7 +272,7 @@ static void convert_cypher_to_subquery(RangeTblEntry *rte, ParseState *pstate)
     FuncExpr *funcexpr = (FuncExpr *)rtfunc->funcexpr;
     Node *arg;
     Name graph_name;
-    Oid graph_oid;
+    graphoid graph_oid;
     const char *query_str;
     int query_loc;
     Param *params;
@@ -305,7 +306,7 @@ static void convert_cypher_to_subquery(RangeTblEntry *rte, ParseState *pstate)
     }
 
     graph_oid = get_graph_oid(NameStr(*graph_name));
-    if (!OidIsValid(graph_oid))
+    if (!graph_oid_is_valid(graph_oid))
     {
         ereport(ERROR,
                 (errcode(ERRCODE_UNDEFINED_SCHEMA),
@@ -485,7 +486,8 @@ static int get_query_location(const int location, const char *source_str)
 
 static Query *analyze_cypher(List *stmt, ParseState *parent_pstate,
                              const char *query_str, int query_loc,
-                             char *graph_name, Oid graph_oid, Param *params)
+                             char *graph_name, graphoid graph_oid,
+                             Param *params)
 {
     cypher_clause *clause;
     ListCell *lc;
@@ -564,7 +566,7 @@ static Query *analyze_cypher(List *stmt, ParseState *parent_pstate,
 static Query *analyze_cypher_and_coerce(List *stmt, RangeTblFunction *rtfunc,
                                         ParseState *parent_pstate,
                                         const char *query_str, int query_loc,
-                                        char *graph_name, Oid graph_oid,
+                                        char *graph_name, graphoid graph_oid,
                                         Param *params)
 {
     ParseState *pstate;
@@ -594,7 +596,7 @@ static Query *analyze_cypher_and_coerce(List *stmt, RangeTblFunction *rtfunc,
     pstate->p_lateral_active = lateral;
 
     subquery = analyze_cypher(stmt, pstate, query_str, query_loc, graph_name,
-                              graph_oid, (Param *)params);
+                              graph_oid, (Param *) params);
 
     pstate->p_lateral_active = false;
     pstate->p_expr_kind = EXPR_KIND_NONE;

--- a/src/backend/parser/cypher_clause.c
+++ b/src/backend/parser/cypher_clause.c
@@ -4089,12 +4089,12 @@ static Node *make_edge_expr(cypher_parsestate *cpstate, RangeTblEntry *rte,
     end_id = scanRTEForColumn(pstate, rte, AG_EDGE_COLNAME_END_ID, -1, 0,
                               NULL);
 
-    label_name_func_oid = get_ag_func_oid("_label_name", 2, OIDOID,
+    label_name_func_oid = get_ag_func_oid("_label_name", 2, GRAPHOIDOID,
                                           GRAPHIDOID);
 
-    graph_oid_const = makeConst(OIDOID, -1, InvalidOid, sizeof(Oid),
-                                ObjectIdGetDatum(cpstate->graph_oid), false,
-                                true);
+    graph_oid_const =
+        makeConst(GRAPHOIDOID, -1, INVALID_AG_GRAPH_OID, sizeof(graphoid),
+                  GraphOidGetDatum(cpstate->graph_oid), false, true);
 
     label_name_args = list_make2(graph_oid_const, id);
 
@@ -4132,12 +4132,12 @@ static Node *make_vertex_expr(cypher_parsestate *cpstate, RangeTblEntry *rte,
 
     id = scanRTEForColumn(pstate, rte, AG_VERTEX_COLNAME_ID, -1, 0, NULL);
 
-    label_name_func_oid = get_ag_func_oid("_label_name", 2, OIDOID,
+    label_name_func_oid = get_ag_func_oid("_label_name", 2, GRAPHOIDOID,
                                           GRAPHIDOID);
 
-    graph_oid_const = makeConst(OIDOID, -1, InvalidOid, sizeof(Oid),
-                                ObjectIdGetDatum(cpstate->graph_oid), false,
-                                true);
+    graph_oid_const =
+        makeConst(GRAPHOIDOID, -1, INVALID_AG_GRAPH_OID, sizeof(graphoid),
+                  GraphOidGetDatum(cpstate->graph_oid), false, true);
 
     label_name_args = list_make2(graph_oid_const, id);
 

--- a/src/backend/utils/adt/age_global_graph.c
+++ b/src/backend/utils/adt/age_global_graph.c
@@ -20,18 +20,18 @@
 #include "postgres.h"
 
 #include "catalog/namespace.h"
+#include "commands/label_commands.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 #include "utils/rel.h"
 #include "utils/snapmgr.h"
-#include "commands/label_commands.h"
 
-#include "utils/age_global_graph.h"
-#include "utils/agtype.h"
 #include "catalog/ag_graph.h"
 #include "catalog/ag_label.h"
-#include "utils/graphid.h"
+#include "utils/age_global_graph.h"
 #include "utils/age_graphid_ds.h"
+#include "utils/agtype.h"
+#include "utils/graphid.h"
 
 /* defines */
 #define VERTEX_HTAB_NAME "Vertex to edge lists " /* added a space at end for */
@@ -70,7 +70,7 @@ typedef struct edge_entry
 typedef struct GRAPH_global_context
 {
     char *graph_name;              /* graph name */
-    Oid graph_oid;                 /* graph oid for searching */
+    graphoid graph_oid;            /* graph oid for searching */
     HTAB *vertex_hashtable;        /* hashtable to hold vertex edge lists */
     HTAB *edge_hashtable;          /* hashtable to hold edge to vertex map */
     TransactionId xmin;            /* transaction ids for this graph */
@@ -94,7 +94,7 @@ static void load_GRAPH_global_hashtables(GRAPH_global_context *ggctx);
 static void load_vertex_hashtable(GRAPH_global_context *ggctx);
 static void load_edge_hashtable(GRAPH_global_context *ggctx);
 static void freeze_GRAPH_global_hashtables(GRAPH_global_context *ggctx);
-static List *get_ag_labels_names(Snapshot snapshot, Oid graph_oid,
+static List *get_ag_labels_names(Snapshot snapshot, graphoid graph_oid,
                                  char label_type);
 static bool insert_edge(GRAPH_global_context *ggctx, graphid edge_id,
                         Datum edge_properties, graphid start_vertex_id,
@@ -161,7 +161,7 @@ static void create_GRAPH_global_hashtables(GRAPH_global_context *ggctx)
 }
 
 /* helper function to get a List of all label names for the specified graph */
-static List *get_ag_labels_names(Snapshot snapshot, Oid graph_oid,
+static List *get_ag_labels_names(Snapshot snapshot, graphoid graph_oid,
                                  char label_type)
 {
     List *labels = NIL;
@@ -176,7 +176,7 @@ static List *get_ag_labels_names(Snapshot snapshot, Oid graph_oid,
 
     /* setup scan keys to get all edges for the given graph oid */
     ScanKeyInit(&scan_keys[1], Anum_ag_label_graph, BTEqualStrategyNumber,
-                F_OIDEQ, ObjectIdGetDatum(graph_oid));
+                F_GRAPHOIDEQ, GraphOidGetDatum(graph_oid));
     ScanKeyInit(&scan_keys[0], Anum_ag_label_kind, BTEqualStrategyNumber,
                 F_CHAREQ, CharGetDatum(label_type));
 
@@ -355,7 +355,7 @@ static bool insert_vertex_edge(GRAPH_global_context *ggctx,
 /* helper routine to load all vertices into the GRAPH global vertex hashtable */
 static void load_vertex_hashtable(GRAPH_global_context *ggctx)
 {
-    Oid graph_oid;
+    graphoid graph_oid;
     Oid graph_namespace_oid;
     Snapshot snapshot;
     List *vertex_label_names = NIL;
@@ -453,7 +453,7 @@ static void load_GRAPH_global_hashtables(GRAPH_global_context *ggctx)
  */
 static void load_edge_hashtable(GRAPH_global_context *ggctx)
 {
-    Oid graph_oid;
+    graphoid graph_oid;
     Oid graph_namespace_oid;
     Snapshot snapshot;
     List *edge_label_names = NIL;
@@ -640,7 +640,7 @@ static void free_specific_GRAPH_global_context(GRAPH_global_context *ggctx)
  * returns the GRAPH global context for the specified graph.
  */
 GRAPH_global_context *manage_GRAPH_global_contexts(char *graph_name,
-                                                   Oid graph_oid)
+                                                   graphoid graph_oid)
 {
     GRAPH_global_context *new_ggctx = NULL;
     GRAPH_global_context *curr_ggctx = NULL;
@@ -789,7 +789,7 @@ static bool delete_specific_GRAPH_global_contexts(char *graph_name)
 {
     GRAPH_global_context *prev_ggctx = NULL;
     GRAPH_global_context *curr_ggctx = NULL;
-    Oid graph_oid = InvalidOid;
+    graphoid graph_oid = INVALID_AG_GRAPH_OID;
 
     if (graph_name == NULL)
     {
@@ -873,7 +873,7 @@ edge_entry *get_edge_entry(GRAPH_global_context *ggctx, graphid edge_id)
  * Helper function to find the GRAPH_global_context used by the specified
  * graph_oid. If not found, it returns NULL.
  */
-GRAPH_global_context *find_GRAPH_global_context(Oid graph_oid)
+GRAPH_global_context *find_GRAPH_global_context(graphoid graph_oid)
 {
     GRAPH_global_context *ggctx = NULL;
 
@@ -1012,7 +1012,7 @@ Datum age_vertex_stats(PG_FUNCTION_ARGS)
     agtype_value agtv_integer;
     agtype_in_state result;
     char *graph_name = NULL;
-    Oid graph_oid = InvalidOid;
+    graphoid graph_oid = INVALID_AG_GRAPH_OID;
     graphid vid = 0;
     int64 self_loops = 0;
     int64 degree = 0;

--- a/src/backend/utils/adt/age_vle.c
+++ b/src/backend/utils/adt/age_vle.c
@@ -66,7 +66,7 @@ typedef enum
 typedef struct VLE_local_context
 {
     char *graph_name;              /* name of the graph */
-    Oid graph_oid;                 /* graph oid for searching */
+    graphoid graph_oid;            /* graph oid for searching */
     GRAPH_global_context *ggctx;   /* global graph context pointer */
     graphid vsid;                  /* starting vertex id */
     graphid veid;                  /* ending vertex id */
@@ -98,7 +98,7 @@ typedef struct VLE_path_container
 {
     char vl_len_[4]; /* Do not touch this field! */
     uint32 header;
-    uint32 graph_oid;
+    graphoid graph_oid;
     int64 graphid_array_size;
     int64 container_size_bytes;
     graphid graphid_array_data;
@@ -478,7 +478,7 @@ static VLE_local_context *build_local_vle_context(FunctionCallInfo fcinfo,
     agtype_value *agtv_temp = NULL;
     agtype_value *agtv_object = NULL;
     char *graph_name = NULL;
-    Oid graph_oid = InvalidOid;
+    graphoid graph_oid = INVALID_AG_GRAPH_OID;
     int64 vle_grammar_node_id = 0;
     bool use_cache = false;
 
@@ -1461,7 +1461,7 @@ static agtype_value *build_edge_list(VLE_path_container *vpc)
 {
     GRAPH_global_context *ggctx = NULL;
     agtype_in_state edges_result;
-    Oid graph_oid = InvalidOid;
+    graphoid graph_oid = INVALID_AG_GRAPH_OID;
     graphid *graphid_array = NULL;
     int64 graphid_array_size = 0;
     int index = 0;
@@ -1525,7 +1525,7 @@ static agtype_value *build_path(VLE_path_container *vpc)
 {
     GRAPH_global_context *ggctx = NULL;
     agtype_in_state path_result;
-    Oid graph_oid = InvalidOid;
+    graphoid graph_oid = INVALID_AG_GRAPH_OID;
     graphid *graphid_array = NULL;
     int64 graphid_array_size = 0;
     int index = 0;

--- a/src/backend/utils/adt/agtype.c
+++ b/src/backend/utils/adt/agtype.c
@@ -4228,11 +4228,11 @@ static char *get_label_name(const char *graph_name, int64 graphid)
     TupleDesc tupdesc;
     char *result = NULL;
 
-    Oid graphoid = get_graph_oid(graph_name);
+    graphoid graph_oid = get_graph_oid(graph_name);
 
     /* scankey for first match in ag_label, column 2, graphoid, BTEQ, OidEQ */
     ScanKeyInit(&scan_keys[0], Anum_ag_label_graph, BTEqualStrategyNumber,
-                F_OIDEQ, ObjectIdGetDatum(graphoid));
+                F_GRAPHOIDEQ, GraphOidGetDatum(graph_oid));
     /* scankey for second match in ag_label, column 3, label id, BTEQ, Int4EQ */
     ScanKeyInit(&scan_keys[1], Anum_ag_label_id, BTEqualStrategyNumber,
                 F_INT4EQ, Int32GetDatum(get_graphid_label_id(graphid)));
@@ -4292,7 +4292,7 @@ static Datum get_vertex(const char *graph, const char *vertex_label,
     Snapshot snapshot = GetActiveSnapshot();
 
     /* initialize the scan key */
-    ScanKeyInit(&scan_keys[0], 1, BTEqualStrategyNumber, F_OIDEQ,
+    ScanKeyInit(&scan_keys[0], 1, BTEqualStrategyNumber, F_INT8EQ,
                 Int64GetDatum(graphid));
 
     /* open the relation (table), begin the scan, and get the tuple  */

--- a/src/backend/utils/cache/ag_cache.c
+++ b/src/backend/utils/cache/ag_cache.c
@@ -60,7 +60,7 @@ typedef struct graph_namespace_cache_entry
 typedef struct label_name_graph_cache_key
 {
     NameData name;
-    Oid graph;
+    graphoid graph;
 } label_name_graph_cache_key;
 
 typedef struct label_name_graph_cache_entry
@@ -71,7 +71,7 @@ typedef struct label_name_graph_cache_entry
 
 typedef struct label_graph_id_cache_key
 {
-    Oid graph;
+    graphoid graph;
     int32 id;
 } label_graph_id_cache_key;
 
@@ -151,12 +151,12 @@ static void invalidate_label_relation_cache(Oid relid);
 static void flush_label_relation_cache(void);
 static label_cache_data *search_label_oid_cache_miss(Oid oid);
 static label_cache_data *search_label_name_graph_cache_miss(Name name,
-                                                            Oid graph);
-static void *label_name_graph_cache_hash_search(Name name, Oid graph,
-                                                HASHACTION action,
-                                                bool *found);
-static label_cache_data *search_label_graph_id_cache_miss(Oid graph, int32 id);
-static void *label_graph_id_cache_hash_search(Oid graph, int32 id,
+                                                            graphoid graph);
+static void *label_name_graph_cache_hash_search(Name name, graphoid graph,
+                                                HASHACTION action, bool *found);
+static label_cache_data *search_label_graph_id_cache_miss(graphoid graph,
+                                                          int32 id);
+static void *label_graph_id_cache_hash_search(graphoid graph, int32 id,
                                               HASHACTION action, bool *found);
 static label_cache_data *search_label_relation_cache_miss(Oid relation);
 static void fill_label_cache_data(label_cache_data *cache_data,
@@ -451,10 +451,10 @@ static void fill_graph_cache_data(graph_cache_data *cache_data,
     bool is_null;
     Datum value;
 
-    // ag_graph.oid
-    value = heap_getattr(tuple, ObjectIdAttributeNumber, tuple_desc, &is_null);
+    // ag_graph.id
+    value = heap_getattr(tuple, Anum_ag_graph_oid, tuple_desc, &is_null);
     Assert(!is_null);
-    cache_data->oid = DatumGetObjectId(value);
+    cache_data->oid = DatumGetGraphOid(value);
     // ag_graph.name
     value = heap_getattr(tuple, Anum_ag_graph_name, tuple_desc, &is_null);
     Assert(!is_null);
@@ -475,11 +475,11 @@ static void initialize_label_caches(void)
     ag_cache_scan_key_init(&label_name_graph_scan_keys[0], Anum_ag_label_name,
                            F_NAMEEQ);
     ag_cache_scan_key_init(&label_name_graph_scan_keys[1], Anum_ag_label_graph,
-                           F_OIDEQ);
+                           F_GRAPHOIDEQ);
 
     // ag_label.graph, ag_label.id
     ag_cache_scan_key_init(&label_graph_id_scan_keys[0], Anum_ag_label_graph,
-                           F_OIDEQ);
+                           F_GRAPHOIDEQ);
     ag_cache_scan_key_init(&label_graph_id_scan_keys[1], Anum_ag_label_id,
                            F_INT4EQ);
 
@@ -861,13 +861,14 @@ static label_cache_data *search_label_oid_cache_miss(Oid oid)
     return entry;
 }
 
-label_cache_data *search_label_name_graph_cache(const char *name, Oid graph)
+label_cache_data *search_label_name_graph_cache(const char *name,
+                                                graphoid graph)
 {
     NameData name_key;
     label_name_graph_cache_entry *entry;
 
     AssertArg(name);
-    AssertArg(OidIsValid(graph));
+    AssertArg(graph_oid_is_valid(graph));
 
     initialize_caches();
 
@@ -881,7 +882,7 @@ label_cache_data *search_label_name_graph_cache(const char *name, Oid graph)
 }
 
 static label_cache_data *search_label_name_graph_cache_miss(Name name,
-                                                            Oid graph)
+                                                            graphoid graph)
 {
     ScanKeyData scan_keys[2];
     Relation ag_label;
@@ -893,7 +894,7 @@ static label_cache_data *search_label_name_graph_cache_miss(Name name,
     memcpy(scan_keys, label_name_graph_scan_keys,
            sizeof(label_name_graph_scan_keys));
     scan_keys[0].sk_argument = NameGetDatum(name);
-    scan_keys[1].sk_argument = ObjectIdGetDatum(graph);
+    scan_keys[1].sk_argument = DatumGetGraphOid(graph);
 
     /*
      * Calling heap_open() might call AcceptInvalidationMessage() and that
@@ -931,7 +932,7 @@ static label_cache_data *search_label_name_graph_cache_miss(Name name,
     return &entry->data;
 }
 
-static void *label_name_graph_cache_hash_search(Name name, Oid graph,
+static void *label_name_graph_cache_hash_search(Name name, graphoid graph,
                                                 HASHACTION action, bool *found)
 {
     label_name_graph_cache_key key;
@@ -943,11 +944,11 @@ static void *label_name_graph_cache_hash_search(Name name, Oid graph,
     return hash_search(label_name_graph_cache_hash, &key, action, found);
 }
 
-label_cache_data *search_label_graph_id_cache(Oid graph, int32 id)
+label_cache_data *search_label_graph_id_cache(graphoid graph, int32 id)
 {
     label_graph_id_cache_entry *entry;
 
-    AssertArg(OidIsValid(graph));
+    AssertArg(graph_oid_is_valid(graph));
     AssertArg(label_id_is_valid(id));
 
     initialize_caches();
@@ -959,7 +960,8 @@ label_cache_data *search_label_graph_id_cache(Oid graph, int32 id)
     return search_label_graph_id_cache_miss(graph, id);
 }
 
-static label_cache_data *search_label_graph_id_cache_miss(Oid graph, int32 id)
+static label_cache_data *search_label_graph_id_cache_miss(graphoid graph,
+                                                          int32 id)
 {
     ScanKeyData scan_keys[2];
     Relation ag_label;
@@ -970,7 +972,7 @@ static label_cache_data *search_label_graph_id_cache_miss(Oid graph, int32 id)
 
     memcpy(scan_keys, label_graph_id_scan_keys,
            sizeof(label_graph_id_scan_keys));
-    scan_keys[0].sk_argument = ObjectIdGetDatum(graph);
+    scan_keys[0].sk_argument = DatumGetGraphOid(graph);
     scan_keys[1].sk_argument = Int32GetDatum(id);
 
     /*
@@ -1008,7 +1010,7 @@ static label_cache_data *search_label_graph_id_cache_miss(Oid graph, int32 id)
     return &entry->data;
 }
 
-static void *label_graph_id_cache_hash_search(Oid graph, int32 id,
+static void *label_graph_id_cache_hash_search(graphoid graph, int32 id,
                                               HASHACTION action, bool *found)
 {
     label_graph_id_cache_key key;

--- a/src/backend/utils/load/ag_load_labels.c
+++ b/src/backend/utils/load/ag_load_labels.c
@@ -17,46 +17,9 @@
  * under the License.
  */
 
-#include <stdio.h>
-#include <string.h>
-#include <errno.h>
-#include <stdlib.h>
-#include <unistd.h>
-
 #include "postgres.h"
 
-#include "access/heapam.h"
-#include "access/xact.h"
-#include "catalog/dependency.h"
-#include "catalog/namespace.h"
-#include "catalog/objectaddress.h"
-#include "catalog/pg_class_d.h"
-#include "commands/defrem.h"
-#include "commands/sequence.h"
-#include "commands/tablecmds.h"
-#include "miscadmin.h"
-#include "nodes/makefuncs.h"
-#include "nodes/nodes.h"
-#include "nodes/parsenodes.h"
-#include "nodes/pg_list.h"
-#include "nodes/plannodes.h"
-#include "nodes/primnodes.h"
-#include "nodes/value.h"
-#include "parser/parse_node.h"
-#include "parser/parser.h"
-#include "storage/lockdefs.h"
-#include "tcop/dest.h"
-#include "tcop/utility.h"
-#include "utils/acl.h"
-#include "utils/builtins.h"
-#include "utils/inval.h"
-#include "utils/lsyscache.h"
-#include "utils/rel.h"
-
 #include "catalog/ag_graph.h"
-#include "catalog/ag_label.h"
-#include "commands/label_commands.h"
-#include "utils/ag_cache.h"
 #include "utils/agtype.h"
 #include "utils/graphid.h"
 
@@ -133,8 +96,8 @@ void vertex_row_cb(int delim __attribute__((unused)), void *data)
 
         props = create_agtype_from_list(cr->header, cr->fields,
                                         n_fields, label_id_int);
-        insert_vertex_simple(cr->graph_id, cr->object_name,
-                             object_graph_id, props);
+        insert_vertex_simple(cr->graph_oid, cr->object_name, object_graph_id,
+                             props);
     }
 
 
@@ -166,12 +129,9 @@ static int is_term(unsigned char c)
     if (c == CSV_CR || c == CSV_LF) return 1;
     return 0;
 }
-int create_labels_from_csv_file(char *file_path,
-                                char *graph_name,
-                                Oid graph_id,
-                                char *object_name,
-                                int object_id,
-                                bool id_field_exists)
+int create_labels_from_csv_file(char *file_path, char *graph_name,
+                                graphoid graph_oid, char *object_name,
+                                int object_id, bool id_field_exists)
 {
 
     FILE *fp;
@@ -206,7 +166,7 @@ int create_labels_from_csv_file(char *file_path,
     cr.header_row_length = 0;
     cr.curr_row_length = 0;
     cr.graph_name = graph_name;
-    cr.graph_id = graph_id;
+    cr.graph_oid = graph_oid;
     cr.object_name = object_name;
     cr.object_id = object_id;
     cr.id_field_exists = id_field_exists;

--- a/src/include/catalog/ag_graph.h
+++ b/src/include/catalog/ag_graph.h
@@ -22,28 +22,34 @@
 
 #include "postgres.h"
 
+#include "nodes/pg_list.h"
+
 #include "catalog/ag_catalog.h"
+#include "utils/graphoid.h"
 
-#define Anum_ag_graph_name 1
-#define Anum_ag_graph_namespace 2
+#define Anum_ag_graph_oid 1
+#define Anum_ag_graph_name 2
+#define Anum_ag_graph_namespace 3
 
-#define Natts_ag_graph 2
+#define Natts_ag_graph 3
 
+#define ag_graph_id_seq() ag_relation_id("ag_graph_id_seq", "sequence")
 #define ag_graph_relation_id() ag_relation_id("ag_graph", "table")
 #define ag_graph_name_index_id() ag_relation_id("ag_graph_name_index", "index")
 #define ag_graph_namespace_index_id() \
     ag_relation_id("ag_graph_namespace_index", "index")
 
-Oid insert_graph(const Name graph_name, const Oid nsp_id);
+graphoid insert_graph(const Name graph_name, const Oid nsp_id);
 void delete_graph(const Name graph_name);
 void update_graph_name(const Name graph_name, const Name new_name);
 
-Oid get_graph_oid(const char *graph_name);
+graphoid get_graph_oid(const char *graph_name);
 char *get_graph_namespace_name(const char *graph_name);
 
 List *get_graphnames(void);
 void drop_graphs(List *graphnames);
 
-#define graph_exists(graph_name) OidIsValid(get_graph_oid(graph_name))
+#define graph_exists(graph_name) \
+    (get_graph_oid(graph_name) != INVALID_AG_GRAPH_OID)
 
 #endif

--- a/src/include/catalog/ag_label.h
+++ b/src/include/catalog/ag_label.h
@@ -25,6 +25,7 @@
 #include "nodes/execnodes.h"
 
 #include "catalog/ag_catalog.h"
+#include "catalog/ag_graph.h"
 
 #define Anum_ag_label_vertex_table_id 1
 #define Anum_ag_label_vertex_table_properties 2
@@ -66,7 +67,7 @@
 #define LABEL_KIND_VERTEX 'v'
 #define LABEL_KIND_EDGE 'e'
 
-Oid insert_label(const char *label_name, Oid label_graph, int32 label_id,
+Oid insert_label(const char *label_name, graphoid label_graph, int32 label_id,
                  char label_kind, Oid label_relation);
 void delete_label(Oid relation);
 
@@ -76,9 +77,10 @@ Oid get_label_relation(const char *label_name, Oid label_graph);
 char *get_label_relation_name(const char *label_name, Oid label_graph);
 
 bool label_id_exists(Oid label_graph, int32 label_id);
-RangeVar *get_label_range_var(char *graph_name, Oid graph_oid, char *label_name);
+RangeVar *get_label_range_var(char *graph_name, graphoid graph_oid,
+                              char *label_name);
 
-List *get_all_edge_labels_per_graph(EState *estate, Oid graph_oid);
+List *get_all_edge_labels_per_graph(EState *estate, graphoid graph_oid);
 
 #define label_exists(label_name, label_graph) \
     OidIsValid(get_label_oid(label_name, label_graph))

--- a/src/include/executor/cypher_utils.h
+++ b/src/include/executor/cypher_utils.h
@@ -55,7 +55,7 @@ typedef struct cypher_create_custom_scan_state
     List *path_values;
     uint32 flags;
     TupleTableSlot *slot;
-    Oid graph_oid;
+    graphoid graph_oid;
 } cypher_create_custom_scan_state;
 
 typedef struct cypher_set_custom_scan_state
@@ -83,7 +83,7 @@ typedef struct cypher_merge_custom_scan_state
     int flags;
     cypher_create_path *path;
     List *path_values;
-    Oid graph_oid;
+    graphoid graph_oid;
     AttrNumber merge_function_attr;
     bool created_new_path;
     bool found_a_path;
@@ -99,7 +99,7 @@ ResultRelInfo *create_entity_result_rel_info(EState *estate, char *graph_name,
                                              char *label_name);
 void destroy_entity_result_rel_info(ResultRelInfo *result_rel_info);
 
-bool entity_exists(EState *estate, Oid graph_oid, graphid id);
+bool entity_exists(EState *estate, graphoid graph_oid, graphid id);
 HeapTuple insert_entity_tuple(ResultRelInfo *resultRelInfo,
                               TupleTableSlot *elemTupleSlot,
                               EState *estate);

--- a/src/include/nodes/cypher_nodes.h
+++ b/src/include/nodes/cypher_nodes.h
@@ -27,6 +27,7 @@
 #include "nodes/pg_list.h"
 
 #include "nodes/ag_nodes.h"
+#include "utils/graphoid.h"
 
 /* cypher sub patterns */
 typedef enum csp_kind
@@ -225,7 +226,7 @@ typedef struct cypher_create_target_nodes
     ExtensibleNode extensible;
     List *paths;
     uint32 flags;
-    Oid graph_oid;
+    graphoid graph_oid;
 } cypher_create_target_nodes;
 
 typedef struct cypher_create_path
@@ -368,7 +369,7 @@ typedef struct cypher_delete_information
     List *delete_items;
     int flags;
     char *graph_name;
-    Oid graph_oid;
+    graphoid graph_oid;
     bool detach;
 } cypher_delete_information;
 
@@ -383,7 +384,7 @@ typedef struct cypher_merge_information
 {
     ExtensibleNode extensible;
     int flags;
-    Oid graph_oid;
+    graphoid graph_oid;
     AttrNumber merge_function_attr;
     cypher_create_path *path;
 } cypher_merge_information;

--- a/src/include/parser/cypher_parse_node.h
+++ b/src/include/parser/cypher_parse_node.h
@@ -23,6 +23,8 @@
 #include "nodes/primnodes.h"
 #include "parser/parse_node.h"
 
+#include "catalog/ag_graph.h"
+
 #define AGE_DEFAULT_ALIAS_PREFIX "_age_default_alias_"
 #define AGE_DEFAULT_VARNAME_PREFIX "_age_varname_"
 
@@ -30,7 +32,7 @@ typedef struct cypher_parsestate
 {
     ParseState pstate;
     char *graph_name;
-    Oid graph_oid;
+    graphoid graph_oid;
     Param *params;
     int default_alias_num;
     List *entities;

--- a/src/include/utils/ag_cache.h
+++ b/src/include/utils/ag_cache.h
@@ -22,10 +22,12 @@
 
 #include "postgres.h"
 
+#include "catalog/ag_graph.h"
+
 // graph_cache_data contains the same fields that ag_graph catalog table has
 typedef struct graph_cache_data
 {
-    Oid oid;
+    graphoid oid;
     NameData name;
     Oid namespace;
 } graph_cache_data;
@@ -35,7 +37,7 @@ typedef struct label_cache_data
 {
     Oid oid;
     NameData name;
-    Oid graph;
+    graphoid graph;
     int32 id;
     char kind;
     Oid relation;
@@ -45,8 +47,9 @@ typedef struct label_cache_data
 graph_cache_data *search_graph_name_cache(const char *name);
 graph_cache_data *search_graph_namespace_cache(Oid namespace);
 label_cache_data *search_label_oid_cache(Oid oid);
-label_cache_data *search_label_name_graph_cache(const char *name, Oid graph);
-label_cache_data *search_label_graph_id_cache(Oid graph, int32 id);
+label_cache_data *search_label_name_graph_cache(const char *name,
+                                                graphoid graph);
+label_cache_data *search_label_graph_id_cache(graphoid graph, int32 id);
 label_cache_data *search_label_relation_cache(Oid relation);
 
 #endif

--- a/src/include/utils/age_global_graph.h
+++ b/src/include/utils/age_global_graph.h
@@ -20,8 +20,9 @@
 #ifndef AG_AGE_GLOBAL_GRAPH_H
 #define AG_AGE_GLOBAL_GRAPH_H
 
-#include "utils/graphid.h"
+#include "catalog/ag_graph.h"
 #include "utils/age_graphid_ds.h"
+#include "utils/graphid.h"
 
 /*
  * We declare the graph nodes and edges here, and in this way, so that it may be
@@ -39,8 +40,8 @@ typedef struct GRAPH_global_context GRAPH_global_context;
 
 /* GRAPH global context functions */
 GRAPH_global_context *manage_GRAPH_global_contexts(char *graph_name,
-                                                   Oid graph_oid);
-GRAPH_global_context *find_GRAPH_global_context(Oid graph_oid);
+                                                   graphoid graph_oid);
+GRAPH_global_context *find_GRAPH_global_context(graphoid graph_oid);
 /* GRAPH retrieval functions */
 ListGraphId *get_graph_vertices(GRAPH_global_context *ggctx);
 vertex_entry *get_vertex_entry(GRAPH_global_context *ggctx,

--- a/src/include/utils/age_graphid_ds.h
+++ b/src/include/utils/age_graphid_ds.h
@@ -20,6 +20,8 @@
 #ifndef AG_AGE_GRAPHID_DS_H
 #define AG_AGE_GRAPHID_DS_H
 
+#include "utils/graphid.h"
+
 #define IS_GRAPHID_STACK_EMPTY(stack) \
             get_stack_size(stack) == 0
 #define PEEK_GRAPHID_STACK(stack) \

--- a/src/include/utils/graphoid.h
+++ b/src/include/utils/graphoid.h
@@ -17,22 +17,22 @@
  * under the License.
  */
 
-#ifndef INCUBATOR_AGE_ENTITY_CREATOR_H
-#define INCUBATOR_AGE_ENTITY_CREATOR_H
+#ifndef AG_GRAPHOID_H
+#define AG_GRAPHOID_H
 
-#include "postgres.h"
+#define graphoid int32
 
-#include "utils/agtype.h"
-#include "utils/graphoid.h"
+#define INVALID_AG_GRAPH_OID 0
 
-agtype* create_agtype_from_list(char **header, char **fields,
-                                size_t fields_len, int64 vertex_id);
-agtype* create_agtype_from_list_i(char **header, char **fields,
-                                  size_t fields_len, size_t start_index);
-void insert_vertex_simple(graphoid graph_oid, char *label_name,
-                          graphid vertex_id, agtype *vertex_properties);
-void insert_edge_simple(graphoid graph_oid, char *label_name, graphid edge_id,
-                        graphid start_id, graphid end_id,
-                        agtype *end_properties);
+#define DatumGetGraphOid(X) ((graphoid) (X))
+#define GraphOidGetDatum(X) ((Datum) (X))
+#define AG_GETARG_GRAPHOID(n) PG_GETARG_INT32(n)
+#define F_GRAPHOIDEQ F_INT4EQ
+#define GRAPHOIDOID INT4OID
 
-#endif //INCUBATOR_AGE_ENTITY_CREATOR_H
+#define graph_oid_is_valid(graph_oid) (graph_oid != INVALID_AG_GRAPH_OID)
+
+#define get_next_graph_oid() \
+    (DatumGetGraphOid(DirectFunctionCall1(nextval_oid, ag_graph_id_seq())))
+
+#endif

--- a/src/include/utils/load/ag_load_edges.h
+++ b/src/include/utils/load/ag_load_edges.h
@@ -20,52 +20,9 @@
 #ifndef AG_LOAD_EDGES_H
 #define AG_LOAD_EDGES_H
 
-
-#include <stdio.h>
-#include <string.h>
-#include <errno.h>
-#include <stdlib.h>
-#include <unistd.h>
-
-
 #include "postgres.h"
 
-#include "access/heapam.h"
-#include "access/xact.h"
-#include "catalog/dependency.h"
-#include "catalog/namespace.h"
-#include "catalog/objectaddress.h"
-#include "catalog/pg_class_d.h"
-#include "commands/defrem.h"
-#include "commands/sequence.h"
-#include "commands/tablecmds.h"
-#include "miscadmin.h"
-#include "nodes/makefuncs.h"
-#include "nodes/nodes.h"
-#include "nodes/parsenodes.h"
-#include "nodes/pg_list.h"
-#include "nodes/plannodes.h"
-#include "nodes/primnodes.h"
-#include "nodes/value.h"
-#include "parser/parse_node.h"
-#include "parser/parser.h"
-#include "storage/lockdefs.h"
-#include "tcop/dest.h"
-#include "tcop/utility.h"
-#include "utils/acl.h"
-#include "utils/builtins.h"
-#include "utils/inval.h"
-#include "utils/lsyscache.h"
-#include "utils/rel.h"
-
 #include "catalog/ag_graph.h"
-#include "catalog/ag_label.h"
-#include "commands/label_commands.h"
-#include "utils/ag_cache.h"
-#include "utils/agtype.h"
-#include "utils/graphid.h"
-
-
 
 typedef struct {
     size_t row;
@@ -80,7 +37,7 @@ typedef struct {
     size_t header_row_length;
     size_t curr_row_length;
     char *graph_name;
-    Oid graph_id;
+    graphoid graph_oid;
     char *object_name;
     int object_id;
     char *start_vertex;
@@ -92,8 +49,9 @@ typedef struct {
 void edge_field_cb(void *field, size_t field_len, void *data);
 void edge_row_cb(int delim __attribute__((unused)), void *data);
 
-int create_edges_from_csv_file(char *file_path, char *graph_name, Oid graph_id,
-                                char *object_name, int object_id );
+int create_edges_from_csv_file(char *file_path, char *graph_name,
+                               graphoid graph_oid, char *object_name,
+                               int object_id);
 
 #endif //AG_LOAD_EDGES_H
 

--- a/src/include/utils/load/ag_load_labels.h
+++ b/src/include/utils/load/ag_load_labels.h
@@ -21,54 +21,10 @@
 #ifndef AG_LOAD_LABELS_H
 #define AG_LOAD_LABELS_H
 
-
-#include <stdio.h>
-#include <string.h>
-#include <errno.h>
-#include <stdlib.h>
-#include <unistd.h>
-
 #include "postgres.h"
 
-#include "access/heapam.h"
-#include "access/xact.h"
-#include "catalog/dependency.h"
-#include "catalog/namespace.h"
-#include "catalog/objectaddress.h"
-#include "catalog/pg_class_d.h"
-#include "commands/defrem.h"
-#include "commands/sequence.h"
-#include "commands/tablecmds.h"
-#include "miscadmin.h"
-#include "nodes/makefuncs.h"
-#include "nodes/nodes.h"
-#include "nodes/parsenodes.h"
-#include "nodes/pg_list.h"
-#include "nodes/plannodes.h"
-#include "nodes/primnodes.h"
-#include "nodes/value.h"
-#include "parser/parse_node.h"
-#include "parser/parser.h"
-#include "storage/lockdefs.h"
-#include "tcop/dest.h"
-#include "tcop/utility.h"
-#include "utils/acl.h"
-#include "utils/builtins.h"
-#include "utils/inval.h"
-#include "utils/lsyscache.h"
-#include "utils/rel.h"
-
-#include "catalog/ag_graph.h"
-#include "catalog/ag_label.h"
-#include "commands/label_commands.h"
-#include "utils/ag_cache.h"
-#include "utils/agtype.h"
 #include "utils/graphid.h"
-
-
-#define AGE_VERTIX 1
-#define AGE_EDGE 2
-
+#include "utils/graphoid.h"
 
 struct counts {
     long unsigned fields;
@@ -89,7 +45,7 @@ typedef struct {
     size_t header_row_length;
     size_t curr_row_length;
     char *graph_name;
-    Oid graph_id;
+    graphoid graph_oid;
     char *object_name;
     int object_id;
     bool id_field_exists;
@@ -99,8 +55,8 @@ typedef struct {
 void vertex_field_cb(void *field, size_t field_len, void *data);
 void vertex_row_cb(int delim __attribute__((unused)), void *data);
 
-int create_labels_from_csv_file(char *file_path, char *graph_name, Oid graph_id,
-                                char *object_name, int object_id,
-                                bool id_field_exists);
+int create_labels_from_csv_file(char *file_path, char *graph_name,
+                                graphoid graph_oid, char *object_name,
+                                int object_id, bool id_field_exists);
 
 #endif //AG_LOAD_LABELS_H


### PR DESCRIPTION
Since PG 12 does not recommend and not allow to use the use of Oids, so
removed Oids. Oid uses 4Byte, it uses INT type for compatibility. and,
create a sequence of "$TABLE_NAME$_$COLUMN_NAME$_seq" and calls it to
create a new ID.

And, due to the rule that a value less than 1 cannot exist, the case
where it does not exist is considered 0 (INVALID_AG_GRAPH_ID).