### PR TITLE
Fix issue 1043: ERROR:  container must be an array or object (#1046)

### DIFF
--- a/regress/expected/cypher_vle.out
+++ b/regress/expected/cypher_vle.out
@@ -1000,6 +1000,50 @@ NOTICE:  graph "access" has been dropped
  
 (1 row)
 
+-- issue 1043
+SELECT create_graph('issue_1043');
+NOTICE:  graph "issue_1043" has been created
+ create_graph 
+--------------
+ 
+(1 row)
+
+SELECT * FROM cypher('issue_1043', $$ CREATE (n)-[:KNOWS {n:'hello'}]->({n:'hello'}) $$) as (a agtype);
+ a 
+---
+(0 rows)
+
+SELECT * FROM cypher('issue_1043', $$ MATCH (x)<-[y *]-(),({n:y[0].n}) RETURN x $$) as (a agtype);
+                                     a                                      
+----------------------------------------------------------------------------
+ {"id": 281474976710658, "label": "", "properties": {"n": "hello"}}::vertex
+(1 row)
+
+SELECT * FROM cypher('issue_1043', $$ CREATE (n)-[:KNOWS {n:'hello'}]->({n:'hello'}) $$) as (a agtype);
+ a 
+---
+(0 rows)
+
+SELECT * FROM cypher('issue_1043', $$ MATCH (x)<-[y *]-(),({n:y[0].n}) RETURN x $$) as (a agtype);
+                                     a                                      
+----------------------------------------------------------------------------
+ {"id": 281474976710658, "label": "", "properties": {"n": "hello"}}::vertex
+ {"id": 281474976710658, "label": "", "properties": {"n": "hello"}}::vertex
+ {"id": 281474976710660, "label": "", "properties": {"n": "hello"}}::vertex
+ {"id": 281474976710660, "label": "", "properties": {"n": "hello"}}::vertex
+(4 rows)
+
+SELECT drop_graph('issue_1043', true);
+NOTICE:  drop cascades to 3 other objects
+DETAIL:  drop cascades to table issue_1043._ag_label_vertex
+drop cascades to table issue_1043._ag_label_edge
+drop cascades to table issue_1043."KNOWS"
+NOTICE:  graph "issue_1043" has been dropped
+ drop_graph 
+------------
+ 
+(1 row)
+
 --
 -- Clean up
 --

--- a/regress/sql/cypher_vle.sql
+++ b/regress/sql/cypher_vle.sql
@@ -330,6 +330,15 @@ SELECT * FROM cypher('access',$$ MATCH ()-[e*]->() RETURN e[0].arry[2], e[1].arr
 
 SELECT drop_graph('access', true);
 
+-- issue 1043
+SELECT create_graph('issue_1043');
+SELECT * FROM cypher('issue_1043', $$ CREATE (n)-[:KNOWS {n:'hello'}]->({n:'hello'}) $$) as (a agtype);
+SELECT * FROM cypher('issue_1043', $$ MATCH (x)<-[y *]-(),({n:y[0].n}) RETURN x $$) as (a agtype);
+SELECT * FROM cypher('issue_1043', $$ CREATE (n)-[:KNOWS {n:'hello'}]->({n:'hello'}) $$) as (a agtype);
+SELECT * FROM cypher('issue_1043', $$ MATCH (x)<-[y *]-(),({n:y[0].n}) RETURN x $$) as (a agtype);
+
+SELECT drop_graph('issue_1043', true);
+
 --
 -- Clean up
 --

--- a/src/backend/utils/adt/agtype.c
+++ b/src/backend/utils/adt/agtype.c
@@ -3473,8 +3473,25 @@ Datum agtype_access_operator(PG_FUNCTION_ARGS)
     /* get the container argument. It could be an object or array */
     container = DATUM_GET_AGTYPE_P(args[0]);
 
+    /* if it is a binary container, check for a VLE vpc */
+    if (AGT_ROOT_IS_BINARY(container))
+    {
+        if (AGT_ROOT_BINARY_FLAGS(container) == AGT_FBINARY_TYPE_VLE_PATH)
+        {
+            /* retrieve an array of edges from the vpc */
+            container_value = agtv_materialize_vle_edges(container);
+            /* clear the container reference */
+            container = NULL;
+        }
+        else
+        {
+            ereport(ERROR,
+                    (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                     errmsg("binary container must be a VLE vpc")));
+        }
+    }
     /* if it is a scalar, open it and pull out the value */
-    if (AGT_ROOT_IS_SCALAR(container))
+    else if (AGT_ROOT_IS_SCALAR(container))
     {
         container_value = get_ith_agtype_value_from_container(&container->root,
                                                               0);


### PR DESCRIPTION
Fixed issue 1043 -

ERROR:  container must be an array or object

This was cause by `agtype_access_operator` not recognizing and decoding a VLE path container.

Added regression tests.