### PR TITLE
[PG12] Merge commit '0e96fbb'

### DIFF
--- a/age--1.1.1.sql
+++ b/age--1.1.1.sql
@@ -33,6 +33,9 @@ CREATE TABLE ag_graph (
 
 CREATE UNIQUE INDEX ag_graph_graphid_index ON ag_graph USING btree (graphid);
 
+-- include content of the ag_graph table into the pg_dump output
+SELECT pg_catalog.pg_extension_config_dump('ag_graph', '');
+
 CREATE UNIQUE INDEX ag_graph_name_index ON ag_graph USING btree (name);
 
 CREATE UNIQUE INDEX ag_graph_namespace_index
@@ -56,6 +59,9 @@ CREATE TABLE ag_label (
     FOREIGN KEY(graph)
     REFERENCES ag_graph(graphid)
 );
+
+-- include content of the ag_label table into the pg_dump output
+SELECT pg_catalog.pg_extension_config_dump('ag_label', '');
 
 CREATE UNIQUE INDEX ag_label_name_graph_index
 ON ag_label

--- a/src/backend/executor/cypher_set.c
+++ b/src/backend/executor/cypher_set.c
@@ -114,7 +114,7 @@ static HeapTuple update_entity_tuple(ResultRelInfo *resultRelInfo,
     bool update_indexes;
     TM_Result   result;
 
-    ResultRelInfo *saved_resultRelInfo  = estate->es_result_relation_info;
+    ResultRelInfo *saved_resultRelInfo = estate->es_result_relation_info;
     estate->es_result_relation_info = resultRelInfo;
 
     lockmode = ExecUpdateLockMode(estate, resultRelInfo);


### PR DESCRIPTION
Merge 0e96fbb into PG12.

#### Modifications w.r.t age for PG12

Two of the changes are invalid w.r.t age for PG12.
- One in cypher_set.c related to saved_resultRelInfo because it is already addressed in commit [AGE PG12.1.0 ALPHA](https://github.com/apache/age/commit/a20169ee78ec1eb7dd6459c32d43a9a428962369#diff-b5c3eddf1924327ef724b641a9257ae5e61bc2bde5f0cd2a7cafad441c87ac07).
- The one related to typo fix i.e. label_oid_cache_hash. This one is invalid because label_oid cache was removed completely in commit[ AGE PG12.1.0 ALPHA](https://github.com/apache/age/commit/a20169ee78ec1eb7dd6459c32d43a9a428962369#diff-f43f80582150c4e6525a8c0a492a96256f367078cd2d2a71de9f6a9b7a76a80b).

The one related to pg_dump is still valid.