### PR TITLE
Fix SET bug, issue #899

### DIFF
--- a/age--1.2.0.sql
+++ b/age--1.2.0.sql
@@ -3158,15 +3158,14 @@ AS 'MODULE_PATHNAME';
 -- functions we need. Wrap the function with this to
 -- prevent that from happening
 --
-CREATE FUNCTION ag_catalog.agtype_volatile_wrapper(agt agtype)
-RETURNS agtype AS $return_value$
-BEGIN
-	RETURN agt;
-END;
-$return_value$ LANGUAGE plpgsql
+
+CREATE FUNCTION ag_catalog.agtype_volatile_wrapper("any")
+RETURNS agtype
+LANGUAGE c
 VOLATILE
 CALLED ON NULL INPUT
-PARALLEL SAFE;
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
 
 --
 -- agtype - list literal (`[expr, ...]`)
@@ -4203,8 +4202,8 @@ CALLED ON NULL INPUT
 PARALLEL SAFE
 AS 'MODULE_PATHNAME';
 
-CREATE FUNCTION ag_catalog.age_create_barbell_graph(graph_name name, 
-                                                graph_size int, 
+CREATE FUNCTION ag_catalog.age_create_barbell_graph(graph_name name,
+                                                graph_size int,
                                                 bridge_size int,
                                                 node_label name = NULL,
                                                 node_properties agtype = NULL,

--- a/regress/expected/cypher_set.out
+++ b/regress/expected/cypher_set.out
@@ -807,6 +807,26 @@ $$) AS (p agtype);
 (1 row)
 
 --
+-- Check passing mismatched types with SET
+-- Issue 899
+--
+SELECT * FROM cypher('cypher_set_1', $$
+    CREATE (x) SET x.n0 = (true OR true) RETURN x
+$$) AS (p agtype);
+                                    p                                     
+--------------------------------------------------------------------------
+ {"id": 281474976710657, "label": "", "properties": {"n0": true}}::vertex
+(1 row)
+
+SELECT * FROM cypher('cypher_set_1', $$
+    CREATE (x) SET x.n0 = (true OR false), x.n1 = (false AND false), x.n2 = (false = false) RETURN x
+$$) AS (p agtype);
+                                                 p                                                 
+---------------------------------------------------------------------------------------------------
+ {"id": 281474976710658, "label": "", "properties": {"n0": true, "n1": false, "n2": true}}::vertex
+(1 row)
+
+--
 -- Clean up
 --
 DROP TABLE tbl;

--- a/regress/sql/cypher_set.sql
+++ b/regress/sql/cypher_set.sql
@@ -276,6 +276,18 @@ SELECT * FROM cypher('cypher_set_1', $$
 $$) AS (p agtype);
 
 --
+-- Check passing mismatched types with SET
+-- Issue 899
+--
+SELECT * FROM cypher('cypher_set_1', $$
+    CREATE (x) SET x.n0 = (true OR true) RETURN x
+$$) AS (p agtype);
+
+SELECT * FROM cypher('cypher_set_1', $$
+    CREATE (x) SET x.n0 = (true OR false), x.n1 = (false AND false), x.n2 = (false = false) RETURN x
+$$) AS (p agtype);
+
+--
 -- Clean up
 --
 DROP TABLE tbl;

--- a/src/backend/parser/cypher_clause.c
+++ b/src/backend/parser/cypher_clause.c
@@ -5457,7 +5457,7 @@ static Expr *add_volatile_wrapper(Expr *node)
 {
     Oid oid;
 
-    oid = get_ag_func_oid("agtype_volatile_wrapper", 1, AGTYPEOID);
+    oid = get_ag_func_oid("agtype_volatile_wrapper", 1, ANYOID);
 
     return (Expr *)makeFuncExpr(oid, AGTYPEOID, list_make1(node), InvalidOid,
                                 InvalidOid, COERCE_EXPLICIT_CALL);


### PR DESCRIPTION
This patch fixes a bug in SET and likely all clauses that use the agtype_volatile_wrapper.

The original wrapper was written such that it could only handle an AGTYPE input. Additionally, it was called regardless of the input type. This would cause crashes on any non-AGTYPE types given as input to the function. For example, a PG boolean.

The fix was to replace this wrapper with a C function that takes "any" type as input and then creates AGTYPE return values for non-AGTYPE types. AGTYPE values would be passed per usual.

Added regression tests.