### PR TITLE
Implement CI test for jdbc driver

### DIFF
--- a/.github/workflows/jdbc-driver.yaml
+++ b/.github/workflows/jdbc-driver.yaml
@@ -1,0 +1,32 @@
+name: JDBC Driver Tests
+
+on:
+  push:
+    branches: [ "master", "PG11" ]
+      
+  pull_request:
+    branches: [ "master", "PG11" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        distributions: ['zulu', 'temurin', 'microsoft']
+
+    defaults:
+      run:
+        working-directory: drivers/jdbc
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Java
+      uses: actions/setup-java@v3
+      with:
+        distribution: ${{ matrix.distributions }}
+        java-version: '17'
+
+    - name: Build and Test
+      run: gradle build

--- a/drivers/jdbc/lib/build.gradle.kts
+++ b/drivers/jdbc/lib/build.gradle.kts
@@ -17,6 +17,9 @@
  * under the License.
  */
 
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+
 plugins {
     `java-library`
     antlr
@@ -36,6 +39,9 @@ dependencies {
 
     testImplementation("org.testcontainers:testcontainers:1.15.3")
     testImplementation("org.postgresql:postgresql:42.2.20")
+
+    testImplementation("org.slf4j:slf4j-api:1.7.5")
+    testImplementation("org.slf4j:slf4j-simple:1.7.5")
 }
 
 tasks.generateGrammarSource {
@@ -50,5 +56,16 @@ tasks.generateGrammarSource {
 }
 
 tasks.test {
-    useJUnitPlatform()
+    useJUnitPlatform();
+    testLogging {
+        // set options for log level LIFECYCLE
+        events(TestLogEvent.FAILED,
+            TestLogEvent.PASSED,
+            TestLogEvent.SKIPPED,
+            TestLogEvent.STANDARD_OUT)
+        exceptionFormat = TestExceptionFormat.FULL
+        showExceptions  = true
+        showCauses = true
+        showStackTraces  = true
+    }
 }


### PR DESCRIPTION
### What I did
- Implemented a CI workflow for jdbc driver that ensures that any PR/commit that modifies files under age/drivers/jdbc is passing the tests.
- Added logger to display the result of tests i.e. passing, failing etc.

### Additional Context

This workflow will only run if there is a modification in files under age/drivers/jdbc.
