### PR TITLE
Fix agtype_btree_cmp test in C.UTF-8 locale

### DIFF
--- a/regress/expected/agtype.out
+++ b/regress/expected/agtype.out
@@ -2883,7 +2883,7 @@ SELECT agtype_btree_cmp('"string"'::agtype, '"string"'::agtype);
                 0
 (1 row)
 
-SELECT agtype_btree_cmp('"string"'::agtype, '"string "'::agtype);
+SELECT sign(agtype_btree_cmp('"string"'::agtype, '"string "'::agtype)) AS agtype_btree_cmp;
  agtype_btree_cmp 
 ------------------
                -1

--- a/regress/sql/agtype.sql
+++ b/regress/sql/agtype.sql
@@ -835,7 +835,7 @@ SELECT agtype_btree_cmp('1'::agtype, '1.0'::agtype);
 SELECT agtype_btree_cmp('1'::agtype, '"1"'::agtype);
 
 SELECT agtype_btree_cmp('"string"'::agtype, '"string"'::agtype);
-SELECT agtype_btree_cmp('"string"'::agtype, '"string "'::agtype);
+SELECT sign(agtype_btree_cmp('"string"'::agtype, '"string "'::agtype)) AS agtype_btree_cmp;
 
 SELECT agtype_btree_cmp(NULL, NULL);
 SELECT agtype_btree_cmp(NULL, '1'::agtype);


### PR DESCRIPTION
When running with LC_COLLATE=C.UTF-8, agtype_btree_cmp returns -32 instead of -1. This is a valid return code, so adjust the test to allow that.

```
--- /home/cbe/projects/postgresql/age/age.git/./regress/expected/agtype.out	2022-12-14 14:42:30.512908027 +0100 +++ /home/cbe/projects/postgresql/age/age.git/./regress/results/agtype.out	2022-12-20 11:24:07.437053056 +0100 @@ -2886,7 +2886,7 @@
 SELECT agtype_btree_cmp('"string"'::agtype, '"string "'::agtype);
  agtype_btree_cmp
 ------------------
-               -1
+              -32
 (1 row)

 SELECT agtype_btree_cmp(NULL, NULL);
```