### PR TITLE
Added inheritance functionality to create_vlabel

### DIFF
--- a/age--1.2.0.sql
+++ b/age--1.2.0.sql
@@ -97,7 +97,7 @@ RETURNS void
 LANGUAGE c
 AS 'MODULE_PATHNAME';
 
-CREATE FUNCTION ag_catalog.create_vlabel(graph_name name, label_name name)
+CREATE FUNCTION ag_catalog.create_vlabel(graph_name name, label_name name, parent_label_name name = NULL)
     RETURNS void
     LANGUAGE c
 AS 'MODULE_PATHNAME';


### PR DESCRIPTION
Added inheritance functionality to `create_vlabel` so now it is possible to a vertex label to have a parent label other than `_ag_vertex_label`. To do this, it is necessary to have an existing parent label and then call the function as:
```sql
SELECT create_vlabel('graph_name', 'label_name', 'parent_label_name');
```
Lets say we create a parent label:
```sql
SELECT create_vlabel('demo', 'Book');
NOTICE:  VLabel "Book" has been created

 create_vlabel
---------------

(1 row)
```

And then create a label that inherits from this "Book" label:
```sql
SELECT create_vlabel('demo', 'Fantasy', 'Book');
NOTICE:  VLabel "Fantasy" has been created

 create_vlabel
---------------

(1 row)
```

Creating a vertex with the "Fanstasy" label:
```sql
SELECT * FROM cypher ('demo', $$
CREATE (v:Fantasy)
RETURN v
$$) as (vertex agtype);
                                 vertex
------------------------------------------------------------------------
 {"id": 1125899906842625, "label": "Fantasy", "properties": {}}::vertex
(1 row)
```

The parent label "Book" will also have this vertex:
```sql
SELECT * FROM demo."Book";
        id        | properties
------------------+------------
 1125899906842625 | {}
(1 row)

SELECT * FROM demo."Fantasy";
        id        | properties
------------------+------------
 1125899906842625 | {}
(1 row)
```