### PR TITLE
Added date() function to Cypher

### DIFF
--- a/age--1.4.0.sql
+++ b/age--1.4.0.sql
@@ -4397,6 +4397,14 @@ STABLE
 PARALLEL SAFE
 AS 'MODULE_PATHNAME';
 
+-- Date functions
+CREATE FUNCTION ag_catalog.age_date()
+RETURNS agtype
+LANGUAGE c
+STABLE
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
 --
 -- End
 --

--- a/regress/expected/expr.out
+++ b/regress/expected/expr.out
@@ -5666,6 +5666,45 @@ SELECT * from cypher('expr', $$
     RETURN sqrt("1")
 $$) as (result agtype);
 ERROR:  sqrt() unsupported argument agtype 1
+-- date()
+SELECT current_date = results::date FROM cypher('expr', $$
+    RETURN date()
+$$) AS (results text), current_date;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT current_date = TO_DATE(results, 'YYYY/MM/DD') FROM cypher('expr', $$
+    RETURN date()
+$$) AS (results text), current_date;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Should fail
+SELECT * FROM cypher('expr', $$
+    RETURN date('text')
+$$) as (today agtype);
+ERROR:  function ag_catalog.age_date(agtype) does not exist
+LINE 2:     RETURN date('text')
+                       ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT * FROM cypher('expr', $$
+    RETURN date(null)
+$$) as (today agtype);
+ERROR:  function ag_catalog.age_date(agtype) does not exist
+LINE 2:     RETURN date(null)
+                       ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT * FROM cypher('expr', $$
+    RETURN date(2)
+$$) as (today agtype);
+ERROR:  function ag_catalog.age_date(agtype) does not exist
+LINE 2:     RETURN date(2)
+                       ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 --
 -- user defined function expressions - using pg functions for these tests
 --

--- a/regress/sql/expr.sql
+++ b/regress/sql/expr.sql
@@ -2432,6 +2432,24 @@ SELECT * from cypher('expr', $$
     RETURN sqrt("1")
 $$) as (result agtype);
 
+-- date()
+SELECT current_date = results::date FROM cypher('expr', $$
+    RETURN date()
+$$) AS (results text), current_date;
+SELECT current_date = TO_DATE(results, 'YYYY/MM/DD') FROM cypher('expr', $$
+    RETURN date()
+$$) AS (results text), current_date;
+-- Should fail
+SELECT * FROM cypher('expr', $$
+    RETURN date('text')
+$$) as (today agtype);
+SELECT * FROM cypher('expr', $$
+    RETURN date(null)
+$$) as (today agtype);
+SELECT * FROM cypher('expr', $$
+    RETURN date(2)
+$$) as (today agtype);
+
 --
 -- user defined function expressions - using pg functions for these tests
 --

--- a/src/backend/utils/adt/agtype.c
+++ b/src/backend/utils/adt/agtype.c
@@ -4415,7 +4415,7 @@ Datum agtype_typecast_vertex(PG_FUNCTION_ARGS)
                  errmsg("typecast object is not a vertex")));
 
     /*
-     * The 3 key/value pairs need to DirectFunctionCall1each exist and their names need to match
+     * The 3 key/value pairs need to each exist and their names need to match
      * the names used for a vertex.
      */
     agtv_key.type = AGTV_STRING;

--- a/src/backend/utils/adt/agtype.c
+++ b/src/backend/utils/adt/agtype.c
@@ -53,6 +53,7 @@
 #include "parser/parse_coerce.h"
 #include "nodes/pg_list.h"
 #include "utils/builtins.h"
+#include "utils/datetime.h"
 #include "utils/float.h"
 #include "utils/fmgroids.h"
 #include "utils/lsyscache.h"
@@ -4414,7 +4415,7 @@ Datum agtype_typecast_vertex(PG_FUNCTION_ARGS)
                  errmsg("typecast object is not a vertex")));
 
     /*
-     * The 3 key/value pairs need to each exist and their names need to match
+     * The 3 key/value pairs need to DirectFunctionCall1each exist and their names need to match
      * the names used for a vertex.
      */
     agtv_key.type = AGTV_STRING;
@@ -11135,4 +11136,27 @@ Datum agtype_volatile_wrapper(PG_FUNCTION_ARGS)
 
     /* otherwise, just pass it through */
     PG_RETURN_POINTER(PG_GETARG_DATUM(0));
+}
+
+/*
+ * Temporal functions.
+ */
+
+PG_FUNCTION_INFO_V1(age_date);
+
+Datum age_date(PG_FUNCTION_ARGS)
+{
+    agtype_value agtv_result;
+    struct pg_tm tm;
+    char date[MAXDATELEN + 1];
+
+    GetCurrentDateTime(&tm);
+    EncodeDateOnly(&tm, USE_ISO_DATES, date);
+
+    // Build the result
+    agtv_result.type = AGTV_STRING;
+    agtv_result.val.string.len = strlen(date);
+    agtv_result.val.string.val = date;
+
+    PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }


### PR DESCRIPTION
I've begun implementing Cypher's temporal functions in AGE, beginning with [date()](https://neo4j.com/docs/cypher-manual/current/functions/temporal/#functions-date).

Here it is in action.
```sql
SELECT * FROM cypher('graph', $$
    RETURN date()
$$) as (today agtype);
    today     
--------------
 "2023-08-13"
(1 row)
```

It could also be converted to PostgreSQL's `date` type, but the record returned by AGE must first be converted to any of PostgreSQL's character types (`char`, `varchar`, or `text`).
```sql
SELECT TO_DATE(today, 'YYYY/MM/DD') FROM cypher('graph', $$
    RETURN date()
$$) as (today text);
--
-- or
--
SELECT today::date FROM cypher('graph', $$
    RETURN date()
$$) AS (today varchar(255));
```

### Limitations
Although the `date()` function in Cypher accepts an optional `zone` parameter to specify what timezone to return, it isn't implemented here yet. Currently, the local time zone is returned. Hopefully, that will be implemented soon.