### PR TITLE
Fix MERGE crashes due to incorrect label type

### DIFF
--- a/src/backend/nodes/cypher_outfuncs.c
+++ b/src/backend/nodes/cypher_outfuncs.c
@@ -204,6 +204,7 @@ void out_cypher_node(StringInfo str, const ExtensibleNode *node)
 
     WRITE_STRING_FIELD(name);
     WRITE_STRING_FIELD(label);
+    WRITE_STRING_FIELD(parsed_label);
     WRITE_NODE_FIELD(props);
     WRITE_LOCATION_FIELD(location);
 }
@@ -215,6 +216,7 @@ void out_cypher_relationship(StringInfo str, const ExtensibleNode *node)
 
     WRITE_STRING_FIELD(name);
     WRITE_STRING_FIELD(label);
+    WRITE_STRING_FIELD(parsed_label);
     WRITE_NODE_FIELD(props);
     WRITE_NODE_FIELD(varlen);
     WRITE_ENUM_FIELD(dir, cypher_rel_dir);


### PR DESCRIPTION
Fixed a crash due to MERGE not checking if the label retrieved was of the correct type.

NOTE: This fix is temporary until a better solution can be
      implemented.

Added error messaging for improper usage of the add_volatile_wrapper function. Previously, it was causing crashes when used by MERGE.