### PR TITLE
Auto creates vertex or edge label on agload

### DIFF
--- a/regress/expected/age_load.out
+++ b/regress/expected/age_load.out
@@ -26,6 +26,9 @@ NOTICE:  graph "agload_test_graph" has been created
  
 (1 row)
 
+-------------------------
+-- Tests with id field --
+-------------------------
 SELECT create_vlabel('agload_test_graph','Country');
 NOTICE:  VLabel "Country" has been created
  create_vlabel 
@@ -110,6 +113,9 @@ SELECT COUNT(*) FROM cypher('agload_test_graph', $$MATCH (a)-[e]->(b) RETURN e$$
  72485
 (1 row)
 
+----------------------------
+-- Tests without id field --
+----------------------------
 SELECT create_vlabel('agload_test_graph','Country2');
 NOTICE:  VLabel "Country2" has been created
  create_vlabel 
@@ -218,8 +224,71 @@ $$) AS (result_1 agtype, result_2 agtype);
  "Croatia" | "Europe"
 (1 row)
 
+--------------------------------------------------------
+-- Tests without creating labels first, with id field --
+--------------------------------------------------------
+SELECT load_labels_from_file('agload_test_graph', 'Country3',
+    'age_load/countries.csv');
+NOTICE:  VLabel "Country3" has been created
+ load_labels_from_file 
+-----------------------
+ 
+(1 row)
+
+SELECT load_labels_from_file('agload_test_graph', 'City3',
+    'age_load/cities.csv');
+NOTICE:  VLabel "City3" has been created
+ load_labels_from_file 
+-----------------------
+ 
+(1 row)
+
+SELECT load_edges_from_file('agload_test_graph', 'has_city3',
+     'age_load/edges.csv');
+NOTICE:  ELabel "has_city3" has been created
+ load_edges_from_file 
+----------------------
+ 
+(1 row)
+
+SELECT table_catalog, table_schema, lower(table_name) as table_name, table_type
+FROM information_schema.tables
+WHERE table_schema = 'agload_test_graph' ORDER BY table_name ASC;
+   table_catalog    |   table_schema    |    table_name    | table_type 
+--------------------+-------------------+------------------+------------
+ contrib_regression | agload_test_graph | _ag_label_edge   | BASE TABLE
+ contrib_regression | agload_test_graph | _ag_label_vertex | BASE TABLE
+ contrib_regression | agload_test_graph | city             | BASE TABLE
+ contrib_regression | agload_test_graph | city2            | BASE TABLE
+ contrib_regression | agload_test_graph | city3            | BASE TABLE
+ contrib_regression | agload_test_graph | country          | BASE TABLE
+ contrib_regression | agload_test_graph | country2         | BASE TABLE
+ contrib_regression | agload_test_graph | country3         | BASE TABLE
+ contrib_regression | agload_test_graph | has_city         | BASE TABLE
+ contrib_regression | agload_test_graph | has_city3        | BASE TABLE
+(10 rows)
+
+SELECT COUNT(*) FROM agload_test_graph."Country3";
+ count 
+-------
+    53
+(1 row)
+
+SELECT COUNT(*) FROM agload_test_graph."City3";
+ count 
+-------
+ 72485
+(1 row)
+
+SELECT COUNT(*) FROM agload_test_graph."has_city3";
+ count 
+-------
+ 72485
+(1 row)
+
+-- DROP GRAPH
 SELECT drop_graph('agload_test_graph', true);
-NOTICE:  drop cascades to 7 other objects
+NOTICE:  drop cascades to 10 other objects
 DETAIL:  drop cascades to table agload_test_graph._ag_label_vertex
 drop cascades to table agload_test_graph._ag_label_edge
 drop cascades to table agload_test_graph."Country"
@@ -227,6 +296,9 @@ drop cascades to table agload_test_graph."City"
 drop cascades to table agload_test_graph.has_city
 drop cascades to table agload_test_graph."Country2"
 drop cascades to table agload_test_graph."City2"
+drop cascades to table agload_test_graph."Country3"
+drop cascades to table agload_test_graph."City3"
+drop cascades to table agload_test_graph.has_city3
 NOTICE:  graph "agload_test_graph" has been dropped
  drop_graph 
 ------------

--- a/regress/sql/age_load.sql
+++ b/regress/sql/age_load.sql
@@ -24,6 +24,10 @@ LOAD 'age';
 SET search_path TO ag_catalog;
 SELECT create_graph('agload_test_graph');
 
+-------------------------
+-- Tests with id field --
+-------------------------
+
 SELECT create_vlabel('agload_test_graph','Country');
 SELECT load_labels_from_file('agload_test_graph', 'Country',
     'age_load/countries.csv');
@@ -47,6 +51,10 @@ SELECT COUNT(*) FROM agload_test_graph."has_city";
 SELECT COUNT(*) FROM cypher('agload_test_graph', $$MATCH(n) RETURN n$$) as (n agtype);
 
 SELECT COUNT(*) FROM cypher('agload_test_graph', $$MATCH (a)-[e]->(b) RETURN e$$) as (n agtype);
+
+----------------------------
+-- Tests without id field --
+----------------------------
 
 SELECT create_vlabel('agload_test_graph','Country2');
 SELECT load_labels_from_file('agload_test_graph', 'Country2',
@@ -77,5 +85,28 @@ SELECT * FROM cypher('agload_test_graph', $$
     WHERE u.name =~ 'Cro.*'
     RETURN u.name, u.region
 $$) AS (result_1 agtype, result_2 agtype);
+
+--------------------------------------------------------
+-- Tests without creating labels first, with id field --
+--------------------------------------------------------
+
+SELECT load_labels_from_file('agload_test_graph', 'Country3',
+    'age_load/countries.csv');
+
+SELECT load_labels_from_file('agload_test_graph', 'City3',
+    'age_load/cities.csv');
+
+SELECT load_edges_from_file('agload_test_graph', 'has_city3',
+     'age_load/edges.csv');
+
+SELECT table_catalog, table_schema, lower(table_name) as table_name, table_type
+FROM information_schema.tables
+WHERE table_schema = 'agload_test_graph' ORDER BY table_name ASC;
+
+SELECT COUNT(*) FROM agload_test_graph."Country3";
+SELECT COUNT(*) FROM agload_test_graph."City3";
+SELECT COUNT(*) FROM agload_test_graph."has_city3";
+
+-- DROP GRAPH
 
 SELECT drop_graph('agload_test_graph', true);

--- a/src/backend/utils/load/age_load.c
+++ b/src/backend/utils/load/age_load.c
@@ -32,7 +32,6 @@
 #include "catalog/ag_label.h"
 #include "utils/agtype.h"
 #include "utils/graphid.h"
-
 #include "utils/load/ag_load_edges.h"
 #include "utils/load/ag_load_labels.h"
 #include "utils/load/age_load.h"
@@ -247,12 +246,19 @@ Datum load_labels_from_file(PG_FUNCTION_ARGS)
     file_path = PG_GETARG_TEXT_P(2);
     id_field_exists = PG_GETARG_BOOL(3);
 
-
     graph_name_str = NameStr(*graph_name);
     label_name_str = NameStr(*label_name);
     file_path_str = text_to_cstring(file_path);
 
     graph_oid = get_graph_oid(graph_name_str);
+
+    if (!label_exists(label_name_str, graph_oid))
+    {
+        DirectFunctionCall2(create_vlabel,
+                            CStringGetDatum(graph_name_str),
+                            CStringGetDatum(label_name_str));
+    }
+
     label_id = get_label_id(label_name_str, graph_oid);
 
     create_labels_from_csv_file(file_path_str, graph_name_str, graph_oid,
@@ -301,6 +307,14 @@ Datum load_edges_from_file(PG_FUNCTION_ARGS)
     file_path_str = text_to_cstring(file_path);
 
     graph_oid = get_graph_oid(graph_name_str);
+
+    if (!label_exists(label_name_str, graph_oid))
+    {
+        DirectFunctionCall2(create_elabel,
+                            CStringGetDatum(graph_name_str),
+                            CStringGetDatum(label_name_str));
+    }
+
     label_id = get_label_id(label_name_str, graph_oid);
 
     create_edges_from_csv_file(file_path_str, graph_name_str, graph_oid,


### PR DESCRIPTION
Changes made in order to reduce redundancy on calling `load_edges_from_file` and `load_labels_from_file`, so calling `create_vlabel` and `create_elabel` before loading a csv file is not needed anymore.
Updated regression tests.

#### BEFORE:
```sql
SELECT create_vlabel('agload_test_graph','City');
NOTICE:  VLabel "City" has been created
 create_vlabel 
---------------
 
(1 row)

SELECT load_labels_from_file('agload_test_graph', 'City',
    'age_load/cities.csv');
 load_labels_from_file 
-----------------------
 
(1 row)

SELECT create_elabel('agload_test_graph','has_city');
NOTICE:  ELabel "has_city" has been created
 create_elabel 
---------------
 
(1 row)

SELECT load_edges_from_file('agload_test_graph', 'has_city',
     'age_load/edges.csv');
 load_edges_from_file 
----------------------
 
(1 row)
```


#### AFTER:
```sql
SELECT load_labels_from_file('agload_test_graph', 'City',
    'age_load/cities.csv');
NOTICE:  VLabel "City" has been created
 load_labels_from_file 
-----------------------
 
(1 row)

SELECT load_edges_from_file('agload_test_graph', 'has_city',
     'age_load/edges.csv');
NOTICE:  ELabel "has_city" has been created
 load_edges_from_file 
----------------------
 
(1 row)
```