### PR TITLE
Moved create_empty_agtype out of loops to avoid repetition

### DIFF
--- a/src/backend/utils/graph_generation.c
+++ b/src/backend/utils/graph_generation.c
@@ -195,12 +195,13 @@ Datum create_complete_graph(PG_FUNCTION_ARGS)
     vtx_seq_id = get_relname_relid(vtx_seq_name_str, nsp_id);
     edge_seq_id = get_relname_relid(edge_seq_name_str, nsp_id);
 
+    props = create_empty_agtype();  
+  
     /* Creating vertices*/
     for (i=(int64)1;i<=no_vertices;i++)
     {   
         vid = nextval_internal(vtx_seq_id, true);
         object_graph_id = make_graphid(vtx_label_id, vid);
-        props = create_empty_agtype();
         insert_vertex_simple(graph_id,vtx_name_str,object_graph_id,props);
     }
 
@@ -218,9 +219,7 @@ Datum create_complete_graph(PG_FUNCTION_ARGS)
 
             start_vertex_graph_id = make_graphid(vtx_label_id, start_vid);
             end_vertex_graph_id = make_graphid(vtx_label_id, end_vid);
-
-            props = create_empty_agtype();
-
+          
             insert_edge_simple(graph_id, edge_name_str,
                             object_graph_id, start_vertex_graph_id,
                             end_vertex_graph_id, props);


### PR DESCRIPTION
`create_empty_agtype` can be classified as a pure function since it does not modify the database, but simply creates an empty agtype.

To avoid repeated calls inside the loop, `create_empty_agtype` was declared outside the loop and its output was assigned to the `props` variable which is then used inside the loop. 

This approach ensures that the function is only called once and improves the efficiency of the code.