### PR TITLE
Fix golang driver CI workflow

### DIFF
--- a/.github/workflows/go-driver.yml
+++ b/.github/workflows/go-driver.yml
@@ -4,9 +4,12 @@ on:
   push:
     branches: [ "master" ]
     paths: 
-      - 'drivers/golang'
+      - 'drivers/golang/**'
+
   pull_request:
     branches: [ "master" ]
+    paths: 
+      - 'drivers/golang/**'
 
 jobs:
   build:


### PR DESCRIPTION
There wasn't any path directive for `on : pull request` due to which workflow was redundantly running on every PR.