### PR TITLE
[AGEHA] Fix server termination on Cypher query syntax error 

### DIFF
--- a/src/age/ag_scanner.c
+++ b/src/age/ag_scanner.c
@@ -4915,16 +4915,16 @@ static int _scan_errmsg(const char *msg, const ag_yy_extra *extra)
 
 static int _scan_errposition(const int location, const ag_yy_extra *extra)
 {
-    // int pos;
+    /*int pos;
 
-    // // no-op if location is unknown
-    // if (location < 0)
-    //     return 0;
+    // no-op if location is unknown
+    if (location < 0)
+        return 0;
 
-    // // convert byte offset to number of characters
-    // pos = pg_mbstrlen_with_len(extra->scan_buf, location) + 1;
-
-    // return errposition(pos);
+    // convert byte offset to number of characters
+    pos = pg_mbstrlen_with_len(extra->scan_buf, location) + 1;
+    return errposition(pos);*/
+    return 0; // Returning dummy value as PGPOOL does not use scan_errposition. See scan.c for details.
 }
 
 ag_scanner_t ag_scanner_create(const char *s)

--- a/src/age/ag_scanner.l
+++ b/src/age/ag_scanner.l
@@ -1120,7 +1120,7 @@ static int _scan_errmsg(const char *msg, const ag_yy_extra *extra)
 
 static int _scan_errposition(const int location, const ag_yy_extra *extra)
 {
-    int pos;
+    /*int pos;
 
     // no-op if location is unknown
     if (location < 0)
@@ -1128,8 +1128,8 @@ static int _scan_errposition(const int location, const ag_yy_extra *extra)
 
     // convert byte offset to number of characters
     pos = pg_mbstrlen_with_len(extra->scan_buf, location) + 1;
-
-    return errposition(pos);
+    return errposition(pos);*/
+    return 0; // Returning dummy value as PGPOOL does not use scan_errposition. See scan.l for details.
 }
 
 ag_scanner_t ag_scanner_create(const char *s)

--- a/src/include/context/pool_query_context.h
+++ b/src/include/context/pool_query_context.h
@@ -104,7 +104,7 @@ extern void pool_unset_node_to_be_sent(POOL_QUERY_CONTEXT * query_context, int n
 extern void pool_clear_node_to_be_sent(POOL_QUERY_CONTEXT * query_context);
 extern void pool_setall_node_to_be_sent(POOL_QUERY_CONTEXT * query_context);
 extern bool pool_multi_node_to_be_sent(POOL_QUERY_CONTEXT * query_context);
-extern void pool_where_to_send(POOL_QUERY_CONTEXT * query_context, char *query, Node *node);
+extern void pool_where_to_send(POOL_QUERY_CONTEXT * query_context, char *query, Node *node, List* cyphertree);
 extern POOL_STATUS pool_send_and_wait(POOL_QUERY_CONTEXT * query_context, int send_type, int node_id);
 extern POOL_STATUS pool_extended_send_and_wait(POOL_QUERY_CONTEXT * query_context, char *kind, int len, char *contents, int send_type, int node_id, bool nowait);
 extern Node *pool_get_parse_tree(void);


### PR DESCRIPTION
-Added TRY/CATCH block (the one used by PG) to handle syntax errors detected by the cypher parser. This prevents server termination upon catching a syntax error, which previously required AGE to be re-loaded on all backend nodes. 

-Moved syntax checking BEFORE query routing. This avoids 3 problems:
1.  Routing is only initialized if both SQL and Cypher queries have valid syntax. Otherwise, routing is forced to give up mid-way if a syntax error is caught during cypher parsing.
2. No new error handling has to be introduced for cypher syntax errors. They are now treated with the same exceptions as SQL syntax errors.  
3. Repeated parsing inside the routing functions pool_where_to_send and send_to_where is avoided.