### PR TITLE
Feat : Remove Unused DSN in python driver unittest

### DIFF
--- a/drivers/python/test_age_py.py
+++ b/drivers/python/test_age_py.py
@@ -18,7 +18,6 @@ import unittest
 import decimal
 import age 
 
-DSN = "host=127.0.0.1 port=5432 dbname=postgres user=postgres password=agens"
 TEST_HOST = "127.0.0.1"
 TEST_PORT = 5432
 TEST_DB = "postgres"


### PR DESCRIPTION
Made this pr as mentioned in issue #810 

DSN is never used in the code. So deleting it might be a good choice for not to confuse users.

