### PR TITLE
Ignored .vscode folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build.sh
 .DS_Store
 *.tokens
 *.interp
+.vscode


### PR DESCRIPTION
Added the .vscode folder in gitignore because whenever i setup launch.json in vscode debugger, it adds that to the changes as well. I believe this would help all others using vscode as a debugger