### PR TITLE
Fix DockerHub warning messages for PG14_latest

### DIFF
--- a/src/backend/utils/adt/agtype_gin.c
+++ b/src/backend/utils/adt/agtype_gin.c
@@ -242,7 +242,10 @@ Datum gin_extract_agtype_query(PG_FUNCTION_ARGS)
 
         /* it should be WAGT_BEGIN_ARRAY */
         itok = agtype_iterator_next(&it, &elem, true);
-        Assert(itok == WAGT_BEGIN_ARRAY);
+        if (itok != WAGT_BEGIN_ARRAY)
+        {
+            elog(ERROR, "unexpected iterator token: %d", itok);
+        }
 
         while (WAGT_END_ARRAY != agtype_iterator_next(&it, &elem, true))
         {

--- a/src/backend/utils/graph_generation.c
+++ b/src/backend/utils/graph_generation.c
@@ -83,7 +83,7 @@ Datum create_complete_graph(PG_FUNCTION_ARGS)
     int64 no_vertices;
     int64 i,j,vid = 1, eid, start_vid, end_vid;
 
-    Name vtx_label_name;
+    Name vtx_label_name = NULL;
     Name edge_label_name;
     int32 vtx_label_id;
     int32 edge_label_id;


### PR DESCRIPTION
Fixed DockerHub warning messages for the build PG14_latest. One was due to an Assert statement that used a variable that was not used for anything else. I changed it to an if with error log output. The other was due to an uninitialized variable.