### PR TITLE
Optimize age_exists function

### DIFF
--- a/src/backend/utils/adt/agtype.c
+++ b/src/backend/utils/adt/agtype.c
@@ -5449,25 +5449,9 @@ PG_FUNCTION_INFO_V1(age_exists);
  */
 Datum age_exists(PG_FUNCTION_ARGS)
 {
-    agtype *agt_arg = NULL;
-    agtype_value *agtv_value = NULL;
-
     /* check for NULL, NULL is FALSE */
     if (PG_ARGISNULL(0))
         PG_RETURN_BOOL(false);
-
-    /* get the argument */
-    agt_arg = AG_GET_ARG_AGTYPE_P(0);
-
-    /* check for a scalar AGTV_NULL */
-    if (AGT_ROOT_IS_SCALAR(agt_arg))
-    {
-        agtv_value = get_ith_agtype_value_from_container(&agt_arg->root, 0);
-
-        /* again, if NULL, NULL is FALSE */
-        if (agtv_value->type == AGTV_NULL)
-            PG_RETURN_BOOL(false);
-    }
 
     /* otherwise, we have something, and something is TRUE */
     PG_RETURN_BOOL(true);


### PR DESCRIPTION
-age_exists, which is the executor for exists(property) function, was making up to 3 redundant memory accesses. 

-exists(property) predicate function only serves to check if a property exists or not. 

-In Cypher, if a property is assigned the value of NULL, this is considered the same as the property not existing at all. Thus the function calls to get the value type is not needed as the check for the null argument itself filters out all NULL inputs. If a property passes this check, it implies existence.