### PR TITLE
Updated Error message for `CALL` with `RETURN`

### DIFF
--- a/regress/expected/cypher_call.out
+++ b/regress/expected/cypher_call.out
@@ -52,10 +52,9 @@ SELECT * FROM cypher('cypher_call', $$CALL sqrt(64)$$) as (sqrt agtype);
 
 /*  CALL RETURN, should fail */
 SELECT * FROM cypher('cypher_call', $$CALL sqrt(64) RETURN sqrt$$) as (sqrt agtype); 
-ERROR:  Procedure call inside a query does not support naming results implicitly
-LINE 2: SELECT * FROM cypher('cypher_call', $$CALL sqrt(64) RETURN s...
-                                             ^
-HINT:  Name explicitly using `YIELD` instead
+ERROR:  could not find rte for sqrt
+LINE 2: ...FROM cypher('cypher_call', $$CALL sqrt(64) RETURN sqrt$$) as...
+                                                             ^
 /* CALL YIELD */
 SELECT * FROM cypher('cypher_call', $$CALL sqrt(64) YIELD sqrt$$) as (sqrt agtype);
  sqrt 


### PR DESCRIPTION
- ADDED Syntax Error on `CALL func() RETURN rte`

- Adjusted `CALL` Regression Test expected ERROR message

The error message reflects missing `rte` declaration when running solo `CALL` function

Fixes issue #871 

### Checks:
- Regression tests:
![Installcheck](https://user-images.githubusercontent.com/4223975/235715624-b98ca4e1-be06-4b3e-93a2-90f64edfe257.png)
