### PR TITLE
Fix issue #878 - unrecognized node type error

### DIFF
--- a/regress/expected/cypher_merge.out
+++ b/regress/expected/cypher_merge.out
@@ -32,16 +32,16 @@ NOTICE:  graph "cypher_merge" has been created
  * test 1: Single MERGE Clause, path doesn't exist
  */
 --test query
-SELECT * FROM cypher('cypher_merge', $$MERGE (n {i: "Hello Merge"})$$) AS (a agtype);
+SELECT * FROM cypher('cypher_merge', $$MERGE (n {i: "Hello Merge", j: (null IS NULL), k: (null IS NOT NULL)})$$) AS (a agtype);
  a 
 ---
 (0 rows)
 
 --validate
 SELECT * FROM cypher('cypher_merge', $$MATCH (n) RETURN n$$) AS (n agtype);
-                                        n                                         
-----------------------------------------------------------------------------------
- {"id": 281474976710657, "label": "", "properties": {"i": "Hello Merge"}}::vertex
+                                                    n                                                    
+---------------------------------------------------------------------------------------------------------
+ {"id": 281474976710657, "label": "", "properties": {"i": "Hello Merge", "j": true, "k": false}}::vertex
 (1 row)
 
 --clean up
@@ -54,7 +54,7 @@ SELECT * FROM cypher('cypher_merge', $$MATCH (n) DETACH DELETE n $$) AS (a agtyp
  * test 2: Single MERGE Clause, path exists
  */
 --data setup
-SELECT * FROM cypher('cypher_merge', $$CREATE ({i: "Hello Merge"}) $$) AS (a agtype);
+SELECT * FROM cypher('cypher_merge', $$CREATE ({i: "Hello Merge", j: (null IS NULL)}) $$) AS (a agtype);
  a 
 ---
 (0 rows)
@@ -65,11 +65,16 @@ SELECT * FROM cypher('cypher_merge', $$MERGE ({i: "Hello Merge"})$$) AS (a agtyp
 ---
 (0 rows)
 
+SELECT * FROM cypher('cypher_merge', $$MERGE ({j: (null IS NULL)})$$) AS (a agtype);
+ a 
+---
+(0 rows)
+
 --validate
 SELECT * FROM cypher('cypher_merge', $$MATCH (n) RETURN n$$) AS (n agtype);
-                                        n                                         
-----------------------------------------------------------------------------------
- {"id": 281474976710658, "label": "", "properties": {"i": "Hello Merge"}}::vertex
+                                              n                                              
+---------------------------------------------------------------------------------------------
+ {"id": 281474976710658, "label": "", "properties": {"i": "Hello Merge", "j": true}}::vertex
 (1 row)
 
 --clean up

--- a/regress/sql/cypher_merge.sql
+++ b/regress/sql/cypher_merge.sql
@@ -30,7 +30,7 @@ SELECT create_graph('cypher_merge');
  * test 1: Single MERGE Clause, path doesn't exist
  */
 --test query
-SELECT * FROM cypher('cypher_merge', $$MERGE (n {i: "Hello Merge"})$$) AS (a agtype);
+SELECT * FROM cypher('cypher_merge', $$MERGE (n {i: "Hello Merge", j: (null IS NULL), k: (null IS NOT NULL)})$$) AS (a agtype);
 
 --validate
 SELECT * FROM cypher('cypher_merge', $$MATCH (n) RETURN n$$) AS (n agtype);
@@ -42,10 +42,11 @@ SELECT * FROM cypher('cypher_merge', $$MATCH (n) DETACH DELETE n $$) AS (a agtyp
  * test 2: Single MERGE Clause, path exists
  */
 --data setup
-SELECT * FROM cypher('cypher_merge', $$CREATE ({i: "Hello Merge"}) $$) AS (a agtype);
+SELECT * FROM cypher('cypher_merge', $$CREATE ({i: "Hello Merge", j: (null IS NULL)}) $$) AS (a agtype);
 
 --test_query
 SELECT * FROM cypher('cypher_merge', $$MERGE ({i: "Hello Merge"})$$) AS (a agtype);
+SELECT * FROM cypher('cypher_merge', $$MERGE ({j: (null IS NULL)})$$) AS (a agtype);
 
 --validate
 SELECT * FROM cypher('cypher_merge', $$MATCH (n) RETURN n$$) AS (n agtype);

--- a/src/backend/parser/cypher_expr.c
+++ b/src/backend/parser/cypher_expr.c
@@ -152,12 +152,15 @@ static Node *transform_cypher_expr_recurse(cypher_parsestate *cpstate,
     case T_NullTest:
     {
         NullTest *n = (NullTest *)expr;
+        NullTest *tranformed_expr = makeNode(NullTest);
 
-        n->arg = (Expr *)transform_cypher_expr_recurse(cpstate,
-                                                       (Node *)n->arg);
-        n->argisrow = type_is_rowtype(exprType((Node *)n->arg));
+        tranformed_expr->arg = (Expr *)transform_cypher_expr_recurse(cpstate,
+                                                         (Node *)n->arg);
+        tranformed_expr->nulltesttype = n->nulltesttype;
+        tranformed_expr->argisrow = type_is_rowtype(exprType((Node *)tranformed_expr->arg));
+        tranformed_expr->location = n->location;
 
-        return expr;
+        return (Node *) tranformed_expr;
     }
     case T_CaseExpr:
         return transform_CaseExpr(cpstate, (CaseExpr *) expr);


### PR DESCRIPTION
- The error was in the way expr was getting transformed in case of T_NullTest.
- The original expr was also getting tranformed, causing the nodeType of that expr unrecognizable next time the expr is used.
- Fixed by creating a new NullTest expr.
- Added regression tests as well.

resolves #878 