### PR TITLE
Fix DockerHub warning messages for latest

### DIFF
--- a/src/backend/parser/cypher_analyze.c
+++ b/src/backend/parser/cypher_analyze.c
@@ -802,7 +802,7 @@ static Query *analyze_cypher_and_coerce(List *stmt, RangeTblFunction *rtfunc,
                                         lateral, true);
 
     rtindex = list_length(pstate->p_rtable);
-    Assert(rtindex == 1); // rte is the only RangeTblEntry in pstate
+    // rte is the only RangeTblEntry in pstate
     if (rtindex !=1 )
     {
         ereport(ERROR,

--- a/src/backend/parser/cypher_clause.c
+++ b/src/backend/parser/cypher_clause.c
@@ -1340,7 +1340,7 @@ static Query *transform_cypher_unwind(cypher_parsestate *cpstate,
 
         pnsi = transform_prev_cypher_clause(cpstate, clause->prev, true);
         rtindex = list_length(pstate->p_rtable);
-        Assert(rtindex == 1); // rte is the first RangeTblEntry in pstate
+        // rte is the first RangeTblEntry in pstate
         if (rtindex != 1)
         {
             ereport(ERROR,
@@ -2325,7 +2325,7 @@ static Query *transform_cypher_clause_with_where(cypher_parsestate *cpstate,
                                                    NULL, true);
         Assert(pnsi != NULL);
         rtindex = list_length(pstate->p_rtable);
-        Assert(rtindex == 1); // rte is the only RangeTblEntry in pstate
+        // rte is the only RangeTblEntry in pstate
         if (rtindex != 1)
         {
             ereport(ERROR,
@@ -2605,7 +2605,7 @@ static Query *transform_cypher_match_pattern(cypher_parsestate *cpstate,
             pnsi = transform_prev_cypher_clause(cpstate, clause->prev, true);
             rte = pnsi->p_rte;
             rtindex = list_length(pstate->p_rtable);
-            Assert(rtindex == 1); // rte is the first RangeTblEntry in pstate
+            // rte is the first RangeTblEntry in pstate
             if (rtindex != 1)
             {
                 ereport(ERROR,
@@ -7016,7 +7016,6 @@ static void handle_prev_clause(cypher_parsestate *cpstate, Query *query,
     // rte is the first RangeTblEntry in pstate
     if (first_rte)
     {
-        Assert(rtindex == 1);
         if (rtindex != 1)
         {
             ereport(ERROR,

--- a/src/backend/parser/cypher_expr.c
+++ b/src/backend/parser/cypher_expr.c
@@ -565,12 +565,17 @@ static Node *transform_AEXPR_IN(cypher_parsestate *cpstate, A_Expr *a)
 
         scalar_type = AGTYPEOID;
 
-        Assert (verify_common_type(scalar_type, allexprs));
+        /* verify they are a common type */
+        if (!verify_common_type(scalar_type, allexprs))
+        {
+            ereport(ERROR,
+                    errmsg_internal("not a common type: %d", scalar_type));
+        }
+
         /*
          * coerce all the right-hand non-Var inputs to the common type
          * and build an ArrayExpr for them.
          */
-
         aexprs = NIL;
         foreach(l, rnonvars)
         {

--- a/src/backend/utils/adt/agtype_gin.c
+++ b/src/backend/utils/adt/agtype_gin.c
@@ -242,7 +242,10 @@ Datum gin_extract_agtype_query(PG_FUNCTION_ARGS)
 
         /* it should be WAGT_BEGIN_ARRAY */
         itok = agtype_iterator_next(&it, &elem, true);
-        Assert(itok == WAGT_BEGIN_ARRAY);
+        if (itok != WAGT_BEGIN_ARRAY)
+        {
+            elog(ERROR, "unexpected iterator token: %d", itok);
+        }
 
         while (WAGT_END_ARRAY != agtype_iterator_next(&it, &elem, true))
         {

--- a/src/include/utils/agtype.h
+++ b/src/include/utils/agtype.h
@@ -46,7 +46,7 @@
 /* Tokens used when sequentially processing an agtype value */
 typedef enum
 {
-    WAGT_DONE,
+    WAGT_DONE = 0x0,
     WAGT_KEY,
     WAGT_VALUE,
     WAGT_ELEM,


### PR DESCRIPTION
Fixed DockerHub warning messages for the build 'latest'. These were due to Assert statements that used variables that were not used for anything else. I changed them to ifs with error log outputs.