### PR TITLE
Remove unnecessary #include in src/backend/utils

### DIFF
--- a/src/backend/utils/adt/ag_float8_supp.c
+++ b/src/backend/utils/adt/ag_float8_supp.c
@@ -25,10 +25,7 @@
 
 #include "postgres.h"
 
-#include <math.h>
-
 #include "utils/float.h"
-#include "utils/builtins.h"
 #include "utils/ag_float8_supp.h"
 
 /*

--- a/src/backend/utils/adt/age_global_graph.c
+++ b/src/backend/utils/adt/age_global_graph.c
@@ -20,28 +20,17 @@
 #include "postgres.h"
 
 #include "access/heapam.h"
-#include "access/relscan.h"
-#include "access/skey.h"
-#include "access/table.h"
-#include "access/tableam.h"
 #include "catalog/namespace.h"
 #include "commands/label_commands.h"
 #include "utils/datum.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
-#include "utils/rel.h"
 #include "utils/snapmgr.h"
 #include "commands/label_commands.h"
 
-#include "catalog/ag_graph.h"
-#include "catalog/ag_label.h"
 #include "utils/age_global_graph.h"
-#include "utils/age_graphid_ds.h"
-#include "utils/agtype.h"
 #include "catalog/ag_graph.h"
 #include "catalog/ag_label.h"
-#include "utils/graphid.h"
-#include "utils/age_graphid_ds.h"
 
 /* defines */
 #define VERTEX_HTAB_NAME "Vertex to edge lists " /* added a space at end for */

--- a/src/backend/utils/adt/age_graphid_ds.c
+++ b/src/backend/utils/adt/age_graphid_ds.c
@@ -19,7 +19,6 @@
 
 #include "postgres.h"
 
-#include "utils/graphid.h"
 #include "utils/age_graphid_ds.h"
 
 /* defines */

--- a/src/backend/utils/adt/age_vle.c
+++ b/src/backend/utils/adt/age_vle.c
@@ -19,16 +19,11 @@
 
 #include "postgres.h"
 
-#include "access/heapam.h"
-#include "catalog/namespace.h"
-#include "catalog/pg_type.h"
 #include "funcapi.h"
 #include "utils/lsyscache.h"
 
 #include "utils/age_vle.h"
 #include "catalog/ag_graph.h"
-#include "utils/graphid.h"
-#include "utils/age_graphid_ds.h"
 #include "nodes/cypher_nodes.h"
 
 /* defines */

--- a/src/backend/utils/adt/agtype.c
+++ b/src/backend/utils/adt/agtype.c
@@ -30,46 +30,29 @@
 
 #include "postgres.h"
 
-#include <math.h>
 #include <float.h>
 
 #include "access/genam.h"
 #include "access/heapam.h"
-#include "access/skey.h"
-#include "access/table.h"
-#include "access/tableam.h"
-#include "access/htup_details.h"
 #include "catalog/namespace.h"
-#include "catalog/pg_collation.h"
-#include "catalog/pg_operator.h"
-#include "catalog/pg_type.h"
-#include "catalog/pg_aggregate_d.h"
 #include "catalog/pg_collation_d.h"
 #include "catalog/pg_operator_d.h"
-#include "executor/nodeAgg.h"
 #include "funcapi.h"
 #include "libpq/pqformat.h"
 #include "miscadmin.h"
 #include "parser/parse_coerce.h"
-#include "nodes/pg_list.h"
 #include "utils/builtins.h"
 #include "utils/float.h"
-#include "utils/fmgroids.h"
 #include "utils/int8.h"
 #include "utils/lsyscache.h"
-#include "utils/rel.h"
 #include "utils/snapmgr.h"
 #include "utils/typcache.h"
-
 #include "utils/age_vle.h"
-#include "utils/agtype.h"
 #include "utils/agtype_parser.h"
 #include "utils/ag_float8_supp.h"
 #include "utils/agtype_raw.h"
 #include "catalog/ag_graph.h"
 #include "catalog/ag_label.h"
-#include "utils/graphid.h"
-#include "utils/numeric.h"
 
 /* State structure for Percentile aggregate functions */
 typedef struct PercentileGroupAggState

--- a/src/backend/utils/adt/agtype_ext.c
+++ b/src/backend/utils/adt/agtype_ext.c
@@ -18,8 +18,6 @@
  */
 
 #include "utils/agtype_ext.h"
-#include "utils/agtype.h"
-#include "utils/graphid.h"
 
 /* define the type and size of the agt_header */
 #define AGT_HEADER_TYPE uint32

--- a/src/backend/utils/adt/agtype_gin.c
+++ b/src/backend/utils/adt/agtype_gin.c
@@ -30,14 +30,11 @@
 
 #include "access/gin.h"
 #include "access/hash.h"
-#include "access/stratnum.h"
 #include "catalog/pg_collation.h"
-#include "catalog/pg_type.h"
+#include "utils/agtype.h"
 #include "utils/float.h"
 #include "utils/builtins.h"
 #include "utils/varlena.h"
-
-#include "utils/agtype.h"
 
 typedef struct PathHashStack
 {

--- a/src/backend/utils/adt/agtype_ops.c
+++ b/src/backend/utils/adt/agtype_ops.c
@@ -26,12 +26,8 @@
 #include <math.h>
 #include <limits.h>
 
-#include "catalog/pg_type_d.h"
-#include "fmgr.h"
-#include "utils/builtins.h"
-#include "utils/numeric.h"
-
 #include "utils/agtype.h"
+#include "utils/builtins.h"
 
 static void ereport_op_str(const char *op, agtype *lhs, agtype *rhs);
 static agtype *agtype_concat_impl(agtype *agt1, agtype *agt2);

--- a/src/backend/utils/adt/agtype_raw.c
+++ b/src/backend/utils/adt/agtype_raw.c
@@ -18,8 +18,7 @@
  */
 
 #include "postgres.h"
-#include "utils/agtype.h"
-#include "utils/agtype_ext.h"
+
 #include "utils/agtype_raw.h"
 
 /*

--- a/src/backend/utils/adt/agtype_util.c
+++ b/src/backend/utils/adt/agtype_util.c
@@ -39,9 +39,7 @@
 #include "utils/memutils.h"
 #include "utils/varlena.h"
 
-#include "utils/agtype.h"
 #include "utils/agtype_ext.h"
-#include "utils/graphid.h"
 
 /*
  * Maximum number of elements in an array (or key/value pairs in an object).

--- a/src/backend/utils/adt/graphid.c
+++ b/src/backend/utils/adt/graphid.c
@@ -19,7 +19,6 @@
 
 #include "postgres.h"
 
-#include "fmgr.h"
 #include "utils/builtins.h"
 #include "utils/sortsupport.h"
 

--- a/src/backend/utils/ag_func.c
+++ b/src/backend/utils/ag_func.c
@@ -24,7 +24,6 @@
 
 #include "postgres.h"
 
-#include "access/htup.h"
 #include "access/htup_details.h"
 #include "catalog/pg_proc.h"
 #include "utils/builtins.h"

--- a/src/backend/utils/ag_guc.c
+++ b/src/backend/utils/ag_guc.c
@@ -18,6 +18,7 @@
  */
 
 #include "postgres.h"
+
 #include "utils/guc.h"
 #include "utils/ag_guc.h"
 

--- a/src/backend/utils/cache/ag_cache.c
+++ b/src/backend/utils/cache/ag_cache.c
@@ -19,31 +19,16 @@
 
 #include "postgres.h"
 
-#include "access/attnum.h"
 #include "access/genam.h"
 #include "access/heapam.h"
-#include "access/htup.h"
-#include "access/htup_details.h"
-#include "access/skey.h"
-#include "access/stratnum.h"
-#include "access/tupdesc.h"
 #include "catalog/pg_collation.h"
-#include "fmgr.h"
-#include "storage/lockdefs.h"
 #include "utils/builtins.h"
 #include "utils/catcache.h"
-#include "utils/fmgroids.h"
-#include "utils/hsearch.h"
 #include "utils/inval.h"
-#include "utils/memutils.h"
-#include "utils/rel.h"
-#include "utils/relcache.h"
-#include "utils/syscache.h"
 
 #include "catalog/ag_graph.h"
 #include "catalog/ag_label.h"
 #include "utils/ag_cache.h"
-#include "utils/graphid.h"
 
 typedef struct graph_name_cache_entry
 {

--- a/src/backend/utils/graph_generation.c
+++ b/src/backend/utils/graph_generation.c
@@ -19,34 +19,9 @@
 
 #include "postgres.h"
 
-#include "access/xact.h"
 #include "access/genam.h"
-#include "access/heapam.h"
-#include "catalog/dependency.h"
-#include "catalog/objectaddress.h"
-#include "commands/defrem.h"
-#include "commands/schemacmds.h"
-#include "commands/tablecmds.h"
-#include "fmgr.h"
-#include "miscadmin.h"
-#include "nodes/makefuncs.h"
-#include "nodes/nodes.h"
-#include "nodes/parsenodes.h"
-#include "nodes/pg_list.h"
-#include "nodes/value.h"
-#include "parser/parser.h"
-#include "utils/fmgroids.h"
-#include "utils/relcache.h"
-#include "utils/rel.h"
-
-#include "catalog/ag_graph.h"
-#include "catalog/ag_label.h"
 #include "commands/graph_commands.h"
-#include "commands/label_commands.h"
-#include "utils/graphid.h"
 #include "utils/load/age_load.h"
-#include "utils/load/ag_load_edges.h"
-#include "utils/load/ag_load_labels.h"
 
 
 int64 get_nextval_internal(graph_cache_data* graph_cache,

--- a/src/backend/utils/load/ag_load_labels.c
+++ b/src/backend/utils/load/ag_load_labels.c
@@ -16,49 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-#include <stdio.h>
-#include <string.h>
-#include <errno.h>
-#include <stdlib.h>
-#include <unistd.h>
-
 #include "postgres.h"
-
-#include "access/heapam.h"
-#include "access/xact.h"
-#include "catalog/dependency.h"
-#include "catalog/namespace.h"
-#include "catalog/objectaddress.h"
-#include "catalog/pg_class_d.h"
-#include "commands/defrem.h"
-#include "commands/sequence.h"
-#include "commands/tablecmds.h"
-#include "miscadmin.h"
-#include "nodes/makefuncs.h"
-#include "nodes/nodes.h"
-#include "nodes/parsenodes.h"
-#include "nodes/pg_list.h"
-#include "nodes/plannodes.h"
-#include "nodes/primnodes.h"
-#include "nodes/value.h"
-#include "parser/parse_node.h"
-#include "parser/parser.h"
-#include "storage/lockdefs.h"
-#include "tcop/dest.h"
-#include "tcop/utility.h"
-#include "utils/acl.h"
-#include "utils/builtins.h"
-#include "utils/inval.h"
-#include "utils/lsyscache.h"
-#include "utils/rel.h"
-
-#include "catalog/ag_graph.h"
-#include "catalog/ag_label.h"
-#include "commands/label_commands.h"
-#include "utils/ag_cache.h"
-#include "utils/agtype.h"
-#include "utils/graphid.h"
 
 #include "utils/load/ag_load_labels.h"
 #include "utils/load/age_load.h"

--- a/src/backend/utils/load/age_load.c
+++ b/src/backend/utils/load/age_load.c
@@ -19,20 +19,6 @@
 
 #include "postgres.h"
 
-#include "access/heapam.h"
-#include "access/xact.h"
-#include "parser/parse_node.h"
-#include "storage/lockdefs.h"
-#include "tcop/dest.h"
-#include "utils/builtins.h"
-#include "utils/lsyscache.h"
-#include "utils/rel.h"
-
-#include "catalog/ag_graph.h"
-#include "catalog/ag_label.h"
-#include "utils/agtype.h"
-#include "utils/graphid.h"
-
 #include "utils/load/ag_load_edges.h"
 #include "utils/load/ag_load_labels.h"
 #include "utils/load/age_load.h"


### PR DESCRIPTION
Removed unnecessary #includes in src/backend/utils files.

Resolved -

Conflicts:
	src/backend/utils/adt/age_vle.c
	src/backend/utils/adt/agtype.c