### PR TITLE
Add missing dependency in cypher_expr.c

### DIFF
--- a/src/backend/parser/cypher_expr.c
+++ b/src/backend/parser/cypher_expr.c
@@ -31,6 +31,7 @@
 #include "nodes/nodes.h"
 #include "nodes/parsenodes.h"
 #include "nodes/value.h"
+#include "optimizer/optimizer.h"
 #include "optimizer/tlist.h"
 #include "parser/parse_coerce.h"
 #include "parser/parse_collate.h"


### PR DESCRIPTION
The function contain_vars_of_level() was missing a header. Added that header to prevent a warning during compilation.