### PR TITLE
Changed the volatility category of the List functions age_range() and age_unnest() from STABLE to IMMUTABLE..

### DIFF
--- a/age--1.1.0.sql
+++ b/age--1.1.0.sql
@@ -4136,14 +4136,14 @@ AS 'MODULE_PATHNAME';
 CREATE FUNCTION ag_catalog.age_range(variadic "any")
 RETURNS agtype
 LANGUAGE c
-STABLE
+IMMUTABLE
 PARALLEL SAFE
 AS 'MODULE_PATHNAME';
 
 CREATE FUNCTION ag_catalog.age_unnest(agtype, block_types boolean = false)
     RETURNS SETOF agtype
     LANGUAGE c
-    STABLE
+    IMMUTABLE
 PARALLEL SAFE
 AS 'MODULE_PATHNAME';
 


### PR DESCRIPTION
The **age_range()** function returns an agtype list comprising all integer values within a range bounded by a start value 'start' and end value 'end'. The returned list only depends on the input arguments: start, end, step.

The **age_unnest()** function expands an array/multiple arrays (possibly of different types)/tsvector to a set of rows. Return value depends only on the input arguments.

These should be IMMUTABLE because:
• No database lookup or modification required for these functions. 
• Guaranteed to return the same results given the same arguments forever so they can be pre-evaluated.
Hence they should be IMMUTABLE functions.