### PR TITLE
Update Go driver CI to run on every PR/commit

### DIFF
--- a/.github/workflows/go-driver.yml
+++ b/.github/workflows/go-driver.yml
@@ -2,14 +2,10 @@ name: Go Driver Tests
 
 on:
   push:
-    branches: [ "master" ]
-    paths: 
-      - 'drivers/golang/**'
+    branches: [ "master", PG11 ]
 
   pull_request:
-    branches: [ "master" ]
-    paths: 
-      - 'drivers/golang/**'
+    branches: [ "master", PG11 ]
 
 jobs:
   build:


### PR DESCRIPTION
- Removed path directive
- Included PG11 as trigger branch