### PR TITLE
Fix PG11 DockerHub build warnings

### DIFF
--- a/src/backend/parser/cypher_expr.c
+++ b/src/backend/parser/cypher_expr.c
@@ -587,7 +587,13 @@ static Node *transform_AEXPR_IN(cypher_parsestate *cpstate, A_Expr *a)
 
         scalar_type = AGTYPEOID;
 
-        Assert(verify_common_type(scalar_type, allexprs));
+        if (verify_common_type(scalar_type, allexprs) != true)
+        {
+            ereport(ERROR,
+                    (errcode(ERRCODE_CANNOT_COERCE),
+                     errmsg_internal("not a common type")));
+        }
+
         /*
          * coerce all the right-hand non-Var inputs to the common type
          * and build an ArrayExpr for them.


### PR DESCRIPTION
Fixed PG11 DockerHub build warnings by converting an Assert to an error message.

This PR is the PG14 PR as they both have similar warnings.

No regression tests needed adjusting.

Resolved -

Conflicts:
	src/backend/parser/cypher_expr.c