### PR TITLE
Fix issue #1399 EXISTS doesn't handle non-existent labels (#1400)

### DIFF
--- a/regress/expected/cypher_match.out
+++ b/regress/expected/cypher_match.out
@@ -2827,6 +2827,167 @@ SELECT * FROM cypher('cypher_match', $$ MATCH p1=(n {name:'Dave'})-[]->() MATCH 
 (1 row)
 
 --
+-- Issue 1399 EXISTS leads to an error if a relation label does not exists as database table
+--
+SELECT create_graph('issue_1399');
+NOTICE:  graph "issue_1399" has been created
+ create_graph 
+--------------
+ 
+(1 row)
+
+-- this is an empty graph so these should return 0
+SELECT * FROM cypher('issue_1399', $$
+  MATCH (foo)
+  WHERE exists((foo)-[]->())
+  RETURN foo
+$$) as (c agtype);
+ c 
+---
+(0 rows)
+
+SELECT * FROM cypher('issue_1399', $$
+  MATCH (foo)
+  WHERE NOT exists((foo)-[]->())
+  RETURN foo
+$$) as (c agtype);
+ c 
+---
+(0 rows)
+
+SELECT * FROM cypher('issue_1399', $$
+  MATCH (foo)
+  WHERE exists((foo)-[:BAR]->())
+  RETURN foo
+$$) as (c agtype);
+ c 
+---
+(0 rows)
+
+SELECT * FROM cypher('issue_1399', $$
+  MATCH (foo)
+  WHERE NOT exists((foo)-[:BAR]->())
+  RETURN foo
+$$) as (c agtype);
+ c 
+---
+(0 rows)
+
+-- this is an empty graph so these should return false
+SELECT * FROM cypher('issue_1399', $$
+  MATCH (foo)
+  WHERE exists((foo)-[]->())
+  RETURN count(foo) > 0
+$$) as (c agtype);
+   c   
+-------
+ false
+(1 row)
+
+SELECT * FROM cypher('issue_1399', $$
+  MATCH (foo)
+  WHERE NOT exists((foo)-[]->())
+  RETURN count(foo) > 0
+$$) as (c agtype);
+   c   
+-------
+ false
+(1 row)
+
+SELECT * FROM cypher('issue_1399', $$
+  MATCH (foo)
+  WHERE exists((foo)-[:BAR]->())
+  RETURN count(foo) > 0
+$$) as (c agtype);
+   c   
+-------
+ false
+(1 row)
+
+SELECT * FROM cypher('issue_1399', $$
+  MATCH (foo)
+  WHERE NOT exists((foo)-[:BAR]->())
+  RETURN count(foo) > 0
+$$) as (c agtype);
+   c   
+-------
+ false
+(1 row)
+
+-- create 1 path
+SELECT * FROM cypher('issue_1399', $$
+  CREATE (foo)-[:BAR]->() RETURN foo
+$$) as (c agtype);
+                               c                                
+----------------------------------------------------------------
+ {"id": 281474976710657, "label": "", "properties": {}}::vertex
+(1 row)
+
+-- these should each return 1 row as it is a directed edge and
+-- only one vertex can match.
+SELECT * FROM cypher('issue_1399', $$
+  MATCH (foo)
+  WHERE exists((foo)-[]->())
+  RETURN foo
+$$) as (c agtype);
+                               c                                
+----------------------------------------------------------------
+ {"id": 281474976710657, "label": "", "properties": {}}::vertex
+(1 row)
+
+SELECT * FROM cypher('issue_1399', $$
+  MATCH (foo)
+  WHERE NOT exists((foo)-[]->())
+  RETURN foo
+$$) as (c agtype);
+                               c                                
+----------------------------------------------------------------
+ {"id": 281474976710658, "label": "", "properties": {}}::vertex
+(1 row)
+
+SELECT * FROM cypher('issue_1399', $$
+  MATCH (foo)
+  WHERE exists((foo)-[:BAR]->())
+  RETURN foo
+$$) as (c agtype);
+                               c                                
+----------------------------------------------------------------
+ {"id": 281474976710657, "label": "", "properties": {}}::vertex
+(1 row)
+
+SELECT * FROM cypher('issue_1399', $$
+  MATCH (foo)
+  WHERE NOT exists((foo)-[:BAR]->())
+  RETURN foo
+$$) as (c agtype);
+                               c                                
+----------------------------------------------------------------
+ {"id": 281474976710658, "label": "", "properties": {}}::vertex
+(1 row)
+
+-- this should return 0 rows as it can't exist - that path isn't in BAR2
+SELECT * FROM cypher('issue_1399', $$
+  MATCH (foo)
+  WHERE exists((foo)-[:BAR2]->())
+  RETURN foo
+$$) as (c agtype);
+ c 
+---
+(0 rows)
+
+-- this should return 2 rows as they all exist
+SELECT * FROM cypher('issue_1399', $$
+  MATCH (foo)
+  WHERE NOT exists((foo)-[:BAR2]->())
+  RETURN foo
+$$) as (c agtype);
+                               c                                
+----------------------------------------------------------------
+ {"id": 281474976710657, "label": "", "properties": {}}::vertex
+ {"id": 281474976710658, "label": "", "properties": {}}::vertex
+(2 rows)
+
+--
 -- Clean up
 --
 SELECT drop_graph('cypher_match', true);
@@ -2884,6 +3045,17 @@ DETAIL:  drop cascades to table issue_945._ag_label_vertex
 drop cascades to table issue_945._ag_label_edge
 drop cascades to table issue_945."Part"
 NOTICE:  graph "issue_945" has been dropped
+ drop_graph 
+------------
+ 
+(1 row)
+
+SELECT drop_graph('issue_1399', true);
+NOTICE:  drop cascades to 3 other objects
+DETAIL:  drop cascades to table issue_1399._ag_label_vertex
+drop cascades to table issue_1399._ag_label_edge
+drop cascades to table issue_1399."BAR"
+NOTICE:  graph "issue_1399" has been dropped
  drop_graph 
 ------------
  

--- a/regress/sql/cypher_match.sql
+++ b/regress/sql/cypher_match.sql
@@ -1183,12 +1183,98 @@ SELECT * FROM cypher('cypher_match', $$ MATCH (n {name:'Dave'}) MATCH p=()-[*]->
 SELECT * FROM cypher('cypher_match', $$ MATCH p1=(n {name:'Dave'})-[]->() MATCH p2=()-[*]->() WHERE p2=p1 RETURN p2=p1 $$) as (path agtype);
 
 --
+-- Issue 1399 EXISTS leads to an error if a relation label does not exists as database table
+--
+SELECT create_graph('issue_1399');
+-- this is an empty graph so these should return 0
+SELECT * FROM cypher('issue_1399', $$
+  MATCH (foo)
+  WHERE exists((foo)-[]->())
+  RETURN foo
+$$) as (c agtype);
+SELECT * FROM cypher('issue_1399', $$
+  MATCH (foo)
+  WHERE NOT exists((foo)-[]->())
+  RETURN foo
+$$) as (c agtype);
+SELECT * FROM cypher('issue_1399', $$
+  MATCH (foo)
+  WHERE exists((foo)-[:BAR]->())
+  RETURN foo
+$$) as (c agtype);
+SELECT * FROM cypher('issue_1399', $$
+  MATCH (foo)
+  WHERE NOT exists((foo)-[:BAR]->())
+  RETURN foo
+$$) as (c agtype);
+-- this is an empty graph so these should return false
+SELECT * FROM cypher('issue_1399', $$
+  MATCH (foo)
+  WHERE exists((foo)-[]->())
+  RETURN count(foo) > 0
+$$) as (c agtype);
+SELECT * FROM cypher('issue_1399', $$
+  MATCH (foo)
+  WHERE NOT exists((foo)-[]->())
+  RETURN count(foo) > 0
+$$) as (c agtype);
+SELECT * FROM cypher('issue_1399', $$
+  MATCH (foo)
+  WHERE exists((foo)-[:BAR]->())
+  RETURN count(foo) > 0
+$$) as (c agtype);
+SELECT * FROM cypher('issue_1399', $$
+  MATCH (foo)
+  WHERE NOT exists((foo)-[:BAR]->())
+  RETURN count(foo) > 0
+$$) as (c agtype);
+-- create 1 path
+SELECT * FROM cypher('issue_1399', $$
+  CREATE (foo)-[:BAR]->() RETURN foo
+$$) as (c agtype);
+-- these should each return 1 row as it is a directed edge and
+-- only one vertex can match.
+SELECT * FROM cypher('issue_1399', $$
+  MATCH (foo)
+  WHERE exists((foo)-[]->())
+  RETURN foo
+$$) as (c agtype);
+SELECT * FROM cypher('issue_1399', $$
+  MATCH (foo)
+  WHERE NOT exists((foo)-[]->())
+  RETURN foo
+$$) as (c agtype);
+SELECT * FROM cypher('issue_1399', $$
+  MATCH (foo)
+  WHERE exists((foo)-[:BAR]->())
+  RETURN foo
+$$) as (c agtype);
+SELECT * FROM cypher('issue_1399', $$
+  MATCH (foo)
+  WHERE NOT exists((foo)-[:BAR]->())
+  RETURN foo
+$$) as (c agtype);
+-- this should return 0 rows as it can't exist - that path isn't in BAR2
+SELECT * FROM cypher('issue_1399', $$
+  MATCH (foo)
+  WHERE exists((foo)-[:BAR2]->())
+  RETURN foo
+$$) as (c agtype);
+-- this should return 2 rows as they all exist
+SELECT * FROM cypher('issue_1399', $$
+  MATCH (foo)
+  WHERE NOT exists((foo)-[:BAR2]->())
+  RETURN foo
+$$) as (c agtype);
+
+--
 -- Clean up
 --
 SELECT drop_graph('cypher_match', true);
 SELECT drop_graph('test_retrieve_var', true);
 SELECT drop_graph('test_enable_containment', true);
 SELECT drop_graph('issue_945', true);
+SELECT drop_graph('issue_1399', true);
 
 --
 -- End


### PR DESCRIPTION
Fixed issue #1399 where EXISTS doesn't handle non-existent labels. However, the issue actually is due to the extra processing (read: extra distance between the AST nodes) that prevented the transform logic from being able to resolve variables created in previous clauses further than one parent up.

Added logic to allow the `find_variable` function to search up the parent parse nodes.

Added regression tests to cover these cases.