### PR TITLE
Update SET clause to support assigning a map to a variable

### DIFF
--- a/regress/expected/cypher_set.out
+++ b/regress/expected/cypher_set.out
@@ -374,7 +374,7 @@ ERROR:  undefined reference to variable wrong_var in SET clause
 LINE 1: ...ELECT * FROM cypher('cypher_set', $$MATCH (n) SET wrong_var....
                                                              ^
 SELECT * FROM cypher('cypher_set', $$MATCH (n) SET i = 3$$) AS (a agtype);
-ERROR:  SET clause expects a variable name
+ERROR:  SET clause expects a map
 LINE 1: ...ELECT * FROM cypher('cypher_set', $$MATCH (n) SET i = 3$$) A...
                                                              ^
 --
@@ -668,6 +668,100 @@ SELECT * FROM cypher('cypher_set', $$MATCH (n) RETURN n$$) AS (a agtype);
 (13 rows)
 
 --
+-- Test entire property update
+--
+SELECT * FROM create_graph('cypher_set_1');
+NOTICE:  graph "cypher_set_1" has been created
+ create_graph 
+--------------
+ 
+(1 row)
+
+SELECT * FROM cypher('cypher_set_1', $$ CREATE (a:Andy {name:'Andy', age:36, hungry:true}) $$) AS (a agtype);
+ a 
+---
+(0 rows)
+
+SELECT * FROM cypher('cypher_set_1', $$ CREATE (a:Peter {name:'Peter', age:34}) $$) AS (a agtype);
+ a 
+---
+(0 rows)
+
+SELECT * FROM cypher('cypher_set_1', $$ CREATE (a:Kevin {name:'Kevin', age:32, hungry:false}) $$) AS (a agtype);
+ a 
+---
+(0 rows)
+
+SELECT * FROM cypher('cypher_set_1', $$ CREATE (a:Matt {name:'Matt', city:'Toronto'}) $$) AS (a agtype);
+ a 
+---
+(0 rows)
+
+SELECT * FROM cypher('cypher_set_1', $$ CREATE (a:Juan {name:'Juan', role:'admin'}) $$) AS (a agtype);
+ a 
+---
+(0 rows)
+
+-- test copying properties between entities
+SELECT * FROM cypher('cypher_set_1', $$
+    MATCH (at {name: 'Andy'}), (pn {name: 'Peter'})
+    SET at = properties(pn)
+    RETURN at, pn
+$$) AS (at agtype, pn agtype);
+                                              at                                              |                                               pn                                               
+----------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------
+ {"id": 844424930131969, "label": "Andy", "properties": {"age": 34, "name": "Peter"}}::vertex | {"id": 1125899906842625, "label": "Peter", "properties": {"age": 34, "name": "Peter"}}::vertex
+(1 row)
+
+SELECT * FROM cypher('cypher_set_1', $$
+    MATCH (at {name: 'Kevin'}), (pn {name: 'Matt'})
+    SET at = pn
+    RETURN at, pn
+$$) AS (at agtype, pn agtype);
+                                                  at                                                   |                                                  pn                                                  
+-------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------
+ {"id": 1407374883553281, "label": "Kevin", "properties": {"city": "Toronto", "name": "Matt"}}::vertex | {"id": 1688849860263937, "label": "Matt", "properties": {"city": "Toronto", "name": "Matt"}}::vertex
+(1 row)
+
+-- test replacing all properties using a map and =
+SELECT * FROM cypher('cypher_set_1', $$
+    MATCH (m {name: 'Matt'})
+    SET m = {name: 'Peter Smith', position: 'Entrepreneur', city:NULL}
+    RETURN m
+$$) AS (m agtype);
+                                                           m                                                           
+-----------------------------------------------------------------------------------------------------------------------
+ {"id": 1407374883553281, "label": "Kevin", "properties": {"name": "Peter Smith", "position": "Entrepreneur"}}::vertex
+ {"id": 1688849860263937, "label": "Matt", "properties": {"name": "Peter Smith", "position": "Entrepreneur"}}::vertex
+(2 rows)
+
+-- test removing all properties using an empty map and =
+SELECT * FROM cypher('cypher_set_1', $$
+    MATCH (p {name: 'Juan'})
+    SET p = {}
+    RETURN p
+$$) AS (p agtype);
+                                  p                                  
+---------------------------------------------------------------------
+ {"id": 1970324836974593, "label": "Juan", "properties": {}}::vertex
+(1 row)
+
+-- test assigning non-map to an enitity
+SELECT * FROM cypher('cypher_set_1', $$
+    MATCH (p {name: 'Peter'})
+    SET p = "Peter"
+    RETURN p
+$$) AS (p agtype);
+ERROR:  SET clause expects a map
+LINE 3:     SET p = "Peter"
+                ^
+SELECT * FROM cypher('cypher_set_1', $$
+    MATCH (p {name: 'Peter'})
+    SET p = sqrt(4)
+    RETURN p
+$$) AS (p agtype);
+ERROR:  a map is expected
+--
 -- Clean up
 --
 DROP TABLE tbl;
@@ -684,6 +778,21 @@ drop cascades to table cypher_set.begin
 drop cascades to table cypher_set.edge
 drop cascades to table cypher_set."end"
 NOTICE:  graph "cypher_set" has been dropped
+ drop_graph 
+------------
+ 
+(1 row)
+
+SELECT drop_graph('cypher_set_1', true);
+NOTICE:  drop cascades to 7 other objects
+DETAIL:  drop cascades to table cypher_set_1._ag_label_vertex
+drop cascades to table cypher_set_1._ag_label_edge
+drop cascades to table cypher_set_1."Andy"
+drop cascades to table cypher_set_1."Peter"
+drop cascades to table cypher_set_1."Kevin"
+drop cascades to table cypher_set_1."Matt"
+drop cascades to table cypher_set_1."Juan"
+NOTICE:  graph "cypher_set_1" has been dropped
  drop_graph 
 ------------
  

--- a/regress/sql/cypher_set.sql
+++ b/regress/sql/cypher_set.sql
@@ -205,11 +205,63 @@ SELECT * FROM cypher('cypher_set', $$MATCH (n) SET n.i = {} RETURN n$$) AS (a ag
 SELECT * FROM cypher('cypher_set', $$MATCH (n) RETURN n$$) AS (a agtype);
 
 --
+-- Test entire property update
+--
+SELECT * FROM create_graph('cypher_set_1');
+
+SELECT * FROM cypher('cypher_set_1', $$ CREATE (a:Andy {name:'Andy', age:36, hungry:true}) $$) AS (a agtype);
+SELECT * FROM cypher('cypher_set_1', $$ CREATE (a:Peter {name:'Peter', age:34}) $$) AS (a agtype);
+SELECT * FROM cypher('cypher_set_1', $$ CREATE (a:Kevin {name:'Kevin', age:32, hungry:false}) $$) AS (a agtype);
+SELECT * FROM cypher('cypher_set_1', $$ CREATE (a:Matt {name:'Matt', city:'Toronto'}) $$) AS (a agtype);
+SELECT * FROM cypher('cypher_set_1', $$ CREATE (a:Juan {name:'Juan', role:'admin'}) $$) AS (a agtype);
+
+-- test copying properties between entities
+SELECT * FROM cypher('cypher_set_1', $$
+    MATCH (at {name: 'Andy'}), (pn {name: 'Peter'})
+    SET at = properties(pn)
+    RETURN at, pn
+$$) AS (at agtype, pn agtype);
+
+SELECT * FROM cypher('cypher_set_1', $$
+    MATCH (at {name: 'Kevin'}), (pn {name: 'Matt'})
+    SET at = pn
+    RETURN at, pn
+$$) AS (at agtype, pn agtype);
+
+-- test replacing all properties using a map and =
+SELECT * FROM cypher('cypher_set_1', $$
+    MATCH (m {name: 'Matt'})
+    SET m = {name: 'Peter Smith', position: 'Entrepreneur', city:NULL}
+    RETURN m
+$$) AS (m agtype);
+
+-- test removing all properties using an empty map and =
+SELECT * FROM cypher('cypher_set_1', $$
+    MATCH (p {name: 'Juan'})
+    SET p = {}
+    RETURN p
+$$) AS (p agtype);
+
+-- test assigning non-map to an enitity
+SELECT * FROM cypher('cypher_set_1', $$
+    MATCH (p {name: 'Peter'})
+    SET p = "Peter"
+    RETURN p
+$$) AS (p agtype);
+
+SELECT * FROM cypher('cypher_set_1', $$
+    MATCH (p {name: 'Peter'})
+    SET p = sqrt(4)
+    RETURN p
+$$) AS (p agtype);
+
+--
 -- Clean up
 --
 DROP TABLE tbl;
 DROP FUNCTION set_test;
 SELECT drop_graph('cypher_set', true);
+SELECT drop_graph('cypher_set_1', true);
 
 --
 

--- a/src/backend/executor/cypher_set.c
+++ b/src/backend/executor/cypher_set.c
@@ -452,14 +452,18 @@ static void process_update_list(CustomScanState *node)
             new_property_value = DATUM_GET_AGTYPE_P(scanTupleSlot->tts_values[update_item->prop_position - 1]);
         }
 
-        /*
-         * Alter the properties Agtype value to contain or remove the updated
-         * property.
-         */
-        altered_properties = alter_property_value(original_properties,
-                                                  update_item->prop_name,
-                                                  new_property_value,
-                                                  remove_property);
+        // Alter the properties Agtype value.
+        if (strcmp(update_item->prop_name, ""))
+        {
+            altered_properties = alter_property_value(original_properties,
+                                                      update_item->prop_name,
+                                                      new_property_value,
+                                                      remove_property);
+        }
+        else
+        {
+            altered_properties = get_map_from_agtype(new_property_value);
+        }
 
         resultRelInfo = create_entity_result_rel_info(estate,
                                                       css->set_list->graph_name,

--- a/src/include/utils/agtype.h
+++ b/src/include/utils/agtype.h
@@ -523,6 +523,7 @@ bool is_decimal_needed(char *numstr);
 int compare_agtype_scalar_values(agtype_value *a, agtype_value *b);
 agtype_value *alter_property_value(agtype_value *properties, char *var_name,
                                    agtype *new_v, bool remove_property);
+agtype_value *get_map_from_agtype(agtype *a);
 
 agtype *get_one_agtype_from_variadic_args(FunctionCallInfo fcinfo,
                                           int variadic_offset,


### PR DESCRIPTION
For example, 'SET v = {..}' will remove all properties of v and set the provided map as its properties.