### PR TITLE
Include invalid labels in reused variables. (#751)

### DIFF
--- a/regress/expected/cypher_match.out
+++ b/regress/expected/cypher_match.out
@@ -527,6 +527,12 @@ $$) AS (a agtype);
 ERROR:  multiple labels for variable 'a' are not supported
 LINE 2:         MATCH (a)-[]-(a)-[]-(a:v1) RETURN a
                                     ^
+SELECT * FROM cypher('cypher_match', $$
+        MATCH (a)-[]-(a)-[]-(a:invalid_label) RETURN a
+$$) AS (a agtype);
+ERROR:  multiple labels for variable 'a' are not supported
+LINE 2:         MATCH (a)-[]-(a)-[]-(a:invalid_label) RETURN a
+                                    ^
 --Valid variable reuse, although why would you want to do it this way?
 SELECT * FROM cypher('cypher_match', $$
 	MATCH (a:v1)-[]-()-[a]-() RETURN a

--- a/regress/sql/cypher_match.sql
+++ b/regress/sql/cypher_match.sql
@@ -284,6 +284,9 @@ $$) AS (a agtype);
 SELECT * FROM cypher('cypher_match', $$
         MATCH (a)-[]-(a)-[]-(a:v1) RETURN a
 $$) AS (a agtype);
+SELECT * FROM cypher('cypher_match', $$
+        MATCH (a)-[]-(a)-[]-(a:invalid_label) RETURN a
+$$) AS (a agtype);
 
 --Valid variable reuse, although why would you want to do it this way?
 SELECT * FROM cypher('cypher_match', $$

--- a/src/backend/parser/cypher_clause.c
+++ b/src/backend/parser/cypher_clause.c
@@ -4527,12 +4527,15 @@ static Expr *transform_cypher_node(cypher_parsestate *cpstate,
             {
                 cypher_node *cnode = (cypher_node *)entity->entity.node;
 
-                if (cnode != NULL &&
+
+
+                if (!node->label ||
+                    (cnode != NULL &&
                     node != NULL &&
                     /* allow node using a default label against resolved var */
                     pg_strcasecmp(node->label, AG_DEFAULT_LABEL_VERTEX) != 0 &&
                     /* allow labels with the same name */
-                    pg_strcasecmp(cnode->label, node->label) != 0)
+                    pg_strcasecmp(cnode->label, node->label) != 0))
                 {
                     ereport(ERROR,
                             (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),


### PR DESCRIPTION
Fixed a segmentation fault edge case regarding invalid labels being used in a repeated variable.

Added regression tests to address this.