### PR TITLE
Changed Volatility of agtype_typecast_path from STABLE to IMMUTABLE

### DIFF
--- a/age--1.1.0.sql
+++ b/age--1.1.0.sql
@@ -4022,7 +4022,7 @@ AS 'MODULE_PATHNAME';
 CREATE FUNCTION ag_catalog.agtype_typecast_path(variadic "any")
 RETURNS agtype
 LANGUAGE c
-STABLE
+IMMUTABLE
 PARALLEL SAFE
 AS 'MODULE_PATHNAME';
 


### PR DESCRIPTION
### Reason : 
- No database lookup.
- No database modification.
- The result will depend on equivalence of any convertible input type. Hence it is guaranteed to return consistent result for same input in parameter.
Hence IMMUTABLE