### PR TITLE
Fix misspellings in many AGE files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ We strongly recommend you to subscribe the mailing lists, join the Apache AGE Di
 
 ## Pull Requests
 
-Changes to AGE source code are proposed, reviewed, and committed via Github pull requests (described in Code Convention). Pull requests are a great way to get your ideas into this repository. Anyone can view and comment on active changes here. Reviewing others' changes are a good way to learn how the change process works and gain exposure to activity in various parts of the code. You can help by reviewing the changes, asking questions, or pointing out issues as simple as typos.
+Changes to AGE source code are proposed, reviewed, and committed via GitHub pull requests (described in Code Convention). Pull requests are a great way to get your ideas into this repository. Anyone can view and comment on active changes here. Reviewing others' changes are a good way to learn how the change process works and gain exposure to activity in various parts of the code. You can help by reviewing the changes, asking questions, or pointing out issues as simple as typos.
 
 ## Documentation Changes
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ sudo apt-get install build-essential libreadline-dev zlib1g-dev flex bison
 Apache AGE is intended to be simple to install and run. It can be installed with Docker and other traditional ways. 
 
 <h4><a><img width="20" src="/img/pg.svg"></a>
-&nbsp;Install PosgtreSQL
+&nbsp;Install PostgreSQL
 </h4>
 
 You will need to install an AGE compatible version of Postgres<a>, for now AGE supports Postgres 11, 12 & 13. Supporting the latest versions is on AGE roadmap. 

--- a/RELEASE
+++ b/RELEASE
@@ -24,7 +24,7 @@ Apache AGE 1.3.0 - Release Notes
     Implement plus-equal operator in SET clause. (#638)
     Implement CI test for python driver. (#587)
     Move from travis CI to github actions for build. (#673)
-    Update all driver CIs to Github actions.
+    Update all driver CIs to GitHub actions.
     Fix build warnings.
     Fix golang driver workflow (#563)
     Updated Readme for drivers folder. (#642)

--- a/drivers/README
+++ b/drivers/README
@@ -19,5 +19,5 @@ This folder contains drivers for specific languages
 
 ### For more information about [Apache AGE](https://age.apache.org/)
 * Apache Age : https://age.apache.org/
-* Github : https://github.com/apache/age
+* GitHub : https://github.com/apache/age
 * Document : https://age.apache.org/age-manual/master/index.html

--- a/drivers/golang/README.md
+++ b/drivers/golang/README.md
@@ -31,7 +31,7 @@ Check [latest version](https://github.com/apache/age/releases)
 
 ### For more information about [Apache AGE](https://age.apache.org/)
 * Apache Age : https://age.apache.org/
-* Github : https://github.com/apache/age
+* GitHub : https://github.com/apache/age
 * Document : https://age.apache.org/docs/
 
 ### Check AGE loaded on your PostgreSQL

--- a/drivers/golang/install.bat
+++ b/drivers/golang/install.bat
@@ -39,7 +39,7 @@ if not exist "%ProgramFiles%\ANTLR" (
 
 echo ANTLR installation complete.
 
-rem Checking Compatablity for Golang
+rem Checking Compatibility for Golang
 echo Checking if current version of Golang >= Go 1.18.....
 set "minimum_version=1.18"
 set "installed_version="

--- a/drivers/golang/install.sh
+++ b/drivers/golang/install.sh
@@ -104,7 +104,7 @@ if ! command -v go >/dev/null 2>&1 || { [ $(go version | grep -o -E '[0-9]+\.[0-
 	 		sudo open -w golang.pkg
 		  
 	  elif [[ "$os" == "Linux" ]]; then
-		  mdkir -p ~/tmp/go1.20.2
+		  mkdir -p ~/tmp/go1.20.2
 		  cd ~/tmp/go1.20.2
 		  if [[ "$arch" == "x86_64" ]]; then
 		  	curl "https://go.dev/dl/go1.20.2.linux-amd64.tar.gz" -o go1.20.2.tar.gz

--- a/drivers/jdbc/README.md
+++ b/drivers/jdbc/README.md
@@ -94,5 +94,5 @@ Vertex : Country, 	Props : {name=US}
 ## For more information about [Apache AGE](https://age.apache.org/)
 
 - Apache Age : [https://age.apache.org/](https://age.apache.org/)
-- Github : [https://github.com/apache/age](https://github.com/apache/age)
+- GitHub : [https://github.com/apache/age](https://github.com/apache/age)
 - Document : [https://age.apache.org/age-manual/master/index.html](https://age.apache.org/age-manual/master/index.html)

--- a/drivers/nodejs/README.md
+++ b/drivers/nodejs/README.md
@@ -48,5 +48,5 @@ const results: QueryResultRow = await client?.query<QueryResultRow>(`
 ```
 ### For more information about [Apache AGE](https://age.apache.org/)
 * Apache Age : https://age.apache.org/
-* Github : https://github.com/apache/age
+* GitHub : https://github.com/apache/age
 * Document : https://age.apache.org/age-manual/master/index.html

--- a/drivers/python/README.md
+++ b/drivers/python/README.md
@@ -3,7 +3,7 @@ AGType parser and driver support for [Apache AGE](https://age.apache.org/), grap
 
 ### Features
 * Unmarshal AGE result data(AGType) to Vertex, Edge, Path
-* Cypher query support for Psycopg2 PostreSQL driver (enables to use cypher queries directly)
+* Cypher query support for Psycopg2 PostgreSQL driver (enables to use cypher queries directly)
 
 ### Prerequisites
 * over Python 3.9
@@ -42,7 +42,7 @@ python setup.py install
 
 ### For more information about [Apache AGE](https://age.apache.org/)
 * Apache Age : https://age.apache.org/
-* Github : https://github.com/apache/age
+* GitHub : https://github.com/apache/age
 * Document : https://age.apache.org/age-manual/master/index.html
 
 ### Check AGE loaded on your PostgreSQL

--- a/drivers/python/age/age.py
+++ b/drivers/python/age/age.py
@@ -113,7 +113,7 @@ def execCypher(conn:ext.connection, graphName:str, cypherStmt:str, cols:list=Non
         raise _EXCEPTION_NoConnection
 
     cursor = conn.cursor()
-    #clean up the string for mogrificiation
+    #clean up the string for mogrification
     cypherStmt = cypherStmt.replace("\n", "")
     cypherStmt = cypherStmt.replace("\t", "")
     cypher = str(cursor.mogrify(cypherStmt, params))
@@ -146,7 +146,7 @@ def execCypher(conn:ext.connection, graphName:str, cypherStmt:str, cols:list=Non
 
 
 def cypher(cursor:ext.cursor, graphName:str, cypherStmt:str, cols:list=None, params:tuple=None) -> ext.cursor :
-    #clean up the string for mogrificiation
+    #clean up the string for mogrification
     cypherStmt = cypherStmt.replace("\n", "")
     cypherStmt = cypherStmt.replace("\t", "")
     cypher = str(cursor.mogrify(cypherStmt, params))

--- a/regress/expected/age_global_graph.out
+++ b/regress/expected/age_global_graph.out
@@ -93,7 +93,7 @@ SELECT * FROM cypher('ag_graph_1', $$ RETURN delete_global_graphs('ag_graph_1') 
 (1 row)
 
 -- delete ag_graph_3's context
--- should return true(succeed) beacuse the previous commands should not delete the 3rd graph's context
+-- should return true(succeed) because the previous commands should not delete the 3rd graph's context
 SELECT * FROM cypher('ag_graph_3', $$ RETURN delete_global_graphs('ag_graph_3') $$) AS (result agtype);
  result 
 --------
@@ -120,7 +120,7 @@ SELECT * FROM cypher('ag_graph_3', $$ RETURN delete_global_graphs('ag_graph_3') 
  false
 (1 row)
 
---- delete unitialized graph context
+--- delete uninitialized graph context
 --- should throw exception graph "ag_graph_4" does not exist
 SELECT * FROM cypher('ag_graph_4', $$ RETURN delete_global_graphs('ag_graph_4') $$) AS (result agtype);
 ERROR:  graph "ag_graph_4" does not exist

--- a/regress/expected/cypher_call.out
+++ b/regress/expected/cypher_call.out
@@ -75,7 +75,7 @@ SELECT * FROM cypher('cypher_call', $$CALL call_stmt_test.add_agtype(1,2)$$) as 
  3
 (1 row)
 
-/* non-existent schema should fail */
+/* nonexistent schema should fail */
 SELECT * FROM cypher('cypher_call', $$CALL ag_catalog.add_agtype(1,2)$$) as (sqrt agtype);
 ERROR:  function ag_catalog.add_agtype(agtype, agtype) does not exist
 LINE 2: ...cypher('cypher_call', $$CALL ag_catalog.add_agtype(1,2)$$) a...

--- a/regress/expected/cypher_create.out
+++ b/regress/expected/cypher_create.out
@@ -538,7 +538,7 @@ cypher('cypher_create', $$
 	CREATE (b)
 	RETURN b
 $$) as t(b agtype);
-ERROR:  cypher create clause cannot be rescaned
+ERROR:  cypher create clause cannot be rescanned
 HINT:  its unsafe to use joins in a query with a Cypher CREATE clause
 -- column definition list for CREATE clause must contain a single agtype
 -- attribute

--- a/regress/expected/cypher_delete.out
+++ b/regress/expected/cypher_delete.out
@@ -84,7 +84,7 @@ SELECT * FROM cypher('cypher_delete', $$MATCH(n) DELETE n RETURN n$$) AS (a agty
  {"id": 844424930131973, "label": "v", "properties": {}}::vertex
 (2 rows)
 
---Test 4: DETACH DELECT a vertex
+--Test 4: DETACH DELETE a vertex
 SELECT * FROM cypher('cypher_delete', $$CREATE (:v)-[:e]->(:v)$$) AS (a agtype);
  a 
 ---
@@ -103,7 +103,7 @@ SELECT * FROM cypher('cypher_delete', $$MATCH(n) RETURN n$$) AS (a agtype);
  {"id": 844424930131975, "label": "v", "properties": {}}::vertex
 (1 row)
 
---Test 4: DETACH DELECT two vertices tied to the same edge
+--Test 4: DETACH DELETE two vertices tied to the same edge
 SELECT * FROM cypher('cypher_delete', $$CREATE (:v)-[:e]->(:v)$$) AS (a agtype);
  a 
 ---
@@ -115,7 +115,7 @@ SELECT * FROM cypher('cypher_delete', $$MATCH(n1)-[e]->(n2) DETACH DELETE n1, n2
  {"id": 1125899906842627, "label": "e", "end_id": 844424930131977, "start_id": 844424930131976, "properties": {}}::edge
 (1 row)
 
---Test 4: DETACH DELECT a vertex
+--Test 4: DETACH DELETE a vertex
 SELECT * FROM cypher('cypher_delete', $$CREATE (:v)-[:e]->(:v)$$) AS (a agtype);
  a 
 ---

--- a/regress/expected/cypher_merge.out
+++ b/regress/expected/cypher_merge.out
@@ -132,7 +132,7 @@ SELECT * FROM cypher('cypher_merge', $$MATCH (n) DETACH DELETE n $$) AS (a agtyp
 (0 rows)
 
 /*
- * test 5: Prev clause has results, path does not exist (differnt property name)
+ * test 5: Prev clause has results, path does not exist (different property name)
  */
 --data setup
 SELECT * FROM cypher('cypher_merge', $$CREATE ({i: "Hello Merge"}) $$) AS (a agtype);
@@ -398,7 +398,7 @@ SELECT * FROM cypher('cypher_merge', $$MATCH (n) DETACH DELETE n $$) AS (a agtyp
 (0 rows)
 
 /*
- * test 13: edge doesn't exists (differnt label), using MATCH
+ * test 13: edge doesn't exists (different label), using MATCH
  */
 -- setup
 SELECT * FROM cypher('cypher_merge', $$CREATE ()-[:e]->() $$) AS (a agtype);

--- a/regress/expected/cypher_set.out
+++ b/regress/expected/cypher_set.out
@@ -358,7 +358,7 @@ SELECT set_test();
 (10 rows)
 
 --
--- Updating multiple fieds
+-- Updating multiple fields
 --
 SELECT * FROM cypher('cypher_set', $$MATCH (n) SET n.i = 3, n.j = 5 RETURN n $$) AS (a agtype);
                                                          a                                                         
@@ -768,7 +768,7 @@ $$) AS (p agtype);
  {"id": 1970324836974593, "label": "Juan", "properties": {}}::vertex
 (1 row)
 
--- test assigning non-map to an enitity
+-- test assigning non-map to an entity
 SELECT * FROM cypher('cypher_set_1', $$
     MATCH (p {name: 'Peter'})
     SET p = "Peter"

--- a/regress/expected/expr.out
+++ b/regress/expected/expr.out
@@ -1147,7 +1147,7 @@ $$) AS r(result agtype);
 (3 rows)
 
 --
---Coearce to Postgres 3 int types (smallint, int, bigint)
+--Coerce to Postgres 3 int types (smallint, int, bigint)
 --
 SELECT create_graph('type_coercion');
 NOTICE:  graph "type_coercion" has been created
@@ -1441,9 +1441,9 @@ RETURN ''::int
 $$) AS r(result agtype);
 ERROR:  invalid input syntax for integer: ""
 SELECT * FROM cypher('expr', $$
-RETURN 'falze'::int
+RETURN 'false_'::int
 $$) AS r(result agtype);
-ERROR:  invalid input syntax for integer: "falze"
+ERROR:  invalid input syntax for integer: "false_"
 --
 -- Test from an agtype value to agtype int
 --
@@ -1465,7 +1465,7 @@ RETURN ''::bool
 $$) AS r(result agtype);
 ERROR:  typecast expression must be an integer or a boolean
 SELECT * FROM cypher('expr', $$
-RETURN 'falze'::bool
+RETURN 'false_'::bool
 $$) AS r(result agtype);
 ERROR:  typecast expression must be an integer or a boolean
 -- Test from an agtype value to an agtype numeric
@@ -2791,7 +2791,7 @@ $$) AS (toBoolean agtype);
 
 -- should return null
 SELECT * FROM cypher('expr', $$
-    RETURN toBoolean("falze")
+    RETURN toBoolean("false_")
 $$) AS (toBoolean agtype);
  toboolean 
 -----------
@@ -2861,7 +2861,7 @@ $$) AS (toFloat agtype);
 
 -- should return null
 SELECT * FROM cypher('expr', $$
-    RETURN toFloat("falze")
+    RETURN toFloat("false_")
 $$) AS (toFloat agtype);
  tofloat 
 ---------
@@ -2931,7 +2931,7 @@ $$) AS (toInteger agtype);
 
 -- should return null
 SELECT * FROM cypher('expr', $$
-    RETURN toInteger("falze")
+    RETURN toInteger("false_")
 $$) AS (toInteger agtype);
  tointeger 
 -----------
@@ -5679,7 +5679,7 @@ SELECT * FROM cypher('UCSC', $$ RETURN collect(5) $$) AS (result agtype);
  [5]
 (1 row)
 
--- should return an empty aray
+-- should return an empty array
 SELECT * FROM cypher('UCSC', $$ RETURN collect(NULL) $$) AS (empty agtype);
  empty 
 -------

--- a/regress/expected/index.out
+++ b/regress/expected/index.out
@@ -254,7 +254,7 @@ SELECT * FROM cypher('cypher_index', $$
         (us)<-[:has_city]-(:City {city_id: 3, name:"Los Angeles", west_coast: true, country_code:"US"}),
         (us)<-[:has_city]-(:City {city_id: 4, name:"Seattle", west_coast: true, country_code:"US"}),
         (ca)<-[:has_city]-(:City {city_id: 5, name:"Vancouver", west_coast: true, country_code:"CA"}),
-        (ca)<-[:has_city]-(:City {city_id: 6, name:"Toroto", west_coast: false, country_code:"CA"}),
+        (ca)<-[:has_city]-(:City {city_id: 6, name:"Toronto", west_coast: false, country_code:"CA"}),
         (ca)<-[:has_city]-(:City {city_id: 7, name:"Montreal", west_coast: false, country_code:"CA"}),
         (mx)<-[:has_city]-(:City {city_id: 8, name:"Mexico City", west_coast: false, country_code:"MX"}),
         (mx)<-[:has_city]-(:City {city_id: 9, name:"Monterrey", west_coast: false, country_code:"MX"}),

--- a/regress/sql/age_global_graph.sql
+++ b/regress/sql/age_global_graph.sql
@@ -37,7 +37,7 @@ SELECT * FROM cypher('ag_graph_2', $$ RETURN delete_global_graphs('ag_graph_2') 
 SELECT * FROM cypher('ag_graph_1', $$ RETURN delete_global_graphs('ag_graph_1') $$) AS (result agtype);
 
 -- delete ag_graph_3's context
--- should return true(succeed) beacuse the previous commands should not delete the 3rd graph's context
+-- should return true(succeed) because the previous commands should not delete the 3rd graph's context
 SELECT * FROM cypher('ag_graph_3', $$ RETURN delete_global_graphs('ag_graph_3') $$) AS (result agtype);
 
 -- delete all graphs' context again
@@ -46,7 +46,7 @@ SELECT * FROM cypher('ag_graph_2', $$ RETURN delete_global_graphs('ag_graph_2') 
 SELECT * FROM cypher('ag_graph_1', $$ RETURN delete_global_graphs('ag_graph_1') $$) AS (result agtype);
 SELECT * FROM cypher('ag_graph_3', $$ RETURN delete_global_graphs('ag_graph_3') $$) AS (result agtype);
 
---- delete unitialized graph context
+--- delete uninitialized graph context
 --- should throw exception graph "ag_graph_4" does not exist
 SELECT * FROM cypher('ag_graph_4', $$ RETURN delete_global_graphs('ag_graph_4') $$) AS (result agtype);
 

--- a/regress/sql/cypher_call.sql
+++ b/regress/sql/cypher_call.sql
@@ -49,7 +49,7 @@ SELECT * FROM cypher('cypher_call', $$CALL sqrt(64) YIELD squirt$$) as (sqrt agt
 
 /* qualified name */
 SELECT * FROM cypher('cypher_call', $$CALL call_stmt_test.add_agtype(1,2)$$) as (sqrt agtype);
-/* non-existent schema should fail */
+/* nonexistent schema should fail */
 SELECT * FROM cypher('cypher_call', $$CALL ag_catalog.add_agtype(1,2)$$) as (sqrt agtype);
 
 /* CALL YIELD WHERE, should fail */

--- a/regress/sql/cypher_delete.sql
+++ b/regress/sql/cypher_delete.sql
@@ -43,18 +43,18 @@ SELECT * FROM cypher('cypher_delete', $$MATCH()-[e]->() DELETE e RETURN e$$) AS 
 --Cleanup
 SELECT * FROM cypher('cypher_delete', $$MATCH(n) DELETE n RETURN n$$) AS (a agtype);
 
---Test 4: DETACH DELECT a vertex
+--Test 4: DETACH DELETE a vertex
 SELECT * FROM cypher('cypher_delete', $$CREATE (:v)-[:e]->(:v)$$) AS (a agtype);
 SELECT * FROM cypher('cypher_delete', $$MATCH(n1)-[e]->(n2) DETACH DELETE n1 RETURN e$$) AS (a agtype);
 
 --Cleanup
 SELECT * FROM cypher('cypher_delete', $$MATCH(n) RETURN n$$) AS (a agtype);
 
---Test 4: DETACH DELECT two vertices tied to the same edge
+--Test 4: DETACH DELETE two vertices tied to the same edge
 SELECT * FROM cypher('cypher_delete', $$CREATE (:v)-[:e]->(:v)$$) AS (a agtype);
 SELECT * FROM cypher('cypher_delete', $$MATCH(n1)-[e]->(n2) DETACH DELETE n1, n2 RETURN e$$) AS (a agtype);
 
---Test 4: DETACH DELECT a vertex
+--Test 4: DETACH DELETE a vertex
 SELECT * FROM cypher('cypher_delete', $$CREATE (:v)-[:e]->(:v)$$) AS (a agtype);
 SELECT * FROM cypher('cypher_delete', $$MATCH(n1)-[e]->(n2) DETACH DELETE n1, n2 RETURN e$$) AS (a agtype);
 

--- a/regress/sql/cypher_merge.sql
+++ b/regress/sql/cypher_merge.sql
@@ -80,7 +80,7 @@ SELECT * FROM cypher('cypher_merge', $$MATCH (n) RETURN n$$) AS (n agtype);
 SELECT * FROM cypher('cypher_merge', $$MATCH (n) DETACH DELETE n $$) AS (a agtype);
 
 /*
- * test 5: Prev clause has results, path does not exist (differnt property name)
+ * test 5: Prev clause has results, path does not exist (different property name)
  */
 --data setup
 SELECT * FROM cypher('cypher_merge', $$CREATE ({i: "Hello Merge"}) $$) AS (a agtype);
@@ -216,7 +216,7 @@ SELECT count(*) FROM cypher('cypher_merge', $$MATCH (n) RETURN n$$) AS (n agtype
 SELECT * FROM cypher('cypher_merge', $$MATCH (n) DETACH DELETE n $$) AS (a agtype);
 
 /*
- * test 13: edge doesn't exists (differnt label), using MATCH
+ * test 13: edge doesn't exists (different label), using MATCH
  */
 -- setup
 SELECT * FROM cypher('cypher_merge', $$CREATE ()-[:e]->() $$) AS (a agtype);

--- a/regress/sql/cypher_set.sql
+++ b/regress/sql/cypher_set.sql
@@ -126,7 +126,7 @@ SELECT set_test();
 SELECT set_test();
 
 --
--- Updating multiple fieds
+-- Updating multiple fields
 --
 SELECT * FROM cypher('cypher_set', $$MATCH (n) SET n.i = 3, n.j = 5 RETURN n $$) AS (a agtype);
 
@@ -247,7 +247,7 @@ SELECT * FROM cypher('cypher_set_1', $$
     RETURN p
 $$) AS (p agtype);
 
--- test assigning non-map to an enitity
+-- test assigning non-map to an entity
 SELECT * FROM cypher('cypher_set_1', $$
     MATCH (p {name: 'Peter'})
     SET p = "Peter"

--- a/regress/sql/expr.sql
+++ b/regress/sql/expr.sql
@@ -543,7 +543,7 @@ MATCH (n:Person) WHERE n.name =~ 'J.*' RETURN n
 $$) AS r(result agtype);
 
 --
---Coearce to Postgres 3 int types (smallint, int, bigint)
+--Coerce to Postgres 3 int types (smallint, int, bigint)
 --
 SELECT create_graph('type_coercion');
 SELECT * FROM cypher('type_coercion', $$
@@ -698,7 +698,7 @@ SELECT * FROM cypher('expr', $$
 RETURN ''::int
 $$) AS r(result agtype);
 SELECT * FROM cypher('expr', $$
-RETURN 'falze'::int
+RETURN 'false_'::int
 $$) AS r(result agtype);
 --
 -- Test from an agtype value to agtype int
@@ -715,7 +715,7 @@ SELECT * FROM cypher('expr', $$
 RETURN ''::bool
 $$) AS r(result agtype);
 SELECT * FROM cypher('expr', $$
-RETURN 'falze'::bool
+RETURN 'false_'::bool
 $$) AS r(result agtype);
 -- Test from an agtype value to an agtype numeric
 --
@@ -1256,7 +1256,7 @@ SELECT * FROM cypher('expr', $$
 $$) AS (toBoolean agtype);
 -- should return null
 SELECT * FROM cypher('expr', $$
-    RETURN toBoolean("falze")
+    RETURN toBoolean("false_")
 $$) AS (toBoolean agtype);
 SELECT * FROM cypher('expr', $$
     RETURN toBoolean(null)
@@ -1286,7 +1286,7 @@ SELECT * FROM cypher('expr', $$
 $$) AS (toFloat agtype);
 -- should return null
 SELECT * FROM cypher('expr', $$
-    RETURN toFloat("falze")
+    RETURN toFloat("false_")
 $$) AS (toFloat agtype);
 SELECT * FROM cypher('expr', $$
     RETURN toFloat(null)
@@ -1316,7 +1316,7 @@ SELECT * FROM cypher('expr', $$
 $$) AS (toInteger agtype);
 -- should return null
 SELECT * FROM cypher('expr', $$
-    RETURN toInteger("falze")
+    RETURN toInteger("false_")
 $$) AS (toInteger agtype);
 SELECT * FROM cypher('expr', $$
     RETURN toInteger(null)
@@ -2385,7 +2385,7 @@ AS (gpa1 agtype, gpa2 agtype);
 SELECT * FROM cypher('UCSC', $$ MATCH (u) RETURN collect(u.zip), collect(u.zip) $$)
 AS (zip1 agtype, zip2 agtype);
 SELECT * FROM cypher('UCSC', $$ RETURN collect(5) $$) AS (result agtype);
--- should return an empty aray
+-- should return an empty array
 SELECT * FROM cypher('UCSC', $$ RETURN collect(NULL) $$) AS (empty agtype);
 SELECT * FROM cypher('UCSC', $$ MATCH (u) WHERE u.name =~ "doesn't exist" RETURN collect(u.name) $$) AS (name agtype);
 

--- a/regress/sql/index.sql
+++ b/regress/sql/index.sql
@@ -159,7 +159,7 @@ SELECT * FROM cypher('cypher_index', $$
         (us)<-[:has_city]-(:City {city_id: 3, name:"Los Angeles", west_coast: true, country_code:"US"}),
         (us)<-[:has_city]-(:City {city_id: 4, name:"Seattle", west_coast: true, country_code:"US"}),
         (ca)<-[:has_city]-(:City {city_id: 5, name:"Vancouver", west_coast: true, country_code:"CA"}),
-        (ca)<-[:has_city]-(:City {city_id: 6, name:"Toroto", west_coast: false, country_code:"CA"}),
+        (ca)<-[:has_city]-(:City {city_id: 6, name:"Toronto", west_coast: false, country_code:"CA"}),
         (ca)<-[:has_city]-(:City {city_id: 7, name:"Montreal", west_coast: false, country_code:"CA"}),
         (mx)<-[:has_city]-(:City {city_id: 8, name:"Mexico City", west_coast: false, country_code:"MX"}),
         (mx)<-[:has_city]-(:City {city_id: 9, name:"Monterrey", west_coast: false, country_code:"MX"}),

--- a/src/backend/commands/label_commands.c
+++ b/src/backend/commands/label_commands.c
@@ -538,7 +538,7 @@ static FuncCall *build_id_default_func_expr(char *graph_name, char *label_name,
     nextval_func = makeFuncCall(nextval_func_name, nextval_func_args, -1);
 
     /*
-     * Build a node that contructs the graphid from the label id function
+     * Build a node that constructs the graphid from the label id function
      * and the next val function for the given sequence.
      */
     graphid_func_name = list_make2(makeString("ag_catalog"),
@@ -805,7 +805,7 @@ static void remove_relation(List *qname)
                                 rel->schemaname, rel->relname)));
     }
 
-    // concurent is false
+    // concurrent is false
 
     ObjectAddressSet(address, RelationRelationId, rel_oid);
 

--- a/src/backend/executor/cypher_create.c
+++ b/src/backend/executor/cypher_create.c
@@ -283,7 +283,7 @@ static void end_cypher_create(CustomScanState *node)
 static void rescan_cypher_create(CustomScanState *node)
 {
     ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-                    errmsg("cypher create clause cannot be rescaned"),
+                    errmsg("cypher create clause cannot be rescanned"),
                     errhint("its unsafe to use joins in a query with a Cypher CREATE clause")));
 }
 

--- a/src/backend/executor/cypher_delete.c
+++ b/src/backend/executor/cypher_delete.c
@@ -212,7 +212,7 @@ static void rescan_cypher_delete(CustomScanState *node)
 {
      ereport(ERROR,
              (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-                      errmsg("cypher DELETE clause cannot be rescaned"),
+                      errmsg("cypher DELETE clause cannot be rescanned"),
                       errhint("its unsafe to use joins in a query with a Cypher DELETE clause")));
 }
 
@@ -484,7 +484,7 @@ static void find_connected_edges(CustomScanState *node, char *graph_name,
      * any edges attached to it.
      *
      * XXX: If we implement an on-disc graph storage system. Such as
-     * an adjacency matrix, the performace of this check can be massively
+     * an adjacency matrix, the performance of this check can be massively
      * improved. However, right now we have to scan every edge to see if
      * one has this vertex as a start or end vertex.
      */

--- a/src/backend/executor/cypher_merge.c
+++ b/src/backend/executor/cypher_merge.c
@@ -64,7 +64,7 @@ const CustomExecMethods cypher_merge_exec_methods = {MERGE_SCAN_STATE_NAME,
                                                      NULL, NULL, NULL, NULL};
 
 /*
- * Initializes the MERGE Execution Node at the begginning of the execution
+ * Initializes the MERGE Execution Node at the beginning of the execution
  * phase.
  */
 static void begin_cypher_merge(CustomScanState *node, EState *estate,
@@ -306,7 +306,7 @@ static void mark_tts_isnull(TupleTableSlot *slot)
 /*
  * Function that is called mid-execution. This function will call
  * its subtree in the execution tree, and depending on the results
- * create the new path, and depending on the the context of the MERGE
+ * create the new path, and depending on the context of the MERGE
  * within the query pass data to the parent execution node.
  *
  * Returns a TupleTableSlot with the next tuple to it parent or
@@ -490,7 +490,7 @@ static TupleTableSlot *exec_cypher_merge(CustomScanState *node)
             Assert(css->found_a_path == false);
 
             /*
-             * This block of sub-case 1 should only be executued once. To
+             * This block of sub-case 1 should only be executed once. To
              * create the single path if the path does not exist. If we find
              * ourselves here again, the internal state of the MERGE execution
              * node was incorrectly altered.
@@ -593,7 +593,7 @@ static void rescan_cypher_merge(CustomScanState *node)
 {
     ereport(ERROR,
             (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-                     errmsg("cypher merge clause cannot be rescaned"),
+                     errmsg("cypher merge clause cannot be rescanned"),
                      errhint("its unsafe to use joins in a query with a Cypher MERGE clause")));
 }
 

--- a/src/backend/executor/cypher_set.c
+++ b/src/backend/executor/cypher_set.c
@@ -633,7 +633,7 @@ static void rescan_cypher_set(CustomScanState *node)
 
      ereport(ERROR,
              (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-                      errmsg("cypher %s clause cannot be rescaned",
+                      errmsg("cypher %s clause cannot be rescanned",
                              clause_name),
                       errhint("its unsafe to use joins in a query with a Cypher %s clause", clause_name)));
 }

--- a/src/backend/nodes/cypher_readfuncs.c
+++ b/src/backend/nodes/cypher_readfuncs.c
@@ -36,11 +36,11 @@
         int  length;
 
 /*
- * The READ_*_FIELD defines first skips the :fildname token (key) part of the string
+ * The READ_*_FIELD defines first skips the :fldname token (key) part of the string
  * and then converts the next token (value) to the correct data type.
  *
  * pg_strtok will split the passed string by whitespace, skipping whitespace in
- * strings. We do not setup pg_strtok. That is for the the caller to do. By default
+ * strings. We do not setup pg_strtok. That is for the caller to do. By default
  * that is the responsibility of Postgres' nodeRead function. We assume that was setup
  * correctly.
  */

--- a/src/backend/optimizer/cypher_paths.c
+++ b/src/backend/optimizer/cypher_paths.c
@@ -148,7 +148,7 @@ static void handle_cypher_delete_clause(PlannerInfo *root, RelOptInfo *rel,
 
     cp = create_cypher_delete_path(root, rel, custom_private);
 
-    // Discard any pre-existing paths
+    // Discard any preexisting paths
     rel->pathlist = NIL;
     rel->partial_pathlist = NIL;
 
@@ -176,7 +176,7 @@ static void handle_cypher_create_clause(PlannerInfo *root, RelOptInfo *rel,
 
     cp = create_cypher_create_path(root, rel, custom_private);
 
-    // Discard any pre-existing paths, they should be under the cp path
+    // Discard any preexisting paths, they should be under the cp path
     rel->pathlist = NIL;
     rel->partial_pathlist = NIL;
 
@@ -201,7 +201,7 @@ static void handle_cypher_set_clause(PlannerInfo *root, RelOptInfo *rel,
 
     cp = create_cypher_set_path(root, rel, custom_private);
 
-    // Discard any pre-existing paths
+    // Discard any preexisting paths
     rel->pathlist = NIL;
     rel->partial_pathlist = NIL;
 
@@ -225,7 +225,7 @@ static void handle_cypher_merge_clause(PlannerInfo *root, RelOptInfo *rel,
 
     cp = create_cypher_merge_path(root, rel, custom_private);
 
-    // Discard any pre-existing paths
+    // Discard any preexisting paths
     rel->pathlist = NIL;
     rel->partial_pathlist = NIL;
 

--- a/src/backend/parser/cypher_clause.c
+++ b/src/backend/parser/cypher_clause.c
@@ -801,7 +801,7 @@ transform_cypher_union_tree(cypher_parsestate *cpstate, cypher_clause *clause,
 
         /*
          * If we find ourselves processing a recursive CTE here something
-         * went horribly wrong. That is an SQL contruct with no parallel in
+         * went horribly wrong. That is an SQL construct with no parallel in
          * cypher.
          */
         if (isTopLevel &&
@@ -1518,7 +1518,7 @@ cypher_update_information *transform_cypher_remove_item_list(
         {
             ereport(ERROR,
                     (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-                     errmsg("REMOVE clause does not support adding propereties from maps"),
+                     errmsg("REMOVE clause does not support adding properties from maps"),
                      parser_errposition(pstate, set_item->location)));
         }
         set_item->is_add = false;
@@ -2950,7 +2950,7 @@ static void transform_match_pattern(cypher_parsestate *cpstate, Query *query,
         {
             /*
              * coerce the WHERE clause to a boolean before AND with the property
-             * contraints, otherwise there could be evaluation issues.
+             * constraints, otherwise there could be evaluation issues.
              */
             where_qual = (Expr *)coerce_to_boolean(pstate, (Node *)where_qual,
                                                    "WHERE");
@@ -3130,7 +3130,7 @@ static List *make_join_condition_for_edge(cypher_parsestate *cpstate,
          * When the previous node is not in the join tree, but there is a vle
          * edge before that join, then we need to compare this vle's start node
          * against the previous vle's end node. No need to check the next edge,
-         * because that would be redundent.
+         * because that would be redundant.
          */
         if (!prev_node->in_join_tree &&
             prev_edge != NULL &&
@@ -3489,9 +3489,9 @@ static A_Expr *filter_vertices_on_label_id(cypher_parsestate *cpstate,
 }
 
 /*
- * Creates the Contains operator to process property contraints for a vertex/
+ * Creates the Contains operator to process property constraints for a vertex/
  * edge in a MATCH clause. creates the agtype @> with the entity's properties
- * on the right and the contraints in the MATCH clause on the left.
+ * on the right and the constraints in the MATCH clause on the left.
  */
 static Node *create_property_constraints(cypher_parsestate *cpstate,
                                          transform_entity *entity,
@@ -3817,8 +3817,8 @@ static List *transform_match_entities(cypher_parsestate *cpstate, Query *query,
                                            expr);
 
             /*
-             * We want to add tranformed entity to entities before tranforming props
-             * so that props referncing currently transformed entity can be resolved.
+             * We want to add transformed entity to entities before transforming props
+             * so that props referencing currently transformed entity can be resolved.
              */
             cpstate->entities = lappend(cpstate->entities, entity);
             entities = lappend(entities, entity);
@@ -3937,8 +3937,8 @@ static List *transform_match_entities(cypher_parsestate *cpstate, Query *query,
                                                expr);
 
                 /*
-                 * We want to add tranformed entity to entities before tranforming props
-                 * so that props referncing currently transformed entity can be resolved.
+                 * We want to add transformed entity to entities before transforming props
+                 * so that props referencing currently transformed entity can be resolved.
                  */
                 cpstate->entities = lappend(cpstate->entities, entity);
                 entities = lappend(entities, entity);
@@ -4016,7 +4016,7 @@ static List *transform_match_entities(cypher_parsestate *cpstate, Query *query,
 
                 /*
                  * Check to see if the previous node was originally created
-                 * in a predecessing clause. If it was, then remove the id field
+                 * in a preceding clause. If it was, then remove the id field
                  * from the column ref. Just reference the agtype vertex
                  * variable that the prev clause created and the vle will handle
                  * extracting the id.
@@ -5618,7 +5618,7 @@ static TargetEntry *findTarget(List *targetList, char *resname)
 
 /*
  * Wrap the expression with a volatile function, to prevent the optimizer from
- * elimating the expression.
+ * eliminating the expression.
  */
 static Expr *add_volatile_wrapper(Expr *node)
 {
@@ -5704,7 +5704,7 @@ Query *cypher_parse_sub_analyze(Node *parseTree,
  * The second query will be for the path that this MERGE clause defines. The
  * two subqueries will be joined together using a LATERAL LEFT JOIN with the
  * previous query on the left and the MERGE path subquery on the right. Like
- * case 1 the targetList will have all the decalred variables and a FuncExpr
+ * case 1 the targetList will have all the declared variables and a FuncExpr
  * that represents the MERGE clause with its needed metadata information, that
  * will be caught in the planner phase and converted into a path.
  *

--- a/src/backend/parser/cypher_expr.c
+++ b/src/backend/parser/cypher_expr.c
@@ -153,15 +153,15 @@ static Node *transform_cypher_expr_recurse(cypher_parsestate *cpstate,
     case T_NullTest:
     {
         NullTest *n = (NullTest *)expr;
-        NullTest *tranformed_expr = makeNode(NullTest);
+        NullTest *transformed_expr = makeNode(NullTest);
 
-        tranformed_expr->arg = (Expr *)transform_cypher_expr_recurse(cpstate,
+        transformed_expr->arg = (Expr *)transform_cypher_expr_recurse(cpstate,
                                                          (Node *)n->arg);
-        tranformed_expr->nulltesttype = n->nulltesttype;
-        tranformed_expr->argisrow = type_is_rowtype(exprType((Node *)tranformed_expr->arg));
-        tranformed_expr->location = n->location;
+        transformed_expr->nulltesttype = n->nulltesttype;
+        transformed_expr->argisrow = type_is_rowtype(exprType((Node *)transformed_expr->arg));
+        transformed_expr->location = n->location;
 
-        return (Node *) tranformed_expr;
+        return (Node *) transformed_expr;
     }
     case T_CaseExpr:
         return transform_CaseExpr(cpstate, (CaseExpr *) expr);

--- a/src/backend/parser/cypher_gram.y
+++ b/src/backend/parser/cypher_gram.y
@@ -1443,7 +1443,7 @@ expr:
         }
     /*
      * This is a catch all grammar rule that allows us to avoid some
-     * shift/reduce errors between expression indirection rules by colapsing
+     * shift/reduce errors between expression indirection rules by collapsing
      * those rules into one generic rule. We can then inspect the expressions to
      * decide what specific rule needs to be applied and then construct the
      * required result.
@@ -2198,7 +2198,7 @@ static char *create_unique_name(char *prefix_name)
         prefix = prefix_name;
     }
 
-    /* get the length of the combinded string */
+    /* get the length of the combined string */
     nlen = snprintf(NULL, 0, "%s_%lu", prefix, unique_number);
 
     /* allocate the space */

--- a/src/backend/parser/cypher_parse_node.c
+++ b/src/backend/parser/cypher_parse_node.c
@@ -138,7 +138,7 @@ char *get_next_default_alias(cypher_parsestate *cpstate)
 
     /*
      * Every clause transformed as a subquery has its own cpstate which is being
-     * freed after it is tranformed. The root cpstate is the one that has the
+     * freed after it is transformed. The root cpstate is the one that has the
      * default alias number initialized. So we need to reach the root cpstate to
      * get the next correct default alias number.
      */
@@ -147,7 +147,7 @@ char *get_next_default_alias(cypher_parsestate *cpstate)
         return get_next_default_alias(parent_cpstate);
     }
 
-    /* get the length of the combinded string */
+    /* get the length of the combined string */
     nlen = snprintf(NULL, 0, "%s%d", AGE_DEFAULT_ALIAS_PREFIX,
                     cpstate->default_alias_num);
 

--- a/src/backend/parser/cypher_parser.c
+++ b/src/backend/parser/cypher_parser.c
@@ -145,7 +145,7 @@ List *parse_cypher(const char *s)
         return NIL;
 
     /*
-     * Append the extra node node regardless of its value. Currently the extra
+     * Append the extra node regardless of its value. Currently the extra
      * node is only used by EXPLAIN
     */
     return lappend(extra.result, extra.extra);

--- a/src/backend/utils/adt/age_global_graph.c
+++ b/src/backend/utils/adt/age_global_graph.c
@@ -41,7 +41,7 @@
 
 /* internal data structures implementation */
 
-/* vertex entry for the vertex_hastable */
+/* vertex entry for the vertex_hashtable */
 typedef struct vertex_entry
 {
     graphid vertex_id;             /* vertex id, it is also the hash key */
@@ -110,7 +110,7 @@ static bool insert_vertex_entry(GRAPH_global_context *ggctx, graphid vertex_id,
 
 /*
  * Helper function to determine validity of the passed GRAPH_global_context.
- * This is based off of the current active snaphot, to see if the graph could
+ * This is based off of the current active snapshot, to see if the graph could
  * have been modified. Ideally, we should find a way to more accurately know
  * whether the particular graph was modified.
  */

--- a/src/backend/utils/adt/age_vle.c
+++ b/src/backend/utils/adt/age_vle.c
@@ -164,7 +164,7 @@ static VLE_local_context *get_cached_VLE_local_context(int64 vle_grammar_node_id
 
             /*
              * Clear (unlink) the previous context's next pointer, if needed.
-             * Also clear prev as we are at the end of avaiable cached contexts
+             * Also clear prev as we are at the end of available cached contexts
              * and just purging them off. Remember, this forms a loop that will
              * exit the while after purging.
              */
@@ -421,7 +421,7 @@ static void free_VLE_local_context(VLE_local_context *vlelctx)
     /*
      * We need to free the contents of our stacks if the context is not dirty.
      * These stacks are created in a more volatile memory context. If the
-     * process was interupted, they will be garbage collected by PG. The only
+     * process was interrupted, they will be garbage collected by PG. The only
      * time we will ever clean them here is if the cache isn't being used.
      */
     if (vlelctx->is_dirty == false)

--- a/src/backend/utils/adt/agtype.c
+++ b/src/backend/utils/adt/agtype.c
@@ -3934,7 +3934,7 @@ Datum agtype_hash_cmp(PG_FUNCTION_ARGS)
     PG_RETURN_INT16(hash);
 }
 
-// Comparision function for btree Indexes
+// Comparison function for btree Indexes
 PG_FUNCTION_INFO_V1(agtype_btree_cmp);
 
 Datum agtype_btree_cmp(PG_FUNCTION_ARGS)
@@ -8598,10 +8598,10 @@ agtype_value *alter_property_value(agtype_value *properties, char *var_name,
             tok = agtype_iterator_next(&it, r, true);
 
             /*
-             * If the the new agtype is scalar, push the agtype_value to the
+             * If the new agtype is scalar, push the agtype_value to the
              * parse state. If the agtype is an object or array convert the
              * agtype to a binary agtype_value to pass to the parse_state.
-             * This will save uncessary deserialization and serialization
+             * This will save unnecessary deserialization and serialization
              * logic from running.
              */
             if (AGTYPE_CONTAINER_IS_SCALAR(&new_v->root))
@@ -8636,10 +8636,10 @@ agtype_value *alter_property_value(agtype_value *properties, char *var_name,
             &parse_state, WAGT_KEY, key);
 
         /*
-         * If the the new agtype is scalar, push the agtype_value to the
+         * If the new agtype is scalar, push the agtype_value to the
          * parse state. If the agtype is an object or array convert the
          * agtype to a binary agtype_value to pass to the parse_state.
-         * This will save uncessary deserialization and serialization
+         * This will save unnecessary deserialization and serialization
          * logic from running.
          */
         if (AGTYPE_CONTAINER_IS_SCALAR(&new_v->root))

--- a/src/backend/utils/adt/agtype_util.c
+++ b/src/backend/utils/adt/agtype_util.c
@@ -192,7 +192,7 @@ uint32 get_agtype_length(const agtype_container *agtc, int index)
 }
 
 /*
- * Helper function to generate the sort priorty of a type. Larger
+ * Helper function to generate the sort priority of a type. Larger
  * numbers have higher priority.
  */
 static int get_type_sort_priority(enum agtype_value_type type)

--- a/src/backend/utils/graph_generation.c
+++ b/src/backend/utils/graph_generation.c
@@ -239,7 +239,7 @@ PG_FUNCTION_INFO_V1(age_create_barbell_graph);
  *                                     n int, 
  *                                     vertex_label_name Name DEFAULT = NULL,
  *                                     vertex_properties agtype DEFAULT = NULL,
- *                                     edge_label_name Name DEAULT = NULL,
+ *                                     edge_label_name Name DEFAULT = NULL,
  *                                     edge_properties agtype DEFAULT = NULL)
  * Input:
  * 

--- a/src/include/nodes/cypher_readfuncs.h
+++ b/src/include/nodes/cypher_readfuncs.h
@@ -32,7 +32,7 @@
 
  *
  * All functions are dependent on the pg_strtok function. We do not
- * setup pg_strtok. That is for the the caller to do. By default that
+ * setup pg_strtok. That is for the caller to do. By default that
  * is the responsibility of Postgres' nodeRead function. We assume
  * that was setup correctly.
  */

--- a/src/include/utils/age_global_graph.h
+++ b/src/include/utils/age_global_graph.h
@@ -29,7 +29,7 @@
  * age_global_graph.c
  */
 
-/* vertex entry for the vertex_hastable */
+/* vertex entry for the vertex_hashtable */
 typedef struct vertex_entry vertex_entry;
 
 /* edge entry for the edge_hashtable */


### PR DESCRIPTION
This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

The misspellings have been reported at https://github.com/jsoref/age/actions/runs/5251076994#summary-14208871240

The action reports that the changes in this PR would make it happy: https://github.com/jsoref/age/actions/runs/5251077113#summary-14208871486