### PR TITLE
Fix reuse of variable with label constraint

### DIFF
--- a/regress/expected/cypher_match.out
+++ b/regress/expected/cypher_match.out
@@ -510,29 +510,41 @@ ERROR:  multiple labels for variable 'a' are not supported
 LINE 2:  MATCH (a)-[]-()-[]-(a:v1) RETURN a
                             ^
 SELECT * FROM cypher('cypher_match', $$
-        MATCH (a)-[]-(a:v2)-[]-(a) RETURN a
+	MATCH (a)-[]-(a:v2)-[]-(a) RETURN a
 $$) AS (a agtype);
 ERROR:  multiple labels for variable 'a' are not supported
-LINE 2:         MATCH (a)-[]-(a:v2)-[]-(a) RETURN a
+LINE 2:  MATCH (a)-[]-(a:v2)-[]-(a) RETURN a
+                      ^
+SELECT * FROM cypher('cypher_match', $$
+	MATCH (a)-[]-(a:v1) RETURN a
+$$) AS (a agtype);
+ERROR:  multiple labels for variable 'a' are not supported
+LINE 2:  MATCH (a)-[]-(a:v1) RETURN a
+                      ^
+SELECT * FROM cypher('cypher_match', $$
+	MATCH (a)-[]-(a)-[]-(a:v1) RETURN a
+$$) AS (a agtype);
+ERROR:  multiple labels for variable 'a' are not supported
+LINE 2:  MATCH (a)-[]-(a)-[]-(a:v1) RETURN a
                              ^
 SELECT * FROM cypher('cypher_match', $$
-        MATCH (a)-[]-(a:v1) RETURN a
+	MATCH (a)-[]-(a)-[]-(a:invalid_label) RETURN a
 $$) AS (a agtype);
 ERROR:  multiple labels for variable 'a' are not supported
-LINE 2:         MATCH (a)-[]-(a:v1) RETURN a
+LINE 2:  MATCH (a)-[]-(a)-[]-(a:invalid_label) RETURN a
                              ^
 SELECT * FROM cypher('cypher_match', $$
-        MATCH (a)-[]-(a)-[]-(a:v1) RETURN a
+	MATCH (a) MATCH (a:v1) RETURN a
 $$) AS (a agtype);
 ERROR:  multiple labels for variable 'a' are not supported
-LINE 2:         MATCH (a)-[]-(a)-[]-(a:v1) RETURN a
-                                    ^
+LINE 2:  MATCH (a) MATCH (a:v1) RETURN a
+                         ^
 SELECT * FROM cypher('cypher_match', $$
-        MATCH (a)-[]-(a)-[]-(a:invalid_label) RETURN a
+	MATCH (a) MATCH (a:invalid_label) RETURN a
 $$) AS (a agtype);
 ERROR:  multiple labels for variable 'a' are not supported
-LINE 2:         MATCH (a)-[]-(a)-[]-(a:invalid_label) RETURN a
-                                    ^
+LINE 2:  MATCH (a) MATCH (a:invalid_label) RETURN a
+                         ^
 --Valid variable reuse, although why would you want to do it this way?
 SELECT * FROM cypher('cypher_match', $$
 	MATCH (a:v1)-[]-()-[a]-() RETURN a

--- a/regress/sql/cypher_match.sql
+++ b/regress/sql/cypher_match.sql
@@ -276,16 +276,22 @@ SELECT * FROM cypher('cypher_match', $$
 	MATCH (a)-[]-()-[]-(a:v1) RETURN a
 $$) AS (a agtype);
 SELECT * FROM cypher('cypher_match', $$
-        MATCH (a)-[]-(a:v2)-[]-(a) RETURN a
+	MATCH (a)-[]-(a:v2)-[]-(a) RETURN a
 $$) AS (a agtype);
 SELECT * FROM cypher('cypher_match', $$
-        MATCH (a)-[]-(a:v1) RETURN a
+	MATCH (a)-[]-(a:v1) RETURN a
 $$) AS (a agtype);
 SELECT * FROM cypher('cypher_match', $$
-        MATCH (a)-[]-(a)-[]-(a:v1) RETURN a
+	MATCH (a)-[]-(a)-[]-(a:v1) RETURN a
 $$) AS (a agtype);
 SELECT * FROM cypher('cypher_match', $$
-        MATCH (a)-[]-(a)-[]-(a:invalid_label) RETURN a
+	MATCH (a)-[]-(a)-[]-(a:invalid_label) RETURN a
+$$) AS (a agtype);
+SELECT * FROM cypher('cypher_match', $$
+	MATCH (a) MATCH (a:v1) RETURN a
+$$) AS (a agtype);
+SELECT * FROM cypher('cypher_match', $$
+	MATCH (a) MATCH (a:invalid_label) RETURN a
 $$) AS (a agtype);
 
 --Valid variable reuse, although why would you want to do it this way?

--- a/src/backend/parser/cypher_clause.c
+++ b/src/backend/parser/cypher_clause.c
@@ -4501,11 +4501,6 @@ static Expr *transform_cypher_node(cypher_parsestate *cpstate,
         /* also search for the variable from a previous transforms */
         expr = colNameToVar(pstate, node->name, false, node->location);
 
-        if (expr != NULL)
-        {
-            return (Expr*)expr;
-        }
-
         if (te != NULL)
         {
             transform_entity *entity = find_variable(cpstate, node->name);
@@ -4527,8 +4522,6 @@ static Expr *transform_cypher_node(cypher_parsestate *cpstate,
             {
                 cypher_node *cnode = (cypher_node *)entity->entity.node;
 
-
-
                 if (!node->label ||
                     (cnode != NULL &&
                     node != NULL &&
@@ -4545,6 +4538,10 @@ static Expr *transform_cypher_node(cypher_parsestate *cpstate,
             }
 
             return te->expr;
+        }
+        else if (expr != NULL)
+        {
+            return (Expr*)expr;
         }
     }
     else


### PR DESCRIPTION
- Reuse of variable with label constraint in concurrent MATCH clauses 
  now errors out instead of giving incorrect results.
- Added regression tests

Resolves #829 