### PR TITLE
Use Debian Buster-based source container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 #
 
 
-FROM postgres:11
+FROM postgres:11-buster
 
 RUN apt-get update 
 RUN apt-get install --assume-yes --no-install-recommends --no-install-suggests \


### PR DESCRIPTION
The `postgres:11` container image is currently based on Debian Bullseye, which does not have `postgres-server-dev-11` in its package repo. Presumably, it used to be based on Buster. This commit ensures we use the Debian release that supports this package.

See: https://packages.debian.org/search?suite=default&section=all&arch=any&searchon=names&keywords=postgresql-server-dev-11