### PR TITLE
Add instruction to enter psql interface in Docker setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,12 @@ docker run \
     apache/age
 ```
 
+<h5> Enter PostgreSQL's psql: </h5>
+
+```bash
+docker exec -it age psql -d postgresDB -U postgresUser
+```
+
 <h2><img height="20" src="/img/contents.svg">&nbsp;&nbsp;Post Installation</h2>
 
 For every connection of AGE you start, you will need to load the AGE extension.


### PR DESCRIPTION
This PR adds instructions to the README.md file on how to enter the PostgreSQL psql interface when running Apache AGE using Docker.

The existing README lacks the instruction for accessing the PostgreSQL psql interface.

This is beneficial for all users who are looking to interact with the database, right after launching the Docker container.

(cherry picked from commit 25660e50d7fec058993e65bad46481392789ec79)