### PR TITLE
Moved create_empty_agtype() outside of loops

### DIFF
--- a/src/backend/utils/graph_generation.c
+++ b/src/backend/utils/graph_generation.c
@@ -194,13 +194,14 @@ Datum create_complete_graph(PG_FUNCTION_ARGS)
 
     vtx_seq_id = get_relname_relid(vtx_seq_name_str, nsp_id);
     edge_seq_id = get_relname_relid(edge_seq_name_str, nsp_id);
+  
+    props = create_empty_agtype();
 
     /* Creating vertices*/
     for (i=(int64)1;i<=no_vertices;i++)
     {   
         vid = nextval_internal(vtx_seq_id, true);
         object_graph_id = make_graphid(vtx_label_id, vid);
-        props = create_empty_agtype();
         insert_vertex_simple(graph_id,vtx_name_str,object_graph_id,props);
     }
 
@@ -218,8 +219,6 @@ Datum create_complete_graph(PG_FUNCTION_ARGS)
 
             start_vertex_graph_id = make_graphid(vtx_label_id, start_vid);
             end_vertex_graph_id = make_graphid(vtx_label_id, end_vid);
-
-            props = create_empty_agtype();
 
             insert_edge_simple(graph_id, edge_name_str,
                             object_graph_id, start_vertex_graph_id,


### PR DESCRIPTION
The statement `props = create_empty_agtype()` was being executed inside loops, which was causing unnecessary overhead. It has been moved outside of the loops, so that it is only executed once.