### PR TITLE
Fix docker-entrypoint-initdb.d in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,0 @@
-docker/Dockerfile

--- a/docker-entrypoint-initdb.d
+++ b/docker-entrypoint-initdb.d
@@ -1,1 +1,0 @@
-docker-entrypoint-initdb.d

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,6 +28,6 @@ RUN apt-get install --assume-yes --no-install-recommends --no-install-suggests \
 COPY . /age
 RUN cd /age && make install
 
-COPY docker-entrypoint-initdb.d/00-create-extension-age.sql /docker-entrypoint-initdb.d/00-create-extension-age.sql
+COPY docker/docker-entrypoint-initdb.d/00-create-extension-age.sql /docker-entrypoint-initdb.d/00-create-extension-age.sql
 
 CMD ["postgres", "-c", "shared_preload_libraries=age"]


### PR DESCRIPTION
If the "Dockerfile location" in Docker Hub Automated Builds is set to "docker/Dockerifle" and the "Build Context" is set to "/" there is no need to create symlinks.