### PR TITLE
Fix Docker file to reflect PostgreSQL version 15

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -17,7 +17,7 @@
 #
 
 
-FROM postgres:14
+FROM postgres:15
 
 RUN apt-get update
 RUN apt-get install --assume-yes --no-install-recommends --no-install-suggests \


### PR DESCRIPTION
Fixed the following Docker file to reflect running under PostgreSQL version 15.

modified:   docker/Dockerfile.dev

This impacts the development DockerHub builds.