### PR TITLE
Add template for upgrading between versions of Apache AGE (#1506)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 *.o
 *.so
 build.sh
-age--*.*.*.sql
 .idea
 .deps
 .DS_Store
 *.tokens
 *.interp
+*.dylib
+age--*.*.*.sql
+!age--*--*sql

--- a/age--1.5.0--y.y.y.sql
+++ b/age--1.5.0--y.y.y.sql
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+-- This is a template for upgrading from the previous version of Apache AGE
+-- It will only work within versions of PostgreSQL, not across.
+-- Please adjust the below ALTER EXTENSION to reflect the correct version
+-- it is upgrading to.
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "ALTER EXTENSION age UPDATE TO '1.4.0'" to load this file. \quit
+
+-- Please add all additions, deletions, and modifications to the end of this
+-- file. We need to keep the order of these changes.
+


### PR DESCRIPTION
Added a template to be used when upgrading between versions of Apache AGE.

This template is to be added to for all additions, deletions, and modifications to the sql files that define operators, types, and functions.

Modified .gitignore to allow these changes.

    modified:   .gitignore
    new file:   age--1.5.0--y.y.y.sql

Resolved -

Conflicts:
	.gitignore