### PR TITLE
[GDBMS_cypher] timestamp(), tointegerornull() and tobooleanlist() functions

### DIFF
--- a/src/backend/utils/adt/cypher_funcs.c
+++ b/src/backend/utils/adt/cypher_funcs.c
@@ -1407,3 +1407,10 @@ array_tail(PG_FUNCTION_ARGS)
 
 	PG_RETURN_ARRAYTYPE_P(makeArrayResult(astate, CurrentMemoryContext));
 }
+
+Datum
+timestamp(PG_FUNCTION_ARGS)
+{
+	Timestamp timestamp = now(fcinfo);
+    PG_RETURN_INT64(timestamp);
+}

--- a/src/include/catalog/pg_proc.dat
+++ b/src/include/catalog/pg_proc.dat
@@ -12037,6 +12037,9 @@
 { oid => '8007', descr => 'returns the integer equivalent or null',
   proname => 'tointegerornull', prorettype => 'int8', proisstrict => 't',
   proargtypes => 'any', prosrc => 'tointegerornull' },
+{ oid => '8008', descr => 'converts the given list to a boolean list',
+  proname => 'tobooleanlist', prorettype => 'jsonb',
+  proargtypes => 'jsonb', prosrc => 'tobooleanlist' },
 
 # supports for graphdatabase binary upgrade
 { oid => '8001', descr => 'for use by pg_upgrade',

--- a/src/include/catalog/pg_proc.dat
+++ b/src/include/catalog/pg_proc.dat
@@ -2296,6 +2296,9 @@
 { oid => '1159', descr => 'adjust timestamp to new time zone',
   proname => 'timezone', prorettype => 'timestamp',
   proargtypes => 'text timestamptz', prosrc => 'timestamptz_zone' },
+{ oid => '8006', descr => 'returns the timestamp of current date and time',
+  proname => 'timestamp_int64', prorettype => 'int8', proisstrict => 't',
+  proargtypes => '', prosrc => 'timestamp' },
 
 { oid => '1160', descr => 'I/O',
   proname => 'interval_in', provolatile => 's', prorettype => 'interval',

--- a/src/include/catalog/pg_proc.dat
+++ b/src/include/catalog/pg_proc.dat
@@ -12034,6 +12034,9 @@
 { oid => '7302', descr => 'a array except the first element',
   proname => 'tail', prorettype => 'anyarray', proargtypes => 'anyarray',
   prosrc => 'array_tail' },
+{ oid => '8007', descr => 'returns the integer equivalent or null',
+  proname => 'tointegerornull', prorettype => 'int8', proisstrict => 't',
+  proargtypes => 'any', prosrc => 'tointegerornull' },
 
 # supports for graphdatabase binary upgrade
 { oid => '8001', descr => 'for use by pg_upgrade',

--- a/src/include/utils/cypher_funcs.h
+++ b/src/include/utils/cypher_funcs.h
@@ -89,5 +89,6 @@ extern Datum array_tail(PG_FUNCTION_ARGS);
 /* utility */
 extern Datum get_last_graph_write_stats(PG_FUNCTION_ARGS);
 extern Datum timestamp(PG_FUNCTION_ARGS);
+extern Datum tointegerornull(PG_FUNCTION_ARGS);
 
 #endif							/* CYPHER_FUNCS_H */

--- a/src/include/utils/cypher_funcs.h
+++ b/src/include/utils/cypher_funcs.h
@@ -85,6 +85,7 @@ extern Datum jsonb_string_regex(PG_FUNCTION_ARGS);
 extern Datum array_head(PG_FUNCTION_ARGS);
 extern Datum array_last(PG_FUNCTION_ARGS);
 extern Datum array_tail(PG_FUNCTION_ARGS);
+extern Datum tobooleanlist(PG_FUNCTION_ARGS);
 
 /* utility */
 extern Datum get_last_graph_write_stats(PG_FUNCTION_ARGS);

--- a/src/include/utils/cypher_funcs.h
+++ b/src/include/utils/cypher_funcs.h
@@ -88,5 +88,6 @@ extern Datum array_tail(PG_FUNCTION_ARGS);
 
 /* utility */
 extern Datum get_last_graph_write_stats(PG_FUNCTION_ARGS);
+extern Datum timestamp(PG_FUNCTION_ARGS);
 
 #endif							/* CYPHER_FUNCS_H */

--- a/src/test/regress/expected/list.out
+++ b/src/test/regress/expected/list.out
@@ -1,0 +1,10 @@
+--
+-- Regression tests for list functions
+--
+-- Test for the tobooleanlist() function
+RETURN tobooleanlist(null) as noList, tobooleanlist([null, null]) as nullsInList, tobooleanlist(['a string', true, 'false', null, ['A','B']]) as mixedList;
+ nolist | nullsinlist  |            mixedlist            
+--------+--------------+---------------------------------
+        | [null, null] | [null, true, false, null, null]
+(1 row)
+

--- a/src/test/regress/expected/scalar.out
+++ b/src/test/regress/expected/scalar.out
@@ -1,0 +1,16 @@
+--
+-- Regression tests for scalar functions
+--
+-- Test for the tointegerornull() function
+RETURN tointegerornull('42'), tointegerornull('not a number'), tointegerornull(true), tointegerornull(['A', 'B', 'C']);
+ tointegerornull | tointegerornull | tointegerornull | tointegerornull 
+-----------------+-----------------+-----------------+-----------------
+ 42              |                 | 1               | 
+(1 row)
+
+RETURN tointegerornull(12.5), tointegerornull('13.5'), tointegerornull(45), tointegerornull(false);
+ tointegerornull | tointegerornull | tointegerornull | tointegerornull 
+-----------------+-----------------+-----------------+-----------------
+ 12              | 13              | 45              | 0
+(1 row)
+

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -161,3 +161,6 @@ test: cypher_finalize
 
 # run scalar functions
 test: scalar
+
+# run list functions
+test: list

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -158,3 +158,6 @@ test: propertyindex
 
 # run cypher finalize
 test: cypher_finalize
+
+# run scalar functions
+test: scalar

--- a/src/test/regress/sql/list.sql
+++ b/src/test/regress/sql/list.sql
@@ -1,0 +1,7 @@
+--
+-- Regression tests for list functions
+--
+
+-- Test for the tobooleanlist() function
+
+RETURN tobooleanlist(null) as noList, tobooleanlist([null, null]) as nullsInList, tobooleanlist(['a string', true, 'false', null, ['A','B']]) as mixedList;

--- a/src/test/regress/sql/scalar.sql
+++ b/src/test/regress/sql/scalar.sql
@@ -1,0 +1,9 @@
+--
+-- Regression tests for scalar functions
+--
+
+-- Test for the tointegerornull() function
+
+RETURN tointegerornull('42'), tointegerornull('not a number'), tointegerornull(true), tointegerornull(['A', 'B', 'C']);
+
+RETURN tointegerornull(12.5), tointegerornull('13.5'), tointegerornull(45), tointegerornull(false);


### PR DESCRIPTION
This PR adds the following functions:
- [x] timestamp() [#597]
- [x] tointegerornull() []
- [x] tobooleanlist() [#607]

The third function will probably be added in a separate PR after re-iterating the problem, considerate testing, and bug fixing.

Update: The third function has been added!