### PR TITLE
Hotfix for DockerHub on PG11

### DIFF
--- a/src/backend/utils/adt/age_global_graph.c
+++ b/src/backend/utils/adt/age_global_graph.c
@@ -20,7 +20,6 @@
 #include "postgres.h"
 
 #include "catalog/namespace.h"
-#include "commands/label_commands.h"
 #include "utils/datum.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"


### PR DESCRIPTION
PR 1353 applied a change that added an additional header file. This caused the build on DockerHub to fail.

This removes the included file and should correct the error. This is only for PG11.

`#include "commands/label_commands.h"`