### PR TITLE
Clean up #included files in nodes, executor, & optimizer directories (#1509)

### DIFF
--- a/src/backend/executor/cypher_create.c
+++ b/src/backend/executor/cypher_create.c
@@ -19,23 +19,10 @@
 
 #include "postgres.h"
 
-#include "access/heapam.h"
-#include "access/htup_details.h"
 #include "access/xact.h"
-#include "executor/tuptable.h"
-#include "nodes/execnodes.h"
-#include "nodes/extensible.h"
-#include "nodes/nodes.h"
-#include "nodes/plannodes.h"
-#include "rewrite/rewriteHandler.h"
-#include "utils/rel.h"
-
 #include "catalog/ag_label.h"
 #include "executor/cypher_executor.h"
 #include "executor/cypher_utils.h"
-#include "nodes/cypher_nodes.h"
-#include "utils/agtype.h"
-#include "utils/graphid.h"
 
 static void begin_cypher_create(CustomScanState *node, EState *estate,
                                 int eflags);

--- a/src/backend/executor/cypher_delete.c
+++ b/src/backend/executor/cypher_delete.c
@@ -19,27 +19,13 @@
 
 #include "postgres.h"
 
-#include "access/heapam.h"
-#include "access/htup_details.h"
-#include "access/multixact.h"
-#include "access/table.h"
 #include "access/xact.h"
-#include "executor/tuptable.h"
-#include "nodes/execnodes.h"
-#include "nodes/extensible.h"
-#include "nodes/nodes.h"
-#include "nodes/plannodes.h"
-#include "parser/parsetree.h"
 #include "storage/bufmgr.h"
-#include "utils/rel.h"
 #include "common/hashfn.h"
 
 #include "catalog/ag_label.h"
 #include "executor/cypher_executor.h"
 #include "executor/cypher_utils.h"
-#include "nodes/cypher_nodes.h"
-#include "utils/agtype.h"
-#include "utils/graphid.h"
 
 static void begin_cypher_delete(CustomScanState *node, EState *estate,
                                 int eflags);

--- a/src/backend/executor/cypher_merge.c
+++ b/src/backend/executor/cypher_merge.c
@@ -19,22 +19,10 @@
 
 #include "postgres.h"
 
-#include "access/htup_details.h"
-#include "access/table.h"
 #include "access/xact.h"
-#include "executor/tuptable.h"
-#include "nodes/execnodes.h"
-#include "nodes/extensible.h"
-#include "nodes/nodes.h"
-#include "nodes/plannodes.h"
-#include "utils/rel.h"
-
 #include "catalog/ag_label.h"
 #include "executor/cypher_executor.h"
 #include "executor/cypher_utils.h"
-#include "nodes/cypher_nodes.h"
-#include "utils/agtype.h"
-#include "utils/graphid.h"
 
 static void begin_cypher_merge(CustomScanState *node, EState *estate,
                                int eflags);

--- a/src/backend/executor/cypher_set.c
+++ b/src/backend/executor/cypher_set.c
@@ -19,23 +19,11 @@
 
 #include "postgres.h"
 
-#include "access/heapam.h"
-#include "access/htup_details.h"
 #include "access/xact.h"
-#include "executor/tuptable.h"
-#include "nodes/execnodes.h"
-#include "nodes/extensible.h"
-#include "nodes/nodes.h"
-#include "nodes/plannodes.h"
-#include "rewrite/rewriteHandler.h"
 #include "storage/bufmgr.h"
-#include "utils/rel.h"
 
 #include "executor/cypher_executor.h"
 #include "executor/cypher_utils.h"
-#include "nodes/cypher_nodes.h"
-#include "utils/agtype.h"
-#include "utils/graphid.h"
 
 static void begin_cypher_set(CustomScanState *node, EState *estate,
                                 int eflags);

--- a/src/backend/executor/cypher_utils.c
+++ b/src/backend/executor/cypher_utils.c
@@ -24,30 +24,14 @@
 
 #include "postgres.h"
 
-#include "access/htup_details.h"
-#include "access/sysattr.h"
 #include "access/xact.h"
-#include "access/heapam.h"
-#include "access/multixact.h"
-#include "access/xact.h"
-#include "nodes/extensible.h"
 #include "nodes/makefuncs.h"
-#include "nodes/nodes.h"
-#include "nodes/nodeFuncs.h"
-#include "nodes/plannodes.h"
-#include "parser/parsetree.h"
 #include "parser/parse_relation.h"
-#include "storage/procarray.h"
-#include "utils/rel.h"
 
 #include "catalog/ag_label.h"
 #include "commands/label_commands.h"
-#include "executor/cypher_executor.h"
 #include "executor/cypher_utils.h"
-#include "utils/agtype.h"
 #include "utils/ag_cache.h"
-#include "utils/agtype.h"
-#include "utils/graphid.h"
 
 /*
  * Given the graph name and the label name, create a ResultRelInfo for the table

--- a/src/backend/nodes/ag_nodes.c
+++ b/src/backend/nodes/ag_nodes.c
@@ -19,8 +19,6 @@
 
 #include "postgres.h"
 
-#include "nodes/extensible.h"
-
 #include "nodes/ag_nodes.h"
 #include "nodes/cypher_copyfuncs.h"
 #include "nodes/cypher_outfuncs.h"

--- a/src/backend/nodes/cypher_copyfuncs.c
+++ b/src/backend/nodes/cypher_copyfuncs.c
@@ -19,10 +19,7 @@
 
 #include "postgres.h"
 
-#include "nodes/bitmapset.h"
 #include "nodes/extensible.h"
-#include "nodes/nodes.h"
-#include "utils/palloc.h"
 
 #include "nodes/cypher_copyfuncs.h"
 #include "nodes/cypher_nodes.h"

--- a/src/backend/nodes/cypher_outfuncs.c
+++ b/src/backend/nodes/cypher_outfuncs.c
@@ -19,10 +19,6 @@
 
 #include "postgres.h"
 
-#include "lib/stringinfo.h"
-#include "nodes/extensible.h"
-#include "nodes/nodes.h"
-
 #include "nodes/cypher_nodes.h"
 #include "nodes/cypher_outfuncs.h"
 

--- a/src/backend/optimizer/cypher_createplan.c
+++ b/src/backend/optimizer/cypher_createplan.c
@@ -19,11 +19,6 @@
 
 #include "postgres.h"
 
-#include "nodes/extensible.h"
-#include "nodes/nodes.h"
-#include "nodes/pg_list.h"
-#include "nodes/plannodes.h"
-
 #include "executor/cypher_executor.h"
 #include "optimizer/cypher_createplan.h"
 

--- a/src/backend/optimizer/cypher_pathnode.c
+++ b/src/backend/optimizer/cypher_pathnode.c
@@ -20,8 +20,6 @@
 #include "postgres.h"
 
 #include "nodes/extensible.h"
-#include "nodes/nodes.h"
-#include "nodes/pg_list.h"
 
 #include "optimizer/cypher_createplan.h"
 #include "optimizer/cypher_pathnode.h"

--- a/src/backend/optimizer/cypher_paths.c
+++ b/src/backend/optimizer/cypher_paths.c
@@ -19,8 +19,6 @@
 
 #include "postgres.h"
 
-#include "nodes/parsenodes.h"
-#include "nodes/primnodes.h"
 #include "optimizer/pathnode.h"
 #include "optimizer/paths.h"
 


### PR DESCRIPTION
Clean up #included files in nodes, executor, & optimizer directories (#1509)

Cleaned up #included files in the .c files in the nodes, executor, and optimizer directories.

    modified:   src/backend/executor/cypher_create.c
    modified:   src/backend/executor/cypher_delete.c
    modified:   src/backend/executor/cypher_merge.c
    modified:   src/backend/executor/cypher_set.c
    modified:   src/backend/executor/cypher_utils.c
    modified:   src/backend/nodes/ag_nodes.c
    modified:   src/backend/nodes/cypher_copyfuncs.c
    modified:   src/backend/nodes/cypher_outfuncs.c
    modified:   src/backend/optimizer/cypher_createplan.c
    modified:   src/backend/optimizer/cypher_pathnode.c
    modified:   src/backend/optimizer/cypher_paths.c