### PR TITLE
Test multi arch automated build for dockerhub

### DIFF
--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -1,0 +1,2 @@
+docker buildx create --name multiarch --use
+docker buildx build . -t $IMAGE_NAME -f Dockerfile --platform linux/arm64/v8,linux/amd64 --push


### PR DESCRIPTION
- Hooks/build overrides the default build process for dockerhub. See https://docs.docker.com/docker-hub/builds/advanced/#build-hook-examples