### PR TITLE
[Graph Generation Algorithms] Erdős–Rényi Graph

### DIFF
--- a/age--1.2.0.sql
+++ b/age--1.2.0.sql
@@ -4215,6 +4215,20 @@ CALLED ON NULL INPUT
 PARALLEL SAFE
 AS 'MODULE_PATHNAME';
 
+
+CREATE FUNCTION ag_catalog.age_create_erdos_renyi_graph(graph_name Name, 
+                                                n int, 
+                                                p float
+                                                vertex_label_name Name DEFAULT = NULL,
+                                                edge_label_name Name DEAULT = NULL,
+                                                bidirectional bool DEFAULT = true)
+RETURNS void
+LANGUAGE c
+CALLED ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
+
 CREATE FUNCTION ag_catalog.age_prepare_cypher(cstring, cstring)
 RETURNS boolean
 LANGUAGE c

--- a/age--1.2.0.sql
+++ b/age--1.2.0.sql
@@ -4216,12 +4216,12 @@ PARALLEL SAFE
 AS 'MODULE_PATHNAME';
 
 
-CREATE FUNCTION ag_catalog.age_create_erdos_renyi_graph(graph_name Name, 
+CREATE FUNCTION ag_catalog.age_create_erdos_renyi_graph(graph_name name, 
                                                 n int, 
-                                                p float
-                                                vertex_label_name Name DEFAULT = NULL,
-                                                edge_label_name Name DEAULT = NULL,
-                                                bidirectional bool DEFAULT = true)
+                                                p name,
+                                                vertex_label_name name = NULL,
+                                                edge_label_name name = NULL,
+                                                bidirectional bool = true)
 RETURNS void
 LANGUAGE c
 CALLED ON NULL INPUT

--- a/regress/expected/expr.out
+++ b/regress/expected/expr.out
@@ -6013,13 +6013,9 @@ SELECT * FROM cypher('opt_forms', $$MATCH (u)-->()<--(v) RETURN u.i, v.i$$) AS (
 (2 rows)
 
 SELECT * FROM cypher('opt_forms', $$MATCH (u) CREATE (u)-[:edge]->() RETURN *$$) AS (results agtype);
-                               results                                
-----------------------------------------------------------------------
- {"id": 281474976710657, "label": "", "properties": {"i": 1}}::vertex
- {"id": 281474976710658, "label": "", "properties": {"i": 2}}::vertex
- {"id": 281474976710659, "label": "", "properties": {"i": 3}}::vertex
-(3 rows)
-
+ERROR:  return row and column definition list do not match
+LINE 1: SELECT * FROM cypher('opt_forms', $$MATCH (u) CREATE (u)-[:e...
+                      ^
 SELECT * FROM cypher('opt_forms', $$MATCH (u)-->()<--(v) RETURN *$$) AS (col1 agtype, col2 agtype);
                                  col1                                 |                                 col2                                 
 ----------------------------------------------------------------------+----------------------------------------------------------------------
@@ -6469,11 +6465,10 @@ NOTICE:  graph "case_statement" has been dropped
 (1 row)
 
 SELECT * FROM drop_graph('opt_forms', true);
-NOTICE:  drop cascades to 4 other objects
+NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to table opt_forms._ag_label_vertex
 drop cascades to table opt_forms._ag_label_edge
 drop cascades to table opt_forms."KNOWS"
-drop cascades to table opt_forms.edge
 NOTICE:  graph "opt_forms" has been dropped
  drop_graph 
 ------------

--- a/regress/expected/graph_generation.out
+++ b/regress/expected/graph_generation.out
@@ -228,3 +228,85 @@ NOTICE:  graph "gp2" has been dropped
  
 (1 row)
 
+-- Tests for Erdos-Renyi graph generation.
+-- Unidirectional.
+SELECT * FROM age_create_erdos_renyi_graph('ErdosRenyi_1', 6, '0', NULL, NULL, false); -- No edges are created.
+NOTICE:  graph "ErdosRenyi_1" has been created
+ age_create_erdos_renyi_graph 
+------------------------------
+ 
+(1 row)
+
+SELECT * FROM age_create_erdos_renyi_graph('ErdosRenyi_2', 6, '1', NULL, NULL, false); -- All edges are created.
+NOTICE:  graph "ErdosRenyi_2" has been created
+ age_create_erdos_renyi_graph 
+------------------------------
+ 
+(1 row)
+
+SELECT count(*) FROM "ErdosRenyi_1"._ag_label_edge; -- No edges are created.
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM "ErdosRenyi_2"._ag_label_edge; -- All edges are created (15).
+ count 
+-------
+    15
+(1 row)
+
+-- Bidirectional.
+SELECT * FROM age_create_erdos_renyi_graph('ErdosRenyi_3', 6, '1', NULL, NULL, true); -- All edges are created.
+NOTICE:  graph "ErdosRenyi_3" has been created
+ age_create_erdos_renyi_graph 
+------------------------------
+ 
+(1 row)
+
+SELECT count(*) FROM "ErdosRenyi_3"._ag_label_edge; -- All edges are created (30).
+ count 
+-------
+    30
+(1 row)
+
+-- Errors.
+SELECT * FROM age_create_erdos_renyi_graph(NULL, NULL, NULL, NULL, NULL, NULL); -- Graph name cannot be NULL.
+ERROR:  Graph name cannot be NULL
+SELECT * FROM age_create_erdos_renyi_graph('ErdosRenyi_Error', NULL, NULL, NULL, NULL, NULL); -- Number of vertices cannot be NULL.
+NOTICE:  graph "ErdosRenyi_Error" has been created
+ERROR:  Number of vertices cannot be NULL.
+SELECT * FROM age_create_erdos_renyi_graph('ErdosRenyi_Error', 6, NULL, NULL, NULL, NULL); -- Probability cannot be NULL.
+NOTICE:  graph "ErdosRenyi_Error" has been created
+ERROR:  Probability cannot be NULL.
+-- Drop Erdos-Renyi Graphs.
+SELECT drop_graph('ErdosRenyi_1', true);
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table "ErdosRenyi_1"._ag_label_vertex
+drop cascades to table "ErdosRenyi_1"._ag_label_edge
+NOTICE:  graph "ErdosRenyi_1" has been dropped
+ drop_graph 
+------------
+ 
+(1 row)
+
+SELECT drop_graph('ErdosRenyi_2', true);
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table "ErdosRenyi_2"._ag_label_vertex
+drop cascades to table "ErdosRenyi_2"._ag_label_edge
+NOTICE:  graph "ErdosRenyi_2" has been dropped
+ drop_graph 
+------------
+ 
+(1 row)
+
+SELECT drop_graph('ErdosRenyi_3', true);
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table "ErdosRenyi_3"._ag_label_vertex
+drop cascades to table "ErdosRenyi_3"._ag_label_edge
+NOTICE:  graph "ErdosRenyi_3" has been dropped
+ drop_graph 
+------------
+ 
+(1 row)
+

--- a/regress/sql/graph_generation.sql
+++ b/regress/sql/graph_generation.sql
@@ -80,3 +80,27 @@ SELECT * FROM age_create_barbell_graph('gp6',5,10,'label',NULL,'label',NULL);
 SELECT drop_graph('gp1', true);
 SELECT drop_graph('gp2', true);
 
+
+-- Tests for Erdos-Renyi graph generation.
+
+-- Unidirectional.
+SELECT * FROM age_create_erdos_renyi_graph('ErdosRenyi_1', 6, '0', NULL, NULL, false); -- No edges are created.
+SELECT * FROM age_create_erdos_renyi_graph('ErdosRenyi_2', 6, '1', NULL, NULL, false); -- All edges are created.
+
+SELECT count(*) FROM "ErdosRenyi_1"._ag_label_edge; -- No edges are created.
+SELECT count(*) FROM "ErdosRenyi_2"._ag_label_edge; -- All edges are created (15).
+
+-- Bidirectional.
+SELECT * FROM age_create_erdos_renyi_graph('ErdosRenyi_3', 6, '1', NULL, NULL, true); -- All edges are created.
+
+SELECT count(*) FROM "ErdosRenyi_3"._ag_label_edge; -- All edges are created (30).
+
+-- Errors.
+SELECT * FROM age_create_erdos_renyi_graph(NULL, NULL, NULL, NULL, NULL, NULL); -- Graph name cannot be NULL.
+SELECT * FROM age_create_erdos_renyi_graph('ErdosRenyi_Error', NULL, NULL, NULL, NULL, NULL); -- Number of vertices cannot be NULL.
+SELECT * FROM age_create_erdos_renyi_graph('ErdosRenyi_Error', 6, NULL, NULL, NULL, NULL); -- Probability cannot be NULL.
+
+-- Drop Erdos-Renyi Graphs.
+SELECT drop_graph('ErdosRenyi_1', true);
+SELECT drop_graph('ErdosRenyi_2', true);
+SELECT drop_graph('ErdosRenyi_3', true);

--- a/src/backend/utils/graph_generation.c
+++ b/src/backend/utils/graph_generation.c
@@ -373,3 +373,20 @@ Datum age_create_barbell_graph(PG_FUNCTION_ARGS)
     
     PG_RETURN_VOID();
 }
+
+
+PG_FUNCTION_INFO_V1(age_create_erdos_renyi_graph);
+/*
+    ag_catalog.age_create_erdos_renyi_graph(graph_name Name, n int, p float
+                                    vertex_label_name Name DEFAULT = NULL,
+                                    edge_label_name Name DEAULT = NULL,
+                                    bidirectional bool DEFAULT = true)
+
+    The Erdős–Rényi model is a random graph generation model that produces 
+    graphs where each edge has a fixed probability of being present or absent, 
+    independently of the other edges.
+*/
+Datum age_create_erdos_renyi_graph(PG_FUNCTION_ARGS)
+{
+    PG_RETURN_VOID();
+}

--- a/src/backend/utils/graph_generation.c
+++ b/src/backend/utils/graph_generation.c
@@ -562,7 +562,7 @@ Datum age_create_erdos_renyi_graph(PG_FUNCTION_ARGS)
             /* Generate a random float number between 0 and 1. */
             random_prob = (float) ((float)rand() / (float)RAND_MAX);
 
-            if (random_prob >= set_prob && i != j)
+            if (random_prob <= set_prob && i != j)
             {
                 eid = nextval_internal(edge_seq_id, true);
                 object_graph_id = make_graphid(edge_label_id, eid);

--- a/src/backend/utils/graph_generation.c
+++ b/src/backend/utils/graph_generation.c
@@ -47,6 +47,7 @@
 #include "utils/load/age_load.h"
 #include "utils/load/ag_load_edges.h"
 #include "utils/load/ag_load_labels.h"
+#include "utils/age_graphid_ds.h"
 
 
 int64 get_nextval_internal(graph_cache_data* graph_cache, 
@@ -388,5 +389,206 @@ PG_FUNCTION_INFO_V1(age_create_erdos_renyi_graph);
 */
 Datum age_create_erdos_renyi_graph(PG_FUNCTION_ARGS)
 {
+    Oid graph_id;
+    Oid vertex_seq_id;
+    Oid edge_seq_id;
+    Oid nsp_id;
+
+    graphid object_graph_id;
+    graphid current_graphid; 
+    graphid* vertex_array;
+
+    agtype *props = NULL;
+
+	Name graph_name;
+    Name vertex_label_name;
+    Name vertex_seq_name;
+    Name edge_label_name;
+    Name edge_seq_name;
+
+	char* graph_name_str;
+    char* vertex_label_str;
+    char* vertex_seq_name_str;
+    char* edge_label_str;
+    char* edge_seq_name_str;
+
+    graph_cache_data *graph_cache;
+    label_cache_data *vertex_cache;
+    label_cache_data *edge_cache;
+
+    int64 no_vertices, eid;
+    int64 vid = 1;
+    int32 vertex_label_id;
+    int32 edge_label_id;
+
+    float random_prob;
+    float set_prob;
+    srand(time(NULL));
+
+    bool bidirectional;
+
+
+    /* Retrieve the graph name (cannot be null). */
+    if (PG_ARGISNULL(0))
+    {
+        ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                        errmsg("Graph name cannot be NULL")));
+    }
+    graph_name = PG_GETARG_NAME(0);
+    graph_name_str = NameStr(*graph_name);
+
+
+    /* Check if graph exists. If it doesn't, create the graph. */
+    if (!graph_exists(graph_name_str))
+    {
+        DirectFunctionCall1(create_graph, CStringGetDatum(graph_name));
+    }
+    graph_id = get_graph_oid(graph_name_str);
+
+
+    /* Get the number of vertices. */
+	if (PG_ARGISNULL(1))
+	{
+		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                                errmsg("Number of vertices cannot be NULL.")));
+	}
+    no_vertices = PG_GETARG_INT64(1);
+
+
+    /* Get the probability for each edge to exist. */
+    if (PG_ARGISNULL(2))
+	{
+		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                                errmsg("Probability cannot be NULL.")));
+	}
+    Name prob_name = PG_GETARG_NAME(2);
+    char* prob_name_str = NameStr(*prob_name);
+    set_prob = strtof(prob_name_str, NULL);
+
+
+    /* Get the vertex label. */
+    if (PG_ARGISNULL(3)) 
+    {
+        namestrcpy(vertex_label_name, AG_DEFAULT_LABEL_VERTEX);
+        vertex_label_str = AG_DEFAULT_LABEL_VERTEX;
+    }
+    else 
+    {
+        vertex_label_name = PG_GETARG_NAME(3);
+        vertex_label_str = NameStr(*vertex_label_name);
+    }
+
+
+    /* Get the edge label. */
+    if (PG_ARGISNULL(4))
+    {
+        namestrcpy(edge_label_name, AG_DEFAULT_LABEL_EDGE);
+        edge_label_str = AG_DEFAULT_LABEL_EDGE;
+    }
+    else
+    {
+        edge_label_name = PG_GETARG_NAME(4);
+        edge_label_str = NameStr(*edge_label_name);
+    }
+
+
+    /* Compare both edge and vertex labels (they cannot be the same).*/
+    if (strcmp(vertex_label_str, edge_label_str) == 0)
+    {
+        ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                errmsg("vertex and edge label can not be same")));
+    }
+
+
+    /* If the vertex label does not exist, create the label. */
+    if (!label_exists(vertex_label_str, graph_id))
+    {
+        DirectFunctionCall2(create_vlabel, CStringGetDatum(graph_name), CStringGetDatum(vertex_label_name));
+    }
+
+
+    /* If the edge label does not exist, create the label. */
+    if (!label_exists(edge_label_str, graph_id))
+    {
+        DirectFunctionCall2(create_elabel, CStringGetDatum(graph_name), CStringGetDatum(edge_label_name));
+    }
+
+
+    /* Get the direction of the graph. */
+    bidirectional = (PG_GETARG_BOOL(5) == true) ? true : false;
+
+
+    vertex_label_id = get_label_id(vertex_label_str, graph_id);
+    edge_label_id = get_label_id(edge_label_str, graph_id);
+
+    graph_cache = search_graph_name_cache(graph_name_str);
+    vertex_cache = search_label_name_graph_cache(vertex_label_str,graph_id);
+    edge_cache = search_label_name_graph_cache(edge_label_str,graph_id);
+
+    nsp_id = graph_cache->namespace;
+    vertex_seq_name = &(vertex_cache->seq_name);
+    vertex_seq_name_str = NameStr(*vertex_seq_name);
+
+    edge_seq_name = &(edge_cache->seq_name);
+    edge_seq_name_str = NameStr(*edge_seq_name);
+
+    vertex_seq_id = get_relname_relid(vertex_seq_name_str, nsp_id);
+    edge_seq_id = get_relname_relid(edge_seq_name_str, nsp_id);
+
+    vertex_array = (graphid*) malloc(sizeof(graphid) * no_vertices);
+
+
+    /* Create the vertices and add them to vertex_array */
+    for (int i = 0; i < no_vertices; i++)
+    {
+        vid = nextval_internal(vertex_seq_id, true);
+        object_graph_id = make_graphid(vertex_label_id, vid);
+        props = create_empty_agtype();
+
+        /* Insert the vertex in the graph and in the list. */
+        insert_vertex_simple(graph_id, vertex_label_str, object_graph_id, props);
+        vertex_array[i] = object_graph_id;
+    }
+
+
+    /* For each unique pair (i, j), generate a random number. If it's probability is P or grater, create
+       an edge between i and j. 
+     */
+    for (int i = 0; i < no_vertices; i++)
+    {
+        /* It starts with (int j = i) because it's a combination of C(n, 2) total edges. */
+        for (int j = i; j < no_vertices; j++)
+        {
+            /* Generate a random float number between 0 and 1. */
+            random_prob = (float) ((float)rand() / (float)RAND_MAX);
+
+            if (random_prob >= set_prob && i != j)
+            {
+                eid = nextval_internal(edge_seq_id, true);
+                object_graph_id = make_graphid(edge_label_id, eid);
+
+                props = create_empty_agtype();
+
+                insert_edge_simple(graph_id, edge_label_str,
+                                object_graph_id, vertex_array[i],
+                                vertex_array[j], props);
+                
+                if (bidirectional == true)
+                {
+                    eid = nextval_internal(edge_seq_id, true);
+                    object_graph_id = make_graphid(edge_label_id, eid);
+
+                    props = create_empty_agtype();
+
+                    insert_edge_simple(graph_id, edge_label_str,
+                                    object_graph_id, vertex_array[j],
+                                    vertex_array[i], props);
+                }
+            }
+        }
+    }
+
+
+    free(vertex_array);
     PG_RETURN_VOID();
 }


### PR DESCRIPTION
This PR is related to #277 and adds a new function `age_create_erdos_renyi_graph` that generates a random graph with n nodes, where the probability for each node to connect to another one is based on a given probability. The edges can be set to be in one direction or in both directions. It is also possible to set the labels for both vertices and edges. 

It uses the _G(n,p)_ model, where the graph is constructed by connecting labeled nodes randomly. Each edge is included in the graph with probability p, independently from every other edge. Equivalently, the probability for generating each graph that has n nodes and M edges is 

![Graph Generation Prob](https://github.com/apache/age/assets/83461020/4cfd195c-2c08-45fc-be84-c8fba3f555eb)

Syntax:
```sql
ag_catalog.age_create_erdos_renyi_graph(graph_name name, 
                                                n int, 
                                                p name,
                                                vertex_label_name name = NULL,
                                                edge_label_name name = NULL,
                                                bidirectional bool = true)
```

Additionally, the probability `p` was set to be of type `name`  because neither `PG_GETARG_FLOAT4(2)` or `DatumGetFloat4(PG_GETARG_DATUM(2));` were working.
