### PR TITLE
Naming rules for graphs

### DIFF
--- a/src/backend/commands/graph_commands.c
+++ b/src/backend/commands/graph_commands.c
@@ -93,19 +93,19 @@ Datum create_graph(PG_FUNCTION_ARGS)
         if(((validity & (1<<0)) != 0) && ((validity & (1<<1)) != 0))
         {
             ereport(ERROR,
-                (errcode(ERRCODE_INVALID_SCHEMA_NAME),
+                (errcode(ERRCODE_INVALID_NAME),
                         errmsg("Graph name must begin either with an alphabet or an underscore and no spaces or other special characters except underscore are allowed.")));
         }
         if((validity & (1<<0)) != 0)
         {
             ereport(ERROR,
-                    (errcode(ERRCODE_INVALID_SCHEMA_NAME),
+                    (errcode(ERRCODE_INVALID_NAME),
                             errmsg("Graph name must begin either with an alphabet or an underscore.")));
         }
         if((validity & (1<<1)) != 0)
         {
             ereport(ERROR,
-                    (errcode(ERRCODE_INVALID_SCHEMA_NAME),
+                    (errcode(ERRCODE_INVALID_NAME),
                             errmsg("No spaces or other special characters except underscore are allowed.")));
         }
     }


### PR DESCRIPTION
Following naming rules were implemented

1. Graph name must begin either with an alphabet or an underscore.
2. The name can also include numbers after the first character.
3. No spaces or other special characters except underscore should be allowed.

Error Code is ERRCODE_INVALID_NAME => 42602
function to check validity is in the same file, please suggest an alternative file where I can instead define them to maintain cleanliness.
