### PR TITLE
Fix `agtype_hash_cmp` function accessing uninitialized value

### DIFF
--- a/src/backend/utils/adt/agtype.c
+++ b/src/backend/utils/adt/agtype.c
@@ -3529,15 +3529,21 @@ Datum agtype_hash_cmp(PG_FUNCTION_ARGS)
     while ((tok = agtype_iterator_next(&it, r, false)) != WAGT_DONE)
     {
         if (IS_A_AGTYPE_SCALAR(r) && AGTYPE_ITERATOR_TOKEN_IS_HASHABLE(tok))
+        {
             agtype_hash_scalar_value_extended(r, &hash, seed);
+        }
         else if (tok == WAGT_BEGIN_ARRAY && !r->val.array.raw_scalar)
+        {
             seed = LEFT_ROTATE(seed, 4);
+        }
         else if (tok == WAGT_BEGIN_OBJECT)
+        {
             seed = LEFT_ROTATE(seed, 6);
-        else if (tok == WAGT_END_ARRAY && !r->val.array.raw_scalar)
+        }
+        else if (tok == WAGT_END_ARRAY || tok == WAGT_END_OBJECT)
+        {
             seed = RIGHT_ROTATE(seed, 4);
-        else if (tok == WAGT_END_OBJECT)
-            seed = RIGHT_ROTATE(seed, 4);
+        }
 
         seed = LEFT_ROTATE(seed, 1);
     }


### PR DESCRIPTION
When `WAGT_END_ARRAY` state, All elements within array already processed. so, `r` variable is not array anymore and `r->val.array` is uninitialized value.
Therefore, this condition passes or fails randomly depending on the memory state.


Valgrind-3.17.0 log
```
==00:00:00:16.700 30654== Memcheck, a memory error detector
==00:00:00:16.700 30654== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==00:00:00:16.700 30654== Using Valgrind-3.17.0 and LibVEX; rerun with -h for copyright info
==00:00:00:16.700 30654== Command: /home/emotionbug/pgsql11dev/bin/postgres -D /home/emotionbug/CLionProjects/incubator-age/./regress/instance/data -F -c listen_addresses= -k /tmp/pg_regress-7TLr7g
==00:00:00:16.700 30654== Parent PID: 30604
==00:00:00:16.700 30654== 
==00:00:00:30.141 30654== Conditional jump or move depends on uninitialised value(s)
==00:00:00:30.141 30654==    at 0xE433904: agtype_hash_cmp (agtype.c:3537)
==00:00:00:30.141 30654==    by 0x8208B2: FunctionCall1Coll (fmgr.c:1123)
==00:00:00:30.141 30654==    by 0x464C5B: TupleHashTableHash (execGrouping.c:432)
==00:00:00:30.141 30654==    by 0x46392B: tuplehash_insert (simplehash.h:486)
==00:00:00:30.141 30654==    by 0x464A2C: LookupTupleHashEntry (execGrouping.c:312)
==00:00:00:30.141 30654==    by 0x481F7F: lookup_hash_entry (nodeAgg.c:1478)
==00:00:00:30.141 30654==    by 0x4820A1: lookup_hash_entries (nodeAgg.c:1522)
==00:00:00:30.141 30654==    by 0x482932: agg_fill_hash_table (nodeAgg.c:1937)
==00:00:00:30.141 30654==    by 0x48215F: ExecAgg (nodeAgg.c:1554)
==00:00:00:30.141 30654==    by 0x472E90: ExecProcNodeFirst (execProcnode.c:445)
==00:00:00:30.141 30654==    by 0x4AE6D1: ExecProcNode (executor.h:248)
==00:00:00:30.141 30654==    by 0x4AE6F6: SubqueryNext (nodeSubqueryscan.c:53)
==00:00:00:30.141 30654== 
{
   <insert_a_suppression_name_here>
   Memcheck:Cond
   fun:agtype_hash_cmp
   fun:FunctionCall1Coll
   fun:TupleHashTableHash
   fun:tuplehash_insert
   fun:LookupTupleHashEntry
   fun:lookup_hash_entry
   fun:lookup_hash_entries
   fun:agg_fill_hash_table
   fun:ExecAgg
   fun:ExecProcNodeFirst
   fun:ExecProcNode
   fun:SubqueryNext
}
==00:00:00:40.667 30654== 
==00:00:00:40.667 30654== HEAP SUMMARY:
==00:00:00:40.667 30654==     in use at exit: 2,646,098 bytes in 734 blocks
==00:00:00:40.667 30654==   total heap usage: 698,786 allocs, 16,056 frees, 330,592,004 bytes allocated
==00:00:00:40.667 30654== 
==00:00:00:40.667 30654== For a detailed leak analysis, rerun with: --leak-check=full
==00:00:00:40.667 30654== 
==00:00:00:40.667 30654== Use --track-origins=yes to see where uninitialised values come from
==00:00:00:40.667 30654== For lists of detected and suppressed errors, rerun with: -s
==00:00:00:40.667 30654== ERROR SUMMARY: 6 errors from 1 contexts (suppressed: 219 from 4)
```