### PR TITLE
Fix Issue 1305 - drop_label NULL cases (#1306)

### DIFF
--- a/regress/expected/drop.out
+++ b/regress/expected/drop.out
@@ -82,3 +82,58 @@ SELECT nspname FROM pg_catalog.pg_namespace WHERE nspname IN ('other_schema', 'd
  other_schema
 (1 row)
 
+-- issue 1305
+CREATE EXTENSION age;
+LOAD 'age';
+SET search_path TO ag_catalog;
+SELECT create_graph('issue_1305');
+NOTICE:  graph "issue_1305" has been created
+ create_graph 
+--------------
+ 
+(1 row)
+
+SELECT create_vlabel('issue_1305', 'n');
+NOTICE:  VLabel "n" has been created
+ create_vlabel 
+---------------
+ 
+(1 row)
+
+SELECT create_elabel('issue_1305', 'r');
+NOTICE:  ELabel "r" has been created
+ create_elabel 
+---------------
+ 
+(1 row)
+
+SELECT drop_label('issue_1305', 'r', false);
+NOTICE:  label "issue_1305"."r" has been dropped
+ drop_label 
+------------
+ 
+(1 row)
+
+SELECT drop_label('issue_1305', 'r');
+ERROR:  rel_name not found for label "r"
+SELECT drop_label('issue_1305', 'n', false);
+NOTICE:  label "issue_1305"."n" has been dropped
+ drop_label 
+------------
+ 
+(1 row)
+
+SELECT drop_label('issue_1305', 'n');
+ERROR:  rel_name not found for label "n"
+SELECT * FROM drop_graph('issue_1305', true);
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table issue_1305._ag_label_vertex
+drop cascades to table issue_1305._ag_label_edge
+NOTICE:  graph "issue_1305" has been dropped
+ drop_graph 
+------------
+ 
+(1 row)
+
+-- END
+DROP EXTENSION age CASCADE;

--- a/regress/sql/drop.sql
+++ b/regress/sql/drop.sql
@@ -49,3 +49,19 @@ DROP EXTENSION age CASCADE;
 
 -- 'other_schema' should exist, 'drop' should be deleted
 SELECT nspname FROM pg_catalog.pg_namespace WHERE nspname IN ('other_schema', 'drop');
+
+-- issue 1305
+CREATE EXTENSION age;
+LOAD 'age';
+SET search_path TO ag_catalog;
+SELECT create_graph('issue_1305');
+SELECT create_vlabel('issue_1305', 'n');
+SELECT create_elabel('issue_1305', 'r');
+SELECT drop_label('issue_1305', 'r', false);
+SELECT drop_label('issue_1305', 'r');
+SELECT drop_label('issue_1305', 'n', false);
+SELECT drop_label('issue_1305', 'n');
+SELECT * FROM drop_graph('issue_1305', true);
+
+-- END
+DROP EXTENSION age CASCADE;

--- a/src/backend/commands/label_commands.c
+++ b/src/backend/commands/label_commands.c
@@ -762,8 +762,27 @@ Datum drop_label(PG_FUNCTION_ARGS)
                         errmsg("force option is not supported yet")));
     }
 
+    /* validate schema_name */
     schema_name = get_namespace_name(nsp_id);
+    if (schema_name == NULL)
+    {
+        ereport(ERROR,
+                (errcode(ERRCODE_UNDEFINED_TABLE),
+                 errmsg("schema_name not found for namespace id \"%d\"",
+                        nsp_id)));
+    }
+
+    /* validate rel_name */
     rel_name = get_rel_name(label_relation);
+    if (rel_name == NULL)
+    {
+        ereport(ERROR,
+                (errcode(ERRCODE_UNDEFINED_TABLE),
+                 errmsg("rel_name not found for label \"%s\"",
+                        label_name_str)));
+    }
+
+    /* build qualified name */
     qname = list_make2(makeString(schema_name), makeString(rel_name));
 
     remove_relation(qname);


### PR DESCRIPTION
Fixed issue 1305 where drop_label doesn't cover the case of rel_name coming back NULL, meaning it wasn't found.

Additionally, added a fix for when the schema_name isn't found from the namespace id search.

Added regression tests.