### PR TITLE
Fix issue #945 unaliased match clause giving incorrect results in count

### DIFF
--- a/regress/expected/cypher_match.out
+++ b/regress/expected/cypher_match.out
@@ -2120,6 +2120,43 @@ SELECT * FROM cypher('cypher_match', $$MATCH ({n0:0}) MATCH ()-[]->() MATCH ({n1
 (0 rows)
 
 --
+-- issue#945 : un-aliased match clauses should be included in output node
+--
+SELECT * from cypher('cypher_match', $$ CREATE (a:label1 {id: '1'}), (b:label1 {id: '2'})$$) as (a agtype);
+ a 
+---
+(0 rows)
+
+SELECT * from cypher('cypher_match', $$ CREATE (a:label2 {id: '1'}), (b:label2 {id: '2'})$$) as (a agtype);
+ a 
+---
+(0 rows)
+
+SELECT * from cypher('cypher_match', $$ MATCH (:label1) RETURN count(*) $$) as (result agtype);
+ result 
+--------
+ 2
+(1 row)
+
+SELECT * from cypher('cypher_match', $$ MATCH (:label1),(:label2) RETURN count(*) $$) as (result agtype);
+ result 
+--------
+ 4
+(1 row)
+
+SELECT * from cypher('cypher_match', $$ MATCH (a:label1),(:label2) RETURN count(*) $$) as (result agtype);
+ result 
+--------
+ 4
+(1 row)
+
+SELECT * from cypher('cypher_match', $$ MATCH (:label1),(a:label2) RETURN count(*) $$) as (result agtype);
+ result 
+--------
+ 4
+(1 row)
+
+--
 -- self referencing property constraints (issue #898)
 --
 SELECT * FROM cypher('cypher_match', $$ MATCH (a {name:a.name}) RETURN a $$) as (a agtype);
@@ -2178,7 +2215,7 @@ SELECT * FROM cypher('cypher_match', $$ CREATE () WITH * MATCH (x{n0:x.n1}) RETU
 -- Clean up
 --
 SELECT drop_graph('cypher_match', true);
-NOTICE:  drop cascades to 17 other objects
+NOTICE:  drop cascades to 19 other objects
 DETAIL:  drop cascades to table cypher_match._ag_label_vertex
 drop cascades to table cypher_match._ag_label_edge
 drop cascades to table cypher_match.v
@@ -2196,6 +2233,8 @@ drop cascades to table cypher_match.other_v
 drop cascades to table cypher_match.opt_match_v
 drop cascades to table cypher_match.opt_match_e
 drop cascades to table cypher_match.knows
+drop cascades to table cypher_match.label1
+drop cascades to table cypher_match.label2
 NOTICE:  graph "cypher_match" has been dropped
  drop_graph 
 ------------

--- a/regress/sql/cypher_match.sql
+++ b/regress/sql/cypher_match.sql
@@ -965,6 +965,17 @@ SELECT * FROM cypher('cypher_match', $$ MATCH ({name: "Dave"}) MATCH ({name: "Da
 SELECT * FROM cypher('cypher_match', $$MATCH ({n0:0}) MATCH ()-[]->() MATCH ({n1:0})-[]-() RETURN 0 AS n2$$) as (a agtype);
 
 --
+-- issue#945 : un-aliased match clauses should be included in output node
+--
+SELECT * from cypher('cypher_match', $$ CREATE (a:label1 {id: '1'}), (b:label1 {id: '2'})$$) as (a agtype);
+SELECT * from cypher('cypher_match', $$ CREATE (a:label2 {id: '1'}), (b:label2 {id: '2'})$$) as (a agtype);
+SELECT * from cypher('cypher_match', $$ MATCH (:label1) RETURN count(*) $$) as (result agtype);
+SELECT * from cypher('cypher_match', $$ MATCH (:label1),(:label2) RETURN count(*) $$) as (result agtype);
+SELECT * from cypher('cypher_match', $$ MATCH (a:label1),(:label2) RETURN count(*) $$) as (result agtype);
+SELECT * from cypher('cypher_match', $$ MATCH (:label1),(a:label2) RETURN count(*) $$) as (result agtype);
+
+
+--
 -- self referencing property constraints (issue #898)
 --
 SELECT * FROM cypher('cypher_match', $$ MATCH (a {name:a.name}) RETURN a $$) as (a agtype);

--- a/src/backend/parser/cypher_clause.c
+++ b/src/backend/parser/cypher_clause.c
@@ -91,9 +91,10 @@
  *      1. the node is in a path variable
  *      2. the node is a variable
  *      3. the node contains filter properties
+ *      4. the node has a valid label
  */
 #define INCLUDE_NODE_IN_JOIN_TREE(path, node) \
-    (path->var_name || node->name || node->props)
+    (path->var_name || node->name || node->props || node->label )
 
 typedef Query *(*transform_method)(cypher_parsestate *cpstate,
                                    cypher_clause *clause);
@@ -3805,7 +3806,7 @@ static List *transform_match_entities(cypher_parsestate *cpstate, Query *query,
             }
 
             /* should we make the node available */
-            output_node = (special_VLE_case && !node->name && !node->props) ?
+            output_node = (special_VLE_case && !node->name && !node->props && !valid_label) ?
                           false :
                           INCLUDE_NODE_IN_JOIN_TREE(path, node);
 


### PR DESCRIPTION
unaliased match clause would give incorrect results in count because the node wasn't being added to the join tree. Fixed it by adding unaliased match clauses with valid label names to join tree.
- added entry for unaliased nodes with label names in macro 
- added regression test for proposed change  

resolves #945 