### PR TITLE
Enable the MATCH clause rule

### DIFF
--- a/cypher.l
+++ b/cypher.l
@@ -37,7 +37,8 @@
 
 [0-9]+ { yylval.int_val = atoi(yytext); return INTEGER; }
 [a-zA-Z][a-zA-Z0-9_]* { yylval.str_val = strdup(yytext); return IDENTIFIER; }
-"([^\"]|\.)*" { yylval.str_val = strdup(yytext); return STRING; }
+\"([^\"]|\.)*\" { yylval.str_val = strdup(yytext); return STRING; }
+[ \t]+    /* ignore spaces and tabs */;
 . { return UNKNOWN; }
 
 %%

--- a/cypher.y
+++ b/cypher.y
@@ -16,7 +16,8 @@ void yyerror(char const *s);
 
 typedef struct yy_buffer_state *YY_BUFFER_STATE;
 
-typedef struct {
+typedef struct
+{
     char* str_val;
     int int_val;
 } yyval;
@@ -24,9 +25,27 @@ typedef struct {
 int yylex(void);
 
 int order_clause_direction = 1; // 1 for ascending, -1 for descending
+
+int match = 0;
+char* label1 = "NULL";
+char* label2 = "NULL";
+char* property = "NULL";
+int expression_int = -1;
+char* expression_str = "NULL";
+char* expression_id = "NULL";
+int directed = 0;
+char* direction = "NULL";
+int where = 0;
+int with = 0;
+int return_ = 0;
+int with_alias = 0;
+int order_by = 0;
+int skip_value = 0;
+int limit_value = 0;
 %}
 
-%union {
+%union
+{
     char* str_val;
     int int_val;
 }
@@ -36,6 +55,8 @@ int order_clause_direction = 1; // 1 for ascending, -1 for descending
 %token <str_val> IDENTIFIER STRING
 %token UNKNOWN
 
+%type <str_val> str_val
+
 %left PIPE
 %left ARROW
 
@@ -44,140 +65,281 @@ int order_clause_direction = 1; // 1 for ascending, -1 for descending
 %%
 
 statement:
-    { printf("Query parsed successfully.\n"); }
+    query
     ;
 
 query:
     match_clause
-    //where_clause_opt
-    //with_clause_opt
-    //return_clause
+    where_clause_opt
+    with_clause_opt
+    return_clause
     ;
 
 match_clause:
-    MATCH path_pattern { printf("Match clause parsed successfully.\n"); }
-	;    
+    MATCH path_pattern 
+        {
+            match = 1;
+        }
+    ;    
 
 path_pattern:
     node_pattern
-    | node_pattern ARROW rel_pattern node_pattern { printf("Path pattern parsed successfully.\n"); }
+    | node_pattern ARROW rel_pattern node_pattern
+        {
+            /*printf("Path pattern parsed successfully.\n");*/
+        }
     ;
 
 node_pattern:
-    LPAREN node_labels_opt node_properties_opt RPAREN { printf("Node pattern parsed successfully.\n"); }
+    LPAREN node_labels_opt node_properties_opt RPAREN 
+        {
+            /*printf("Node pattern parsed successfully.\n");*/
+        }
     ;
 
 node_labels_opt:
-    /* empty */ { printf("No node labels.\n"); }
-    | COLON IDENTIFIER { printf("Node label parsed: %s.\n", $2); }
-    | node_labels_opt COLON IDENTIFIER { printf("Node label parsed: %s.\n", $3); }
+    /* empty */ 
+        { 
+            label1 = "NULL"; 
+            label2 = "NULL";
+        }
+    |
+      IDENTIFIER
+        {
+            label1 = $1;
+        }
+    | COLON IDENTIFIER 
+        {
+            label1 = $2;
+        }
+    | node_labels_opt COLON IDENTIFIER 
+        {
+            label2 = $3;
+        }
     ;
 
 node_properties_opt:
-    /* empty */ { printf("No node properties.\n"); }
-    | LBRACE map_literal RBRACE { printf("Node properties parsed successfully.\n"); }
+    /* empty */ 
+        { 
+            property = "NULL"; 
+        }
+    | LBRACE map_literal RBRACE 
+        {
+            /*printf("Node properties parsed successfully.\n");*/
+        }
+    ;
+
+str_val:
+    IDENTIFIER 
+        {
+            $$ = $1;
+        }
+    | STRING 
+        {
+            $$ = $1;
+        }
     ;
 
 rel_pattern:
-    rel_type rel_direction rel_type { printf("Rel pattern parsed successfully.\n"); }
+    rel_type rel_direction rel_type 
+        {
+            directed = 1;
+        }
     ;
 
 rel_type:
-    { printf("Rel type parsed: \n"); }
+    COLON str_val
+        {
+            /*printf("Rel type parsed: %s.\n", $2);*/
+        }
+    | LBRACKET str_val RBRACKET 
+        {
+            /*printf("Rel type parsed: %s.\n", $2);*/
+        }
     ;
-
-//rel_type:
-//    COLON str_val { printf("Rel type parsed: %s.\n", $2); }
-//     | LBRACKET str_val RBRACKET { printf("Rel type parsed: %s.\n", $2); }
-//    ;
-
 
 rel_direction:
-    {printf("Rel direction parsed: ->.\n"); }
+    ARROW 
+        {
+            direction = "->";
+        }
+    | ARROW str_val ARROW 
+        {
+            /*printf("Rel direction parsed: ->%s->.\n", $2);*/
+        }
     ;
 
-//rel_direction:
-//    ARROW { printf("Rel direction parsed: ->.\n"); }
-//    | ARROW rel_type_name ARROW { printf("Rel direction parsed: ->%s->.\n", $2); }
-//    ;
-
 map_literal:
-    /* empty */ { printf("Empty map literal.\n"); }
-    | nonempty_map_literal { printf("Nonempty map literal.\n"); }
+    /* empty */ 
+        {
+            /*printf("Empty map literal.\n");*/
+        }
+    | nonempty_map_literal 
+        {
+            /*printf("Nonempty map literal.\n");*/
+        }
     ;
 
 nonempty_map_literal:
-    map_entry { printf("Map literal entry parsed successfully.\n"); }
-    | nonempty_map_literal COMMA map_entry { printf("Map literal entry parsed successfully.\n"); }
+    map_entry 
+        {
+            /*printf("Map literal entry parsed successfully.\n");*/
+        }
+    | nonempty_map_literal COMMA map_entry 
+        {
+            /*printf("Map literal entry parsed successfully.\n");*/
+        }
     ;
 
 map_entry:
-    IDENTIFIER COLON expression { printf("Map entry parsed successfully.\n"); }
+    IDENTIFIER COLON expression 
+        {
+            property = $1;
+        }
     ;
 
 expression:
-    INTEGER { printf("Integer expression parsed: %d.\n", $1); }
-    | STRING { printf("String expression parsed: %s.\n", $1); }
-    | IDENTIFIER { printf("Identifier expression parsed: %s.\n", $1); }
+    INTEGER 
+        {
+            expression_int = $1;
+        }
+    | STRING 
+        {
+            expression_str = $1;
+        }
+    | IDENTIFIER 
+        {
+            expression_id = $1;
+        }
     ;
 
 where_clause_opt:
-    /* empty */ { printf("No WHERE clause.\n"); }
-    | WHERE expression { printf("WHERE clause parsed successfully.\n"); }
+    /* empty */ 
+        {
+            where = 0;
+        }
+    | WHERE expression 
+        { 
+            where = 1;
+        }
     ;
 
 with_clause_opt:
-    /* empty */ { printf("No WITH clause.\n"); }
-    | WITH expression_list return_clause { printf("WITH clause parsed successfully.\n"); }
+    /* empty */ 
+        {
+            with = 0;
+        }
+    | WITH expression_list return_clause 
+        {
+            with = 1;
+        }
+        ;
 
 expression_list:
-	expression { printf("Expression parsed successfully.\n"); }
-	| expression_list COMMA expression { printf("Expression parsed successfully.\n"); }
+	expression 
+            {
+                /*printf("Expression parsed successfully.\n");*/
+            }
+	| expression_list COMMA expression 
+            {
+                /*printf("Expression parsed successfully.\n");*/
+            }
 	;
 
 return_clause:
-	RETURN return_item_list order_clause_opt skip_clause_opt limit_clause_opt { printf("Return clause parsed successfully.\n"); }
-;
+	RETURN return_item_list order_clause_opt skip_clause_opt limit_clause_opt 
+            {
+                return_ = 1;
+            }
+        ;
 
 return_item_list:
-	return_item { printf("Return item parsed successfully.\n"); }
-	| return_item_list COMMA return_item { printf("Return item parsed successfully.\n"); }
+	return_item 
+            {
+                /*printf("Return item parsed successfully.\n");*/
+            }
+	| return_item_list COMMA return_item 
+            {
+                /*printf("Return item parsed successfully.\n");*/
+            }
 	;
 
 return_item:
-	expression { printf("Return item parsed successfully.\n"); }
-	| expression AS IDENTIFIER { printf("Return item with alias parsed successfully.\n"); }
+	expression 
+            {
+                /*printf("Return item parsed successfully.\n");*/
+            }
+	| expression AS IDENTIFIER 
+            {
+                with_alias = 1;
+            }
 	;
 
 order_clause_opt:
-	/* empty */ { printf("No ORDER BY clause.\n"); }
-	| ORDER BY sort_item_list { printf("ORDER BY clause parsed successfully.\n"); }
+	/* empty */ 
+            {
+                order_by = 0;
+            }
+	| ORDER BY sort_item_list 
+            {
+                order_by = 1;
+            }
 	;
 
 sort_item_list:
-sort_item { printf("Sort item parsed successfully.\n"); }
-| sort_item_list COMMA sort_item { printf("Sort item parsed successfully.\n"); }
-;
+    sort_item 
+        {
+            /*printf("Sort item parsed successfully.\n");*/
+        }
+    | sort_item_list COMMA sort_item 
+        {
+            /*printf("Sort item parsed successfully.\n");*/
+        }
+    ;
 
 sort_item:
-expression sort_direction_opt { printf("Sort item parsed successfully.\n"); }
-;
+    expression sort_direction_opt 
+        {
+            /*printf("Sort item parsed successfully.\n");*/
+        }
+    ;
 
 sort_direction_opt:
-	/* empty */ { printf("Sort direction not specified; defaulting to ASC.\n"); order_clause_direction = 1; }
-	| ASC { printf("Sort direction specified: ASC.\n"); order_clause_direction = 1; }
-	| DESC { printf("Sort direction specified: DESC.\n"); order_clause_direction = -1; }
-	;
+    /* empty */ 
+        {
+            printf("Sort direction not specified; defaulting to ASC.\n");
+            order_clause_direction = 1;
+        }
+    | ASC 
+        {
+            printf("Sort direction specified: ASC.\n"); 
+            order_clause_direction = 1;
+        }
+    | DESC 
+        {
+            printf("Sort direction specified: DESC.\n"); 
+            order_clause_direction = -1;
+        }
+    ;
 
 skip_clause_opt:
-	/* empty */ { printf("No SKIP clause.\n"); }
-	| SKIP INTEGER { printf("SKIP clause parsed: %d.\n", $2); }
-	;
+    /* empty */ {/* printf("No SKIP clause.\n"); */}
+    | SKIP INTEGER 
+        {
+            skip_value = $2;
+        }
+    ;
 
 limit_clause_opt:
-	/* empty */ { printf("No LIMIT clause.\n"); }
-	| LIMIT INTEGER { printf("LIMIT clause parsed: %d.\n", $2); }
-	;
+    /* empty */ 
+        {
+            /* printf("No LIMIT clause.\n"); */
+        }
+    | LIMIT INTEGER
+        {
+            limit_value = $2;
+        }
+    ;
 
 %%
 
@@ -189,5 +351,23 @@ void yyerror(char const *s)
 void
 psql_scan_cypher_command(PsqlScanState state)
 {
-
+    yyparse();
+    printf("match = : %d\n", match);
+    printf("label1 = : %s\n", label1);
+    printf("label2 = : %s\n", label2);
+    printf("property = : %s\n", property);
+    printf("expression_int = : %d\n", expression_int);
+    printf("expression_str = : %s\n", expression_str);
+    printf("expression_id = : %s\n", expression_id);
+    printf("str_val = : %s\n", yylval.str_val);
+    printf("directed = : %d\n", directed);
+    printf("direction = : %s\n", direction);
+    printf("where = : %d\n", where);
+    printf("with = : %d\n", with);
+    printf("return = : %d\n", return_);
+    printf("with_alias = : %d\n", with_alias);
+    printf("order_by = : %d\n", order_by);
+    printf("order_clause_direction = : %d\n", order_clause_direction);
+    printf("skip_value = : %d\n", skip_value);
+    printf("limit_value = : %d\n", limit_value);
 }


### PR DESCRIPTION
* This commit creates variables for constructing the Cypher query and prints those variables.
* It adds lexical definitions for strings, the space character, and tabs.
* Enables WHERE, WITH, and RETURN clauses.
* Enables alias, ORDER BY, SKIP, and LIMIT options.
* Formats the code according to Apache AGE standards.

To compile the code:

```
flex -b -Cfe -p -p -o ‘cypher.c’ cypher.l
bison -d cypher.y
make
```

To run the code:

```
createdb ageslqldb // create database
pg_ctl -D agesqldb -l logfile start // start database process 
./agesql agesqldb // run agesql
```

Query example:

```
agesqldb=# \
MATCH (p:Person) RETURN p

match = : 1
label1 = : p
label2 = : Person
property = : NULL
expression_int = : -1
expression_str = : NULL
expression_id = : p
str_val = : p
directed = : 0
direction = : NULL
where = : 0
with = : 0
return = : 1
with_alias = : 0
order_by = : 0
order_clause_direction = : 1
skip_value = : 0
limit_value = : 0
```