### PR TITLE
TEST PR for CI

### DIFF
--- a/.github/workflows/jdbc-driver.yaml
+++ b/.github/workflows/jdbc-driver.yaml
@@ -27,13 +27,13 @@ jobs:
       run: |
         if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
           if [[ "$GITHUB_REF" == "refs/heads/master" ]]; then
-            echo "TAG=latest" >> $GITHUB_ENV
+            echo "TAG=PG14_latest" >> $GITHUB_ENV
           elif [[ "$GITHUB_REF" == "refs/heads/PG14" ]]; then
             echo "TAG=PG14_latest" >> $GITHUB_ENV
           fi
         elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
           if [[ "$GITHUB_BASE_REF" == "master" ]]; then
-            echo "TAG=latest" >> $GITHUB_ENV
+            echo "TAG=PG14_latest" >> $GITHUB_ENV
           elif [[ "$GITHUB_BASE_REF" == "PG14" ]]; then
             echo "TAG=PG14_latest" >> $GITHUB_ENV
           fi

--- a/drivers/docker-compose.yml
+++ b/drivers/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
   db:
-    image: apache/age:${TAG}
+    image: apache/age:PG14_latest
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=agens


### PR DESCRIPTION
Temporary fix for the CI jobs. For some strange reason, the
DockerHub **latest** build is not working for CI connections. This
is a temporary patch to allow them to run correctly while we look
into the issue.