### PR TITLE
Fix typo in agtype_raw.h header guard

### DIFF
--- a/src/include/utils/agtype_raw.h
+++ b/src/include/utils/agtype_raw.h
@@ -23,7 +23,7 @@
  */
 
 #ifndef AG_AGTYPE_RAW_H
-#define AG_AGTYPE_RAw_H
+#define AG_AGTYPE_RAW_H
 
 #include "postgres.h"
 #include "utils/agtype.h"


### PR DESCRIPTION
Header guard AG_AGTYPE_RAW_H was misspelled AG_AGTYPE_RAw_H