### PR TITLE
Fix Docker files to reflect PostgreSQL version 16

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,14 +16,14 @@
 # limitations under the License.
 #
 
-FROM postgres:15
+FROM postgres:16
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends --no-install-suggests \
        bison \
        build-essential \
        flex \
-       postgresql-server-dev-15 \
+       postgresql-server-dev-16 \
        locales
 
 ENV LANG=en_US.UTF-8

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -17,14 +17,14 @@
 #
 
 
-FROM postgres:14
+FROM postgres:16
 
 RUN apt-get update
 RUN apt-get install --assume-yes --no-install-recommends --no-install-suggests \
   bison \
   build-essential \
   flex \
-  postgresql-server-dev-15 \
+  postgresql-server-dev-16 \
   locales
 
 ENV LANG=en_US.UTF-8


### PR DESCRIPTION
Fixed the following Docker files to reflect running under PostgreSQL version 16.

    modified:   docker/Dockerfile
    modified:   docker/Dockerfile.dev

This impacts the DockerHub builds.