### PR TITLE
Update to go version 1.19, as 1.16 is EOL

### DIFF
--- a/.github/workflows/go-driver.yml
+++ b/.github/workflows/go-driver.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ '1.18', '1.19' ]
     defaults:
       run:
         working-directory: drivers/golang/age/
@@ -24,7 +27,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.16
+        go-version: ${{ matrix.go-version }}
 
     - name: Build
       run: go build -v ./...

--- a/drivers/golang/README.md
+++ b/drivers/golang/README.md
@@ -7,7 +7,7 @@ AGType parser and driver support for [Apache AGE](https://age.apache.org/), grap
 * Cypher query support for 3rd. Party sql driver (enables to use cypher queries directly)
 
 ### Prerequisites
-* over Go 1.16
+* over Go 1.18 / 1.19
 * This module runs on golang standard api [database/sql](https://golang.org/pkg/database/sql/) and [antlr4-python3](https://github.com/antlr/antlr4/tree/master/runtime/Go/antlr)
 
 

--- a/drivers/golang/go.mod
+++ b/drivers/golang/go.mod
@@ -19,10 +19,16 @@
 
 module github.com/apache/age/drivers/golang
 
-go 1.16
+go 1.19
 
 require (
 	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210521184019-c5ad59b459ec
 	github.com/lib/pq v1.10.2
 	github.com/stretchr/testify v1.7.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/drivers/golang/go.sum
+++ b/drivers/golang/go.sum
@@ -9,6 +9,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
The current version of the driver is 1.16 which went EOL Feb 2021

This upgrades to 1.19 and also configures CI to retrospectively test back to 1.18 (1.17 is EOL). This will give test coverage for all actively supported go versions.