### PR TITLE
Fix DockerHub warning messages for PG12_latest

### DIFF
--- a/src/backend/utils/adt/agtype_gin.c
+++ b/src/backend/utils/adt/agtype_gin.c
@@ -243,7 +243,10 @@ Datum gin_extract_agtype_query(PG_FUNCTION_ARGS)
 
         /* it should be WAGT_BEGIN_ARRAY */
         itok = agtype_iterator_next(&it, &elem, true);
-        Assert(itok == WAGT_BEGIN_ARRAY);
+        if (itok != WAGT_BEGIN_ARRAY)
+        {
+            elog(ERROR, "unexpected iterator token: %d", itok);
+        }
 
         while (WAGT_END_ARRAY != agtype_iterator_next(&it, &elem, true))
         {


### PR DESCRIPTION
Fixed DockerHub warning message for the build PG12_latest. This was due to an Assert statement that used a variable that was not used for anything else. I changed it to an if with error log output instead.