### PR TITLE
Update regression test to prevent bogus failure

### DIFF
--- a/regress/expected/expr.out
+++ b/regress/expected/expr.out
@@ -7214,7 +7214,7 @@ SELECT * FROM cypher('keys', $$MATCH (v) RETURN keys(v)$$) AS (vertex_keys agtyp
  ["age", "job", "name"]
 (4 rows)
 
-SELECT * FROM cypher('keys', $$MATCH ()-[e]-() RETURN keys(e)$$) AS (edge_keys agtype);
+SELECT * FROM cypher('keys', $$MATCH ()-[e]-() RETURN keys(e) ORDER BY keys(e) ASC $$) AS (edge_keys agtype);
  edge_keys 
 -----------
  []
@@ -7250,8 +7250,10 @@ SELECT * from cypher('keys', $$RETURN keys([1,2,3])$$) as (keys agtype);
 ERROR:  keys() argument must be a vertex, edge, object or null
 SELECT * from cypher('keys', $$RETURN keys("string")$$) as (keys agtype);
 ERROR:  keys() argument must be a vertex, edge, object or null
+\set debug_parallel_query to regress -- suppresses context message from a parallel worker
 SELECT * from cypher('keys', $$MATCH u=()-[]-() RETURN keys(u)$$) as (keys agtype);
 ERROR:  keys() argument must be a vertex, edge, object or null
+\unset debug_parallel_query
 SELECT create_graph('list');
 NOTICE:  graph "list" has been created
  create_graph 

--- a/regress/sql/expr.sql
+++ b/regress/sql/expr.sql
@@ -2989,7 +2989,7 @@ SELECT * FROM cypher('keys', $$CREATE ({name: 'keiko fuji', age: 62, job: 'singe
 SELECT * FROM cypher('keys', $$MATCH (a),(b) WHERE a.name = 'hikaru utada' AND b.name = 'alexander guy cook' CREATE (a)-[:collaborated_with {song:"one last kiss"}]->(b)$$) AS (result agtype);
 SELECT * FROM cypher('keys', $$MATCH (a),(b) WHERE a.name = 'hikaru utada' AND b.name = 'keiko fuji' CREATE (a)-[:knows]->(b)$$) AS (result agtype);
 SELECT * FROM cypher('keys', $$MATCH (v) RETURN keys(v)$$) AS (vertex_keys agtype);
-SELECT * FROM cypher('keys', $$MATCH ()-[e]-() RETURN keys(e)$$) AS (edge_keys agtype);
+SELECT * FROM cypher('keys', $$MATCH ()-[e]-() RETURN keys(e) ORDER BY keys(e) ASC $$) AS (edge_keys agtype);
 SELECT * FROM cypher('keys', $$RETURN keys({a:1,b:'two',c:[1,2,3]})$$) AS (keys agtype);
 
 --should return empty list
@@ -2999,7 +2999,9 @@ SELECT * FROM cypher('keys', $$RETURN keys(null)$$) AS (keys agtype);
 --should return error
 SELECT * from cypher('keys', $$RETURN keys([1,2,3])$$) as (keys agtype);
 SELECT * from cypher('keys', $$RETURN keys("string")$$) as (keys agtype);
+\set debug_parallel_query to regress -- suppresses context message from a parallel worker
 SELECT * from cypher('keys', $$MATCH u=()-[]-() RETURN keys(u)$$) as (keys agtype);
+\unset debug_parallel_query
 
 SELECT create_graph('list');
 SELECT * from cypher('list', $$CREATE p=({name:"rick"})-[:knows]->({name:"morty"}) RETURN p$$) as (path agtype);


### PR DESCRIPTION
Changes:
--------
 - The ORDER BY clause is added to a query that was causing row-ordering difference.

 - The debug_parallel_query variable is set to 'regress' around a query that may
   choose parallel worker and therefore, may output a notice from a parallel worker.

   Setting this option will suppress notices from parallel workers and result in a
   consistent query output regardless of parallel worker being selected or not. Note
   that, this option also forces a query to choose parallel worker if it is safe.
