### PR TITLE
Implement CI testing for Golang Driver

### DIFF
--- a/.github/workflows/go-driver.yml
+++ b/.github/workflows/go-driver.yml
@@ -1,0 +1,33 @@
+name: Go Driver Tests
+
+on:
+  push:
+    branches: [ "master" ]
+    paths: 
+      - 'drivers/golang'
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: drivers/golang/age/
+  
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Run apache/age docker image
+      run: docker-compose up -d
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.16
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test . -v

--- a/drivers/golang/docker-compose.yml
+++ b/drivers/golang/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.3"
+services:
+  db:
+    image: apache/age
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=agens
+      - POSTGRES_DB=postgres
+    ports:
+      - 5432:5432


### PR DESCRIPTION
This change will implement running of the go driver unit tests upon every pull request made to the `drivers/golang` code.

It uses the `paths` directive to ensure the github action workflow only runs when the go driver code is changed (and not the core age code or other drivers).

The docker-compose file is required to instantiate a postgres instance, needed for unit testing.