### PR TITLE
Fix issue 1000: Indexes created on WHERE (#1133)

### DIFF
--- a/age--1.3.0.sql
+++ b/age--1.3.0.sql
@@ -364,7 +364,7 @@ AS 'MODULE_PATHNAME';
 CREATE FUNCTION ag_catalog._label_name(graph_oid oid, graphid)
 RETURNS cstring
 LANGUAGE c
-STABLE
+IMMUTABLE
 PARALLEL SAFE
 AS 'MODULE_PATHNAME';
 
@@ -3104,7 +3104,7 @@ AS 'MODULE_PATHNAME';
 CREATE FUNCTION ag_catalog._agtype_build_vertex(graphid, cstring, agtype)
 RETURNS agtype
 LANGUAGE c
-STABLE
+IMMUTABLE
 CALLED ON NULL INPUT
 PARALLEL SAFE
 AS 'MODULE_PATHNAME';
@@ -3112,10 +3112,11 @@ AS 'MODULE_PATHNAME';
 --
 -- agtype - edge
 --
-CREATE FUNCTION ag_catalog._agtype_build_edge(graphid, graphid, graphid, cstring, agtype)
+CREATE FUNCTION ag_catalog._agtype_build_edge(graphid, graphid, graphid,
+                                              cstring, agtype)
 RETURNS agtype
 LANGUAGE c
-STABLE
+IMMUTABLE
 CALLED ON NULL INPUT
 PARALLEL SAFE
 AS 'MODULE_PATHNAME';


### PR DESCRIPTION
This fixes the issue with applying indexes on the WHERE clause.

It does this by modifying the volatility flag for 3 functions -

    _agtype_build_vertex
    _agtype_build_edge
    _label_name

All three were verified to meet the specifications for IMMUTABLE.