### PR TITLE
[AGEHA] Add cypher query routing to PgPool-II

### DIFF
--- a/src/age/age_pool.c
+++ b/src/age/age_pool.c
@@ -73,8 +73,11 @@ preprocess_cypherstr(char *target)
 
 bool
 /* If the given raw parse tree root node 
-*  contains a cypher call, the cypher query
-*  inside is stored within str.
+*  contains a cypher call, true is
+*  returned and the cypher query
+*  inside is stored within str. Pass NULL as
+*  the second argument if you don't need
+*  to extract the actual cypher query content.
 */
 isCypherQuery (Node* node, char** retstr)
 {
@@ -131,8 +134,9 @@ isCypherQuery (Node* node, char** retstr)
 							}
 					}
 					
-					if (isCypherCall){
-
+					if (isCypherCall)
+					{	
+						if (retstr != NULL){
 						StringInfoData cypher_str;
 						initStringInfo(&cypher_str);
 
@@ -141,6 +145,7 @@ isCypherQuery (Node* node, char** retstr)
 						preprocess_cypherstr(cypher_str.data);
 
 						*retstr = cypher_str.data;
+						}
 
 						return true;
 					}

--- a/src/age/age_pool.c
+++ b/src/age/age_pool.c
@@ -19,12 +19,18 @@
 
 #include "pool.h"
 
+#include <string.h>
 #include "parser/pg_list.h"
 #include "parser/nodes.h"
 #include "parser/parsenodes.h"
 #include "utils/elog.h"
 #include "parser/extensible.h"
 #include "age/cypher_nodes.h"
+
+
+bool isCypherQuery (Node* node, char** str);
+void preprocess_cypherstr(char *target);
+bool isWriteQuery(List *ParsedCyphertreeList);
 
 
 void


### PR DESCRIPTION
-Added cypher query routing to PgPool-II, such that write queries go to the primary node in load balancing/replication mode and read queries go to secondary nodes.