### PR TITLE
Updated README.md; Fixed inconsistent format in 'Quick Start' code block using 'MATCH' clause.

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,9 +243,10 @@ $$) as (v agtype);
 To query the graph, you can use the MATCH clause.  
 
 ```bash
-SELECT * FROM cypher('graph_name', $$
-MATCH (v)
-RETURN v
+SELECT * 
+FROM cypher('graph_name', $$
+    MATCH (v)
+    RETURN v
 $$) as (v agtype);
 ```
 


### PR DESCRIPTION
In the 'Quick Start' code blocks, the majority of them have a new line after `SELECT *`, as well as four spaces when using Cypher clauses. The code block showing how to use the 'MATCH' clause does not match this formatting, which was fixed.