### PR TITLE
Add an additional way to find a previous variable ref (#1450)

### DIFF
--- a/src/backend/parser/cypher_expr.c
+++ b/src/backend/parser/cypher_expr.c
@@ -841,10 +841,16 @@ static Node *transform_column_ref_for_indirection(cypher_parsestate *cpstate,
     /* locate the referenced RTE */
     rte = find_rte(cpstate, relname);
 
-    /* if we didn't find anything, return NULL */
+    /*
+     * If we didn't find anything, try looking for a previous variable
+     * reference. Otherwise, return NULL (colNameToVar will return NULL
+     * if nothing is found).
+     */
     if (!rte)
     {
-        return NULL;
+        Node *prev_var = colNameToVar(pstate, relname, false, cr->location);
+
+        return prev_var;
     }
 
     /* find the properties column of the NSI and return a var for it */


### PR DESCRIPTION
Added an additional way to find a previous variable reference to `transform_column_ref_for_indirection`.

There was no impact on current regression tests.

Resolved -
Conflicts:
	src/backend/parser/cypher_expr.c