### PR TITLE
Created remove_graphid_list and get_list_tail functions

### DIFF
--- a/src/backend/utils/adt/age_graphid_ds.c
+++ b/src/backend/utils/adt/age_graphid_ds.c
@@ -86,6 +86,12 @@ GraphIdNode *get_list_head(ListGraphId *list)
     return list->head;
 }
 
+/* return a reference to the tail entry of a list */
+GraphIdNode *get_list_tail(ListGraphId *list)
+{
+    return list->tail;
+}
+
 /* get the size of the passed list */
 int64 get_list_size(ListGraphId *list)
 {
@@ -126,6 +132,63 @@ ListGraphId *append_graphid(ListGraphId *container, graphid id)
 
     return container;
 }
+
+
+/* removes a specified GraphIdNode from the list */
+graphid remove_graphid_list(ListGraphId *container, graphid id)
+{
+    graphid removed_id = 0; // Default value if id is not found
+
+    if (container == NULL)
+    {
+        // Empty container, nothing to remove
+        return removed_id;
+    }
+
+    GraphIdNode *current = get_list_head(container);
+    GraphIdNode *previous = NULL;
+
+    while (current != NULL)
+    {
+        if (current->id == id)
+        {
+            // Found the node with the specified id
+            if (previous == NULL)
+            {
+                // The node to remove is the head
+                container->head = current->next;
+            }
+            else
+            {
+                // The node to remove is not the head
+                previous->next = current->next;
+
+                if (current == container->tail)
+                {
+                    // The node to remove is the tail
+                    container->tail = previous;
+                }
+            }
+
+            removed_id = current->id;
+
+            // Free the memory of the node
+            pfree(current);
+            current = NULL;
+
+            // Decrease the size of the container
+            container->size--;
+
+            break;
+        }
+
+        previous = current;
+        current = current->next;
+    }
+
+    return removed_id;
+}
+
 
 /* free (delete) a ListGraphId list */
 void free_ListGraphId(ListGraphId *container)

--- a/src/include/utils/age_graphid_ds.h
+++ b/src/include/utils/age_graphid_ds.h
@@ -42,31 +42,48 @@ GraphIdNode *next_GraphIdNode(GraphIdNode *node);
 graphid get_graphid(GraphIdNode *node);
 
 /* graphid stack functions */
+
 /* create a new ListGraphId stack */
 ListGraphId *new_graphid_stack(void);
+
 /* free a ListGraphId stack */
 void free_graphid_stack(ListGraphId *stack);
+
 /* push a graphid onto a ListGraphId stack */
 void push_graphid_stack(ListGraphId *stack, graphid id);
+
 /* pop (remove) a GraphIdNode from the top of the stack */
 graphid pop_graphid_stack(ListGraphId *stack);
+
 /* peek (doesn't remove) at the head entry of a ListGraphId stack */
 GraphIdNode *peek_stack_head(ListGraphId *stack);
+
 /* peek (doesn't remove) at the tail entry of a ListGraphId stack */
 GraphIdNode *peek_stack_tail(ListGraphId *stack);
+
 /* return the size of a ListGraphId stack */
 int64 get_stack_size(ListGraphId *stack);
 
 /* graphid list functions */
+
 /*
  * Helper function to add a graphid to the end of a ListGraphId container.
  * If the container is NULL, it creates the container with the entry.
  */
 ListGraphId *append_graphid(ListGraphId *container, graphid id);
+
+/* removes a specified GraphIdNode from the list */
+graphid remove_graphid_list(ListGraphId *container, graphid id);
+
 /* free a ListGraphId container */
 void free_ListGraphId(ListGraphId *container);
+
 /* return a reference to the head entry of a list */
 GraphIdNode *get_list_head(ListGraphId *list);
+
+/* return a reference to the tail entry of a list */
+GraphIdNode *get_list_tail(ListGraphId *list);
+
 /* get the size of the passed list */
 int64 get_list_size(ListGraphId *list);
 


### PR DESCRIPTION
Hi there! I found that it would be interesting to add these two new functionalities for the `ListGraphId` list structure since the stack structure already had similar functions for it. These new functions enhance the functionality of the existing code by allowing the removal of a specified `graphid` from the `ListGraphId` list and retrieving the tail of the list.

To remove a specific `graphid` from the list, the `remove_graphid_list` function can be used as follows:
```c
graphid removedId = remove_graphid_list(container, idToRemove);
```

To retrieve the tail of the list, the `get_list_tail` function can be used as follows:
```c
GraphIdNode* tailNode = get_list_tail(container);
```

Please let me know if you have any feedbacks or suggestions for improvements. Thank you for your attention and for considering my contribution!