### PR TITLE
Fix DockerHub warning messages for PG11_latest

### DIFF
--- a/src/backend/utils/adt/agtype.c
+++ b/src/backend/utils/adt/agtype.c
@@ -2360,7 +2360,9 @@ static agtype_value* agtype_build_map_as_agtype_value(FunctionCallInfo fcinfo)
     nargs = extract_variadic_args(fcinfo, 0, true, &args, &types, &nulls);
 
     if (nargs < 0)
-        PG_RETURN_NULL();
+    {
+        return NULL;
+    }
 
     if (nargs % 2 != 0)
     {
@@ -2403,7 +2405,13 @@ PG_FUNCTION_INFO_V1(agtype_build_map);
  */
 Datum agtype_build_map(PG_FUNCTION_ARGS)
 {
-    agtype_value *result= agtype_build_map_as_agtype_value(fcinfo);
+    agtype_value *result = agtype_build_map_as_agtype_value(fcinfo);
+
+    if (result == NULL)
+    {
+        PG_RETURN_NULL();
+    }
+
     PG_RETURN_POINTER(agtype_value_to_agtype(result));
 }
 
@@ -2431,8 +2439,15 @@ PG_FUNCTION_INFO_V1(agtype_build_map_nonull);
  */
 Datum agtype_build_map_nonull(PG_FUNCTION_ARGS)
 {
-    agtype_value *result= agtype_build_map_as_agtype_value(fcinfo);
+    agtype_value *result = agtype_build_map_as_agtype_value(fcinfo);
+
+    if (result == NULL)
+    {
+        PG_RETURN_NULL();
+    }
+
     remove_null_from_agtype_object(result);
+
     PG_RETURN_POINTER(agtype_value_to_agtype(result));
 }
 

--- a/src/backend/utils/adt/agtype_gin.c
+++ b/src/backend/utils/adt/agtype_gin.c
@@ -242,7 +242,10 @@ Datum gin_extract_agtype_query(PG_FUNCTION_ARGS)
 
         /* it should be WAGT_BEGIN_ARRAY */
         itok = agtype_iterator_next(&it, &elem, true);
-        Assert(itok == WAGT_BEGIN_ARRAY);
+        if (itok != WAGT_BEGIN_ARRAY)
+        {
+            elog(ERROR, "unexpected iterator token: %d", itok);
+        }
 
         while (WAGT_END_ARRAY != agtype_iterator_next(&it, &elem, true))
         {


### PR DESCRIPTION
Fixed DockerHub warning messages for PG11_latest. One was due to an Assert statements that used a variable that was not used for anything else. I changed it to an if with error log output instead.

The other was due to a function returning with PG_RETURN_NULL() when it needed to return NULL instead. I updated the functions that used it to work appropriately.