### PR TITLE
Fix unsorted output of some queries in the cypher_match test

### DIFF
--- a/regress/expected/cypher_match.out
+++ b/regress/expected/cypher_match.out
@@ -1998,13 +1998,13 @@ SELECT * FROM cypher('cypher_match', $$
 (0 rows)
 
 SELECT * FROM cypher('cypher_match', $$
-	MATCH (a)-[r]-(b) RETURN r $$) as (r agtype);
+	MATCH (a)-[r]-(b) RETURN r ORDER BY r DESC $$) as (r agtype);
                                                                                 r                                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
- {"id": 4785074604081153, "label": "knows", "end_id": 281474976710666, "start_id": 281474976710661, "properties": {"years": 3, "relationship": "friends"}}::edge
- {"id": 4785074604081153, "label": "knows", "end_id": 281474976710666, "start_id": 281474976710661, "properties": {"years": 3, "relationship": "friends"}}::edge
  {"id": 4785074604081154, "label": "knows", "end_id": 281474976710666, "start_id": 281474976710659, "properties": {"years": 4, "relationship": "enemies"}}::edge
  {"id": 4785074604081154, "label": "knows", "end_id": 281474976710666, "start_id": 281474976710659, "properties": {"years": 4, "relationship": "enemies"}}::edge
+ {"id": 4785074604081153, "label": "knows", "end_id": 281474976710666, "start_id": 281474976710661, "properties": {"years": 3, "relationship": "friends"}}::edge
+ {"id": 4785074604081153, "label": "knows", "end_id": 281474976710666, "start_id": 281474976710661, "properties": {"years": 3, "relationship": "friends"}}::edge
  {"id": 1407374883553283, "label": "e1", "end_id": 281474976710661, "start_id": 281474976710660, "properties": {}}::edge
  {"id": 1407374883553283, "label": "e1", "end_id": 281474976710661, "start_id": 281474976710660, "properties": {}}::edge
 (6 rows)
@@ -2091,13 +2091,13 @@ SELECT * FROM cypher('cypher_match', $$
 
 -- check reuse of 'r' clause-to-clause - edges
 SELECT * FROM cypher('cypher_match', $$
-	MATCH ()-[r]-() RETURN r $$) as (r agtype);
+	MATCH ()-[r]-() RETURN r ORDER BY r DESC $$) as (r agtype);
                                                                                 r                                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
- {"id": 4785074604081153, "label": "knows", "end_id": 281474976710666, "start_id": 281474976710661, "properties": {"years": 3, "relationship": "friends"}}::edge
- {"id": 4785074604081153, "label": "knows", "end_id": 281474976710666, "start_id": 281474976710661, "properties": {"years": 3, "relationship": "friends"}}::edge
  {"id": 4785074604081154, "label": "knows", "end_id": 281474976710666, "start_id": 281474976710659, "properties": {"years": 4, "relationship": "enemies"}}::edge
  {"id": 4785074604081154, "label": "knows", "end_id": 281474976710666, "start_id": 281474976710659, "properties": {"years": 4, "relationship": "enemies"}}::edge
+ {"id": 4785074604081153, "label": "knows", "end_id": 281474976710666, "start_id": 281474976710661, "properties": {"years": 3, "relationship": "friends"}}::edge
+ {"id": 4785074604081153, "label": "knows", "end_id": 281474976710666, "start_id": 281474976710661, "properties": {"years": 3, "relationship": "friends"}}::edge
  {"id": 1407374883553283, "label": "e1", "end_id": 281474976710661, "start_id": 281474976710660, "properties": {}}::edge
  {"id": 1407374883553283, "label": "e1", "end_id": 281474976710661, "start_id": 281474976710660, "properties": {}}::edge
 (6 rows)

--- a/regress/sql/cypher_match.sql
+++ b/regress/sql/cypher_match.sql
@@ -965,7 +965,7 @@ SELECT * FROM cypher('cypher_match', $$
 	MATCH (a),(b) WHERE a.age = 4 AND a.name = "orphan" AND b.age = 6 CREATE
 	(a)-[:knows {relationship: "enemies", years: 4}]->(b) $$) as (r agtype);
 SELECT * FROM cypher('cypher_match', $$
-	MATCH (a)-[r]-(b) RETURN r $$) as (r agtype);
+	MATCH (a)-[r]-(b) RETURN r ORDER BY r DESC $$) as (r agtype);
 
 -- check reuse of 'a' clause-to-clause - vertices
 SELECT * FROM cypher('cypher_match', $$
@@ -996,7 +996,7 @@ SELECT * FROM cypher('cypher_match', $$
 
 -- check reuse of 'r' clause-to-clause - edges
 SELECT * FROM cypher('cypher_match', $$
-	MATCH ()-[r]-() RETURN r $$) as (r agtype);
+	MATCH ()-[r]-() RETURN r ORDER BY r DESC $$) as (r agtype);
 SELECT * FROM cypher('cypher_match', $$
 	MATCH ()-[r]-() MATCH ()-[r {relationship: "friends"}]-() RETURN r $$) as (r agtype);
 SELECT * FROM cypher('cypher_match', $$


### PR DESCRIPTION
Hello! In the process of discussing issue #1439, I found a way to quickly reproduce test failure (allocating 2 cores to the virtual machine). This also resulted in periodic failure of the "cypher_match" test. 
regression.out:
```
============== running regression test queries        ==============
test scan                         ... ok          269 ms
test graphid                      ... ok            8 ms
test agtype                       ... ok           67 ms
test catalog                      ... ok           66 ms
test cypher                       ... ok           21 ms
test expr                         ... ok          419 ms
test cypher_create                ... ok           88 ms
test cypher_match                 ... FAILED      518 ms
test cypher_unwind                ... ok           44 ms
test cypher_set                   ... ok           96 ms
test cypher_remove                ... ok           69 ms
test cypher_delete                ... ok          171 ms
test cypher_with                  ... ok           65 ms
test cypher_vle                   ... ok          811 ms
test cypher_union                 ... ok           21 ms
test cypher_call                  ... ok           37 ms
test cypher_merge                 ... ok          189 ms
test age_global_graph             ... ok          103 ms
test age_load                     ... ok         1243 ms
test index                        ... ok           92 ms
test analyze                      ... ok           19 ms
test graph_generation             ... ok           54 ms
test name_validation              ... ok          101 ms
test jsonb_operators              ... ok           64 ms
test drop                         ... ok          208 ms
============== shutting down postmaster               ==============

=======================
 1 of 25 tests failed. 
=======================
```
The essence of failures is that the execution of some queries may result in different output. 
regression.diffs:
```
diff -U3 /home/egor/work/age/regress/expected/cypher_match.out /home/egor/work/age/regress/results/cypher_match.out
--- /home/egor/work/age/regress/expected/cypher_match.out       2024-01-12 08:58:58.614061424 +0300
+++ /home/egor/work/age/regress/results/cypher_match.out        2024-01-12 09:16:11.639188103 +0300
@@ -2001,12 +2001,12 @@
        MATCH (a)-[r]-(b) RETURN r $$) as (r agtype);
                                                                                 r
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"id": 1407374883553283, "label": "e1", "end_id": 281474976710661, "start_id": 281474976710660, "properties": {}}::edge
+ {"id": 1407374883553283, "label": "e1", "end_id": 281474976710661, "start_id": 281474976710660, "properties": {}}::edge
  {"id": 4785074604081153, "label": "knows", "end_id": 281474976710666, "start_id": 281474976710661, "properties": {"years": 3, "relationship": "friends"}}::edge
  {"id": 4785074604081153, "label": "knows", "end_id": 281474976710666, "start_id": 281474976710661, "properties": {"years": 3, "relationship": "friends"}}::edge
  {"id": 4785074604081154, "label": "knows", "end_id": 281474976710666, "start_id": 281474976710659, "properties": {"years": 4, "relationship": "enemies"}}::edge
  {"id": 4785074604081154, "label": "knows", "end_id": 281474976710666, "start_id": 281474976710659, "properties": {"years": 4, "relationship": "enemies"}}::edge
- {"id": 1407374883553283, "label": "e1", "end_id": 281474976710661, "start_id": 281474976710660, "properties": {}}::edge
- {"id": 1407374883553283, "label": "e1", "end_id": 281474976710661, "start_id": 281474976710660, "properties": {}}::edge
 (6 rows)

 -- check reuse of 'a' clause-to-clause - vertices
@@ -2094,12 +2094,12 @@
        MATCH ()-[r]-() RETURN r $$) as (r agtype);
                                                                                 r
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"id": 1407374883553283, "label": "e1", "end_id": 281474976710661, "start_id": 281474976710660, "properties": {}}::edge
+ {"id": 1407374883553283, "label": "e1", "end_id": 281474976710661, "start_id": 281474976710660, "properties": {}}::edge
  {"id": 4785074604081153, "label": "knows", "end_id": 281474976710666, "start_id": 281474976710661, "properties": {"years": 3, "relationship": "friends"}}::edge
  {"id": 4785074604081153, "label": "knows", "end_id": 281474976710666, "start_id": 281474976710661, "properties": {"years": 3, "relationship": "friends"}}::edge
  {"id": 4785074604081154, "label": "knows", "end_id": 281474976710666, "start_id": 281474976710659, "properties": {"years": 4, "relationship": "enemies"}}::edge
  {"id": 4785074604081154, "label": "knows", "end_id": 281474976710666, "start_id": 281474976710659, "properties": {"years": 4, "relationship": "enemies"}}::edge
- {"id": 1407374883553283, "label": "e1", "end_id": 281474976710661, "start_id": 281474976710660, "properties": {}}::edge
- {"id": 1407374883553283, "label": "e1", "end_id": 281474976710661, "start_id": 281474976710660, "properties": {}}::edge
 (6 rows)

 SELECT * FROM cypher('cypher_match', $$
```
The ORDER BY clause is added to these queries to prevent row-ordering difference.

Best regards,
Egor Chindyaskin
Postgres Professional: http://postgrespro.com/