### PR TITLE
Order some regression tests for stability on big-endian

### DIFF
--- a/regress/expected/cypher_match.out
+++ b/regress/expected/cypher_match.out
@@ -1520,13 +1520,13 @@ NOTICE:  graph "for_isEmpty" has been dropped
 SELECT * FROM cypher('cypher_match', $$
 	MATCH (u)
 	RETURN DISTINCT u.id
-$$) AS (i agtype);
+$$) AS (i agtype) ORDER BY i;
      i     
 -----------
- 
  "end"
  "initial"
  "middle"
+ 
 (4 rows)
 
 SELECT * FROM cypher('cypher_match', $$
@@ -1556,7 +1556,7 @@ $$) AS (i agtype);
 SELECT * FROM cypher('cypher_match', $$
 	MATCH p=(:duplicate)-[]-(:other_v)
 	RETURN DISTINCT p
-$$) AS (i agtype);
+$$) AS (i agtype) ORDER BY i;
                                                                                                                                                 i                                                                                                                                                 
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  [{"id": 3377699720527873, "label": "duplicate", "properties": {}}::vertex, {"id": 3659174697238529, "label": "dup_edge", "end_id": 3940649673949185, "start_id": 3377699720527873, "properties": {"id": 1}}::edge, {"id": 3940649673949185, "label": "other_v", "properties": {}}::vertex]::path

--- a/regress/sql/cypher_match.sql
+++ b/regress/sql/cypher_match.sql
@@ -725,7 +725,7 @@ SELECT drop_graph('for_isEmpty', true);
 SELECT * FROM cypher('cypher_match', $$
 	MATCH (u)
 	RETURN DISTINCT u.id
-$$) AS (i agtype);
+$$) AS (i agtype) ORDER BY i;
 
 SELECT * FROM cypher('cypher_match', $$
 	CREATE (u:duplicate)-[:dup_edge {id:1 }]->(:other_v)
@@ -744,7 +744,7 @@ $$) AS (i agtype);
 SELECT * FROM cypher('cypher_match', $$
 	MATCH p=(:duplicate)-[]-(:other_v)
 	RETURN DISTINCT p
-$$) AS (i agtype);
+$$) AS (i agtype) ORDER BY i;
 
 --
 -- Limit


### PR DESCRIPTION
On Debian's s390x architecture, some regression tests were failing because the result set was reordered. Fix by attaching ORDER BY in problematic cases.

On top of this change, another fix is required: `agtype_hash_cmp()` changes values on big-endian architectures. For Debian, I fixed it by adding a `regress/expected/agtype_1.out` alternate output file where the diff to the original output file is this:

```
 diff -u regress/expected/agtype.out regress/expected/agtype_1.out
--- regress/expected/agtype.out	2024-01-11 13:03:54.051579131 +0100
+++ regress/expected/agtype_1.out	2024-01-11 14:33:37.961477838 +0100
@@ -3593,13 +3593,13 @@
 SELECT agtype_hash_cmp('1.0'::agtype);
  agtype_hash_cmp 
 -----------------
-       614780178
+      1437092844
 (1 row)
 
 SELECT agtype_hash_cmp('"1"'::agtype);
  agtype_hash_cmp 
 -----------------
-      -888576106
+     -1434266898
 (1 row)
 
 SELECT agtype_hash_cmp('[1]'::agtype);
@@ -3659,7 +3659,7 @@
 SELECT agtype_hash_cmp('[1, "abcde", 2.0]'::agtype);
  agtype_hash_cmp 
 -----------------
-     -1128310748
+       826120111
 (1 row)
 
 SELECT agtype_hash_cmp(agtype_in('null'));
@@ -3701,7 +3701,7 @@
 SELECT agtype_hash_cmp('{"id":1, "label":"test", "properties":{"id":100}}'::agtype);
  agtype_hash_cmp 
 -----------------
-      1116453668
+      -947461933
 (1 row)
 
 SELECT agtype_hash_cmp('{"id":1, "label":"test", "properties":{"id":100}}::vertex'::agtype);
@@ -3713,7 +3713,7 @@
 SELECT agtype_hash_cmp('{"id":2, "start_id":1, "end_id": 3, "label":"elabel", "properties":{}}'::agtype);
  agtype_hash_cmp 
 -----------------
-      1064722414
+      1662709842
 (1 row)
 
 SELECT agtype_hash_cmp('{"id":2, "start_id":1, "end_id": 3, "label":"elabel", "properties":{}}::edge'::agtype);
```

With that extra file, AGE passes all regression tests on apt.postgresql.org:
https://pgdgbuild.dus.dg-i.net/job/postgresql-16-age-binaries/

But maintaining a full `agtype.out` file along with a full `agtype_1.out` will be painful, so some other solution will be needed.

* Move the 5 `agtype_hash_cmp` tests to a separate test file, so only these tests would need two files
* Rewrite the test such that the different value isn't visible (perhaps check for `<> 0` or similar)
* Just don't test the output value
* Rewrite `agtype_hash_cmp` to output the same value on all architectures

I can help implementing this, but I can't really decide which one of these options fits best. (The least intrusive version would probably option 1.)