### PR TITLE
Fix issue #1389 - Server crashes on using null operand for access operators

### DIFF
--- a/regress/expected/jsonb_operators.out
+++ b/regress/expected/jsonb_operators.out
@@ -938,6 +938,30 @@ SELECT '{"a": 9, "b": 11, "c": {"ca": [[], {}, null]}, "d": true, "1": false}'::
  
 (1 row)
 
+SELECT '{"n":null,"a":1,"b":[1,2],"c":{"1":2},"automatically":{"1":[2,3]}}'::agtype -> '"n"'::agtype -> '"1"'::agtype;
+ ?column? 
+----------
+ 
+(1 row)
+
+SELECT '{"n":null,"a":1,"b":[1,2],"c":{"1":2},"automatically":{"1":[2,3]}}'::agtype -> '"n"'::agtype -> 1::text;
+ ?column? 
+----------
+ 
+(1 row)
+
+SELECT '{"n":null,"a":1,"b":[1,2],"c":{"1":2},"automatically":{"1":[2,3]}}'::agtype -> '"n"'::agtype -> '"a"';
+ ?column? 
+----------
+ 
+(1 row)
+
+SELECT 'null'::agtype -> '"1"';
+ ?column? 
+----------
+ 
+(1 row)
+
 -- LHS is an array
 SELECT '["a","b","c",[1,2],null]'::agtype -> '0'::agtype;
  ?column? 
@@ -1236,6 +1260,30 @@ SELECT '{"a": [{"b": "c"}, {"b": "cc"}]}'::agtype ->> null::text;
 (1 row)
 
 SELECT '{"a": [{"b": "c"}, {"b": "cc"}]}'::agtype ->> null::int;
+ ?column? 
+----------
+ 
+(1 row)
+
+SELECT '{"n":null,"a":1,"b":[1,2],"c":{"1":2},"automatically":{"1":[2,3]}}'::agtype -> '"n"'::agtype ->> '"1"'::agtype;
+ ?column? 
+----------
+ 
+(1 row)
+
+SELECT '{"n":null,"a":1,"b":[1,2],"c":{"1":2},"automatically":{"1":[2,3]}}'::agtype -> '"n"'::agtype ->> 1::text;
+ ?column? 
+----------
+ 
+(1 row)
+
+SELECT '{"n":null,"a":1,"b":[1,2],"c":{"1":2},"automatically":{"1":[2,3]}}'::agtype -> '"n"'::agtype ->> '"a"';
+ ?column? 
+----------
+ 
+(1 row)
+
+SELECT 'null'::agtype ->> '"1"';
  ?column? 
 ----------
  

--- a/regress/sql/jsonb_operators.sql
+++ b/regress/sql/jsonb_operators.sql
@@ -223,6 +223,12 @@ SELECT '{"a": [{"b": "c"}, {"b": "cc"}]}'::agtype -> null::int;
 SELECT '{"a": [-1, -2, -3]}'::agtype -> '"a"'::text;
 SELECT '{"a": 9, "b": 11, "c": {"ca": [[], {}, null]}, "d": true, "1": false}'::agtype -> '1'::text::agtype;
 
+SELECT '{"n":null,"a":1,"b":[1,2],"c":{"1":2},"automatically":{"1":[2,3]}}'::agtype -> '"n"'::agtype -> '"1"'::agtype;
+SELECT '{"n":null,"a":1,"b":[1,2],"c":{"1":2},"automatically":{"1":[2,3]}}'::agtype -> '"n"'::agtype -> 1::text;
+SELECT '{"n":null,"a":1,"b":[1,2],"c":{"1":2},"automatically":{"1":[2,3]}}'::agtype -> '"n"'::agtype -> '"a"';
+
+SELECT 'null'::agtype -> '"1"';
+
 -- LHS is an array
 SELECT '["a","b","c",[1,2],null]'::agtype -> '0'::agtype;
 SELECT '["a","b","c",[1,2],null]'::agtype -> 1;
@@ -287,6 +293,12 @@ SELECT '{"1": -1.99, "a": 1, "b": 2, "c": {"d": [{}, [[[], [9]]]]}, "1": true}':
 SELECT '{"1": -1.99, "a": 1, "b": 2, "c": {"d": [{}, [[[], [9]]]]}, "1": true}'::agtype ->> '1';
 SELECT '{"a": [{"b": "c"}, {"b": "cc"}]}'::agtype ->> null::text;
 SELECT '{"a": [{"b": "c"}, {"b": "cc"}]}'::agtype ->> null::int;
+
+SELECT '{"n":null,"a":1,"b":[1,2],"c":{"1":2},"automatically":{"1":[2,3]}}'::agtype -> '"n"'::agtype ->> '"1"'::agtype;
+SELECT '{"n":null,"a":1,"b":[1,2],"c":{"1":2},"automatically":{"1":[2,3]}}'::agtype -> '"n"'::agtype ->> 1::text;
+SELECT '{"n":null,"a":1,"b":[1,2],"c":{"1":2},"automatically":{"1":[2,3]}}'::agtype -> '"n"'::agtype ->> '"a"';
+
+SELECT 'null'::agtype ->> '"1"';
 
 -- LHS is an array
 SELECT '["a","b","c",[1,2],null]'::agtype ->> 0;

--- a/src/backend/utils/adt/agtype.c
+++ b/src/backend/utils/adt/agtype.c
@@ -3644,9 +3644,14 @@ Datum agtype_object_field_impl(FunctionCallInfo fcinfo, agtype *agtype_in,
 
     if (AGT_ROOT_IS_SCALAR(agtype_in))
     {
-        process_agtype =
-            agtype_value_to_agtype(extract_entity_properties(agtype_in,
-                                                             false));
+        agtype_value *process_agtv = extract_entity_properties(agtype_in,
+                                                               false);
+        if (!process_agtv)
+        {
+            PG_RETURN_NULL();
+        }
+
+        process_agtype = agtype_value_to_agtype(process_agtv);
     }
     else
     {


### PR DESCRIPTION
This PR is a fix for #1389 where the server crashes on queries like
`SELECT 'null'::agtype -> '"1"';`

The issue was due to code not handling null values as LHS operands for access operators(->, ->>)

 Added check for this case to return NULL on such inputs and included regression tests