### PR TITLE
[PG13] Changed duplicated IF-STATEMENT INT4OID to INT2OID

### DIFF
--- a/regress/expected/agtype.out
+++ b/regress/expected/agtype.out
@@ -3192,6 +3192,30 @@ SELECT agtype_btree_cmp(
                -1
 (1 row)
 
+--Int2 to Agtype in agtype_volatile_wrapper
+SELECT ag_catalog.agtype_volatile_wrapper(1::int2);
+ agtype_volatile_wrapper 
+-------------------------
+ 1
+(1 row)
+
+SELECT ag_catalog.agtype_volatile_wrapper(32767::int2);
+ agtype_volatile_wrapper 
+-------------------------
+ 32767
+(1 row)
+
+SELECT ag_catalog.agtype_volatile_wrapper(-32767::int2);
+ agtype_volatile_wrapper 
+-------------------------
+ -32767
+(1 row)
+
+-- These should fail
+SELECT ag_catalog.agtype_volatile_wrapper(32768::int2);
+ERROR:  smallint out of range
+SELECT ag_catalog.agtype_volatile_wrapper(-32768::int2);
+ERROR:  smallint out of range
 --
 -- Cleanup
 --

--- a/regress/sql/agtype.sql
+++ b/regress/sql/agtype.sql
@@ -925,6 +925,15 @@ SELECT agtype_btree_cmp(
 	'[{"id":1, "label":"test", "properties":{"id":100}}::vertex,
 	  {"id":2, "start_id":1, "end_id": 3, "label":"elabel", "properties":{}}::edge,
 	  {"id":4, "label":"vlabel", "properties":{}}::vertex]::path'::agtype);
+
+--Int2 to Agtype in agtype_volatile_wrapper
+SELECT ag_catalog.agtype_volatile_wrapper(1::int2);
+SELECT ag_catalog.agtype_volatile_wrapper(32767::int2);
+SELECT ag_catalog.agtype_volatile_wrapper(-32767::int2);
+
+-- These should fail
+SELECT ag_catalog.agtype_volatile_wrapper(32768::int2);
+SELECT ag_catalog.agtype_volatile_wrapper(-32768::int2);
 --
 -- Cleanup
 --

--- a/src/backend/utils/adt/agtype.c
+++ b/src/backend/utils/adt/agtype.c
@@ -10699,7 +10699,7 @@ Datum agtype_volatile_wrapper(PG_FUNCTION_ARGS)
             {
                 agtv_result.val.int_value = (int64) DatumGetInt32(arg);
             }
-            else if (type == INT4OID)
+            else if (type == INT2OID)
             {
                 agtv_result.val.int_value = (int64) DatumGetInt16(arg);
             }


### PR DESCRIPTION
This PR is the PG13 version of [PR](https://github.com/apache/age/pull/1172) merged by @rafsun42

### Description
Fixed duplicated IF-STATEMENT of INT4OID in agtype_volatile_wrapper function changing it to INT2OID and created tests for INT2OID to Agtype in agtype_volatile_wrapper function