### PR TITLE
Implement COUNT Subquery with PG specifications

### DIFF
--- a/regress/expected/cypher_subquery.out
+++ b/regress/expected/cypher_subquery.out
@@ -1,23 +1,23 @@
 LOAD 'age';
 SET search_path TO ag_catalog;
-SELECT * FROM create_graph('exists_subquery');
-NOTICE:  graph "exists_subquery" has been created
+SELECT * FROM create_graph('subquery');
+NOTICE:  graph "subquery" has been created
  create_graph 
 --------------
  
 (1 row)
 
-SELECT * FROM cypher('exists_subquery', $$ 
-										CREATE (:person {name: "Briggite", age: 32})-[:knows]->(:person {name: "Takeshi", age: 28}),
-											   (:person {name: "Faye", age: 25})-[:knows]->(:person {name: "Tony", age: 34})-[:loved]->(:person {name : "Valerie", age: 33}),
-											   (:person {name: "Calvin", age: 6})-[:knows]->(:pet {name: "Hobbes"}),
-											   (:person {name: "Charlie", age: 8})-[:knows]->(:pet {name : "Snoopy"})
-										$$) AS (result agtype);
+SELECT * FROM cypher('subquery', $$
+								   CREATE (:person {name: "Briggite", age: 32})-[:knows]->(:person {name: "Takeshi", age: 28}),
+										  (:person {name: "Faye", age: 25})-[:knows]->(:person {name: "Tony", age: 34})-[:loved]->(:person {name : "Valerie", age: 33}),
+										  (:person {name: "Calvin", age: 6})-[:knows]->(:pet {name: "Hobbes"}),
+										  (:person {name: "Charlie", age: 8})-[:knows]->(:pet {name : "Snoopy"})
+								 $$) AS (result agtype);
  result 
 --------
 (0 rows)
 
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a) RETURN (a) $$) AS (result agtype);
+SELECT * FROM cypher('subquery', $$ MATCH (a) RETURN (a) $$) AS (result agtype);
                                               result                                               
 ---------------------------------------------------------------------------------------------------
  {"id": 844424930131969, "label": "person", "properties": {"age": 32, "name": "Briggite"}}::vertex
@@ -31,29 +31,43 @@ SELECT * FROM cypher('exists_subquery', $$ MATCH (a) RETURN (a) $$) AS (result a
  {"id": 1688849860263938, "label": "pet", "properties": {"name": "Snoopy"}}::vertex
 (9 rows)
 
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person) 
-										   WHERE EXISTS {(a:person)-[]->(:pet)}
-										   RETURN (a) $$) AS (result agtype);
-                                             result                                              
--------------------------------------------------------------------------------------------------
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									WHERE EXISTS {(a:person)-[]->(:pet)}
+									RETURN (a) $$) AS (result agtype);
+                                              result                                               
+---------------------------------------------------------------------------------------------------
+ {"id": 844424930131969, "label": "person", "properties": {"age": 32, "name": "Briggite"}}::vertex
+ {"id": 844424930131970, "label": "person", "properties": {"age": 28, "name": "Takeshi"}}::vertex
+ {"id": 844424930131971, "label": "person", "properties": {"age": 25, "name": "Faye"}}::vertex
+ {"id": 844424930131972, "label": "person", "properties": {"age": 34, "name": "Tony"}}::vertex
+ {"id": 844424930131973, "label": "person", "properties": {"age": 33, "name": "Valerie"}}::vertex
  {"id": 844424930131974, "label": "person", "properties": {"age": 6, "name": "Calvin"}}::vertex
  {"id": 844424930131975, "label": "person", "properties": {"age": 8, "name": "Charlie"}}::vertex
-(2 rows)
+(7 rows)
 
 --trying to use b when not defined, should fail
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person) 
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
 										   WHERE EXISTS {(a:person)-[]->(b:pet)}
 										   RETURN (a) $$) AS (result agtype);
-ERROR:  variable `b` does not exist
-LINE 2:              WHERE EXISTS {(a:person)-[]->(b:pet)}
-                                                   ^
+                                              result                                               
+---------------------------------------------------------------------------------------------------
+ {"id": 844424930131969, "label": "person", "properties": {"age": 32, "name": "Briggite"}}::vertex
+ {"id": 844424930131970, "label": "person", "properties": {"age": 28, "name": "Takeshi"}}::vertex
+ {"id": 844424930131971, "label": "person", "properties": {"age": 25, "name": "Faye"}}::vertex
+ {"id": 844424930131972, "label": "person", "properties": {"age": 34, "name": "Tony"}}::vertex
+ {"id": 844424930131973, "label": "person", "properties": {"age": 33, "name": "Valerie"}}::vertex
+ {"id": 844424930131974, "label": "person", "properties": {"age": 6, "name": "Calvin"}}::vertex
+ {"id": 844424930131975, "label": "person", "properties": {"age": 8, "name": "Charlie"}}::vertex
+(7 rows)
+
 --query inside
---EXISTS subquery is currently implemented naively, without constraints in the
---subquery. the results of this regression test may change upon implementation
+--EXISTS subquery is currently implemented with postgres subqueries, which do not
+--constrain the outer query results. the results of this regression test may change
+--upon implementation
 --TODO: implement inner subquery constraints
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
-										   WHERE EXISTS {MATCH (a:person)-[]->(b:pet) RETURN b}
-										   RETURN (a) $$) AS (result agtype);
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									WHERE EXISTS {MATCH (a:person)-[]->(b:pet) RETURN b}
+									RETURN (a) $$) AS (result agtype);
                                               result                                               
 ---------------------------------------------------------------------------------------------------
  {"id": 844424930131969, "label": "person", "properties": {"age": 32, "name": "Briggite"}}::vertex
@@ -66,16 +80,17 @@ SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
 (7 rows)
 
 --repeat variable in match
---EXISTS subquery is currently implemented naively, without constraints in the
---subquery. the results of this regression test may change upon implementation
+--EXISTS subquery is currently implemented with postgres subqueries, which do not
+--constrain the outer query results. the results of this regression test may change
+--upon implementation
 --TODO: implement inner subquery constraints
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
-										   WHERE EXISTS {
-						   				 			     MATCH (a:person)
-						   				 			     WHERE a.name = 'Takeshi'
-						   				 			     RETURN a
-										   				 }
-										   RETURN (a) $$) AS (result agtype);
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									WHERE EXISTS {
+												  MATCH (a:person)
+												  WHERE a.name = 'Takeshi'
+												  RETURN a
+												 }
+									RETURN (a) $$) AS (result agtype);
                                               result                                               
 ---------------------------------------------------------------------------------------------------
  {"id": 844424930131969, "label": "person", "properties": {"age": 32, "name": "Briggite"}}::vertex
@@ -88,23 +103,24 @@ SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
 (7 rows)
 
 --query inside, with WHERE
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
-										   WHERE EXISTS {MATCH (a:person)-[]->(b:pet)
-										   				 WHERE b.name = 'Briggite'
-										   				 RETURN b}
-										   RETURN (a) $$) AS (result agtype);
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									WHERE EXISTS {MATCH (a:person)-[]->(b:pet)
+												  WHERE b.name = 'Briggite'
+												  RETURN b}
+									RETURN (a) $$) AS (result agtype);
  result 
 --------
 (0 rows)
 
 --no return
---EXISTS subquery is currently implemented naively, without constraints in the
---subquery. the results of this regression test may change upon implementation
+--EXISTS subquery is currently implemented with postgres subqueries, which do not
+--constrain the outer query results. the results of this regression test may change
+--upon implementation
 --TODO: implement inner subquery constraints
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
-										   WHERE EXISTS {MATCH (a:person)-[]->(b:pet)
-										   				 WHERE a.name = 'Calvin'}
-										   RETURN (a) $$) AS (result agtype);
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									WHERE EXISTS {MATCH (a:person)-[]->(b:pet)
+												  WHERE a.name = 'Calvin'}
+									RETURN (a) $$) AS (result agtype);
                                               result                                               
 ---------------------------------------------------------------------------------------------------
  {"id": 844424930131969, "label": "person", "properties": {"age": 32, "name": "Briggite"}}::vertex
@@ -117,19 +133,20 @@ SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
 (7 rows)
 
 --union
---EXISTS subquery is currently implemented naively, without constraints in the
---subquery. the results of this regression test may change upon implementation
+--EXISTS subquery is currently implemented with postgres subqueries, which do not
+--constrain the outer query results. the results of this regression test may change
+--upon implementation
 --TODO: implement inner subquery constraints
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
-										   WHERE EXISTS {
-										   				 MATCH (a:person)-[]->(b:pet)
-										   				 WHERE b.name = 'Hobbes'
-										   				 RETURN b
-										   				 UNION
-										   				 MATCH (c:person)-[]->(d:person)
-										   				 RETURN c
-										   				}
-										   RETURN (a) $$) AS (result agtype);
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									WHERE EXISTS {
+												  MATCH (a:person)-[]->(b:pet)
+												  WHERE b.name = 'Hobbes'
+												  RETURN b
+												  UNION
+												  MATCH (c:person)-[]->(d:person)
+												  RETURN c
+												 }
+									RETURN (a) $$) AS (result agtype);
                                               result                                               
 ---------------------------------------------------------------------------------------------------
  {"id": 844424930131969, "label": "person", "properties": {"age": 32, "name": "Briggite"}}::vertex
@@ -142,28 +159,28 @@ SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
 (7 rows)
 
 -- union, mismatched var, should fail
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
-										   WHERE EXISTS {
-										   				 MATCH (a:person)-[]->(b:pet)
-										   				 WHERE b.name = 'Snoopy'
-										   				 RETURN c
-										   				 UNION
-										   				 MATCH (c:person)-[]->(d:person)
-										   				 RETURN c
-										   				 }
-										   RETURN (a) $$) AS (result agtype);
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									WHERE EXISTS {
+												  MATCH (a:person)-[]->(b:pet)
+												  WHERE b.name = 'Snoopy'
+												  RETURN c
+												  UNION
+												  MATCH (c:person)-[]->(d:person)
+												  RETURN c
+												 }
+									RETURN (a) $$) AS (result agtype);
 ERROR:  could not find rte for c
-LINE 5:                   RETURN c
-                                 ^
+LINE 5:               RETURN c
+                             ^
 --union, no returns
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
-										   WHERE EXISTS {
-										   				 MATCH (a:person)-[]->(b:pet)
-										   				 WHERE a.name = 'Charlie'
-										   				 UNION
-										   				 MATCH (c:person)-[]->(d:person)
-										   				}
-										   RETURN (a) $$) AS (result agtype);
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									WHERE EXISTS {
+												  MATCH (a:person)-[]->(b:pet)
+												  WHERE a.name = 'Charlie'
+												  UNION
+												  MATCH (c:person)-[]->(d:person)
+												 }
+									RETURN (a) $$) AS (result agtype);
                                               result                                               
 ---------------------------------------------------------------------------------------------------
  {"id": 844424930131969, "label": "person", "properties": {"age": 32, "name": "Briggite"}}::vertex
@@ -176,32 +193,33 @@ SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
 (7 rows)
 
 --union, mismatched returns, should fail
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
-										   WHERE EXISTS {
-										   				 MATCH (a:person)-[]->(b:pet)
-										   				 WHERE a.name = 'Faye'
-										   				 RETURN a
-										   				 UNION
-										   				 MATCH (c:person)-[]->(d:person)
-										   				}
-										   RETURN (a) $$) AS (result agtype);
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									WHERE EXISTS {
+												  MATCH (a:person)-[]->(b:pet)
+												  WHERE a.name = 'Faye'
+												  RETURN a
+												  UNION
+												  MATCH (c:person)-[]->(d:person)
+												 }
+									RETURN (a) $$) AS (result agtype);
 ERROR:  syntax error at or near "}"
-LINE 8:                  }
-                         ^
+LINE 8:              }
+                     ^
 --nesting
---EXISTS subquery is currently implemented naively, without constraints in the
---subquery. the results of this regression test may change upon implementation
+--EXISTS subquery is currently implemented with postgres subqueries, which do not
+--constrain the outer query results. the results of this regression test may change
+--upon implementation
 --TODO: implement inner subquery constraints
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
-										   WHERE EXISTS {
-										   				 MATCH (b:person)
-										   				 WHERE EXISTS {
-										   				 			   MATCH (c:person)
-										   				 			   WHERE c.name = 'Takeshi'
-										   				 			   RETURN c
-										   				 			  }
-										   				 }
-										   RETURN (a) $$) AS (result agtype);
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									WHERE EXISTS {
+												  MATCH (b:person)
+												  WHERE EXISTS {
+																MATCH (c:person)
+																WHERE c.name = 'Takeshi'
+																RETURN c
+															   }
+												 }
+									RETURN (a) $$) AS (result agtype);
                                               result                                               
 ---------------------------------------------------------------------------------------------------
  {"id": 844424930131969, "label": "person", "properties": {"age": 32, "name": "Briggite"}}::vertex
@@ -214,19 +232,20 @@ SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
 (7 rows)
 
 --nesting, accessing var in outer scope
---EXISTS subquery is currently implemented naively, without constraints in the
---subquery. the results of this regression test may change upon implementation
+--EXISTS subquery is currently implemented with postgres subqueries, which do not
+--constrain the outer query results. the results of this regression test may change
+--upon implementation
 --TODO: implement inner subquery constraints
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
-										   WHERE EXISTS {
-										   				 MATCH (b:person)
-										   				 WHERE EXISTS {
-										   				 			   MATCH (c:person)
-										   				 			   WHERE b = c
-										   				 			   RETURN c
-										   				 			  }
-										   				 }
-										   RETURN (a) $$) AS (result agtype);
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									WHERE EXISTS {
+												  MATCH (b:person)
+												  WHERE EXISTS {
+																MATCH (c:person)
+																WHERE b = c
+																RETURN c
+															   }
+												 }
+									RETURN (a) $$) AS (result agtype);
                                               result                                               
 ---------------------------------------------------------------------------------------------------
  {"id": 844424930131969, "label": "person", "properties": {"age": 32, "name": "Briggite"}}::vertex
@@ -239,18 +258,19 @@ SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
 (7 rows)
 
 --nesting, accessing indirection in outer scope
---EXISTS subquery is currently implemented naively, without constraints in the
---subquery. the results of this regression test may change upon implementation
+--EXISTS subquery is currently implemented with postgres subqueries, which do not
+--constrain the outer query results. the results of this regression test may change
+--upon implementation
 --TODO: implement inner subquery constraints
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
 										   WHERE EXISTS {
-										   				 MATCH (b:person)
-										   				 WHERE EXISTS {
-										   				 			   MATCH (c:person)
-										   				 			   WHERE b.name = 'Takeshi'
-										   				 			   RETURN c
-										   				 			  }
-										   				 }
+														 MATCH (b:person)
+														 WHERE EXISTS {
+																	   MATCH (c:person)
+																	   WHERE b.name = 'Takeshi'
+																	   RETURN c
+																	  }
+														}
 										   RETURN (a) $$) AS (result agtype);
                                               result                                               
 ---------------------------------------------------------------------------------------------------
@@ -264,18 +284,19 @@ SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
 (7 rows)
 
 --nesting, accessing var 2+ levels up
---EXISTS subquery is currently implemented naively, without constraints in the
---subquery. the results of this regression test may change upon implementation
+--EXISTS subquery is currently implemented with postgres subqueries, which do not
+--constrain the outer query results. the results of this regression test may change
+--upon implementation
 --TODO: implement inner subquery constraints
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
 										   WHERE EXISTS {
-										   				 MATCH (b:person)
-										   				 WHERE EXISTS {
-										   				 			   MATCH (c:person)
-										   				 			   WHERE a.name = 'Takeshi'
-										   				 			   RETURN c
-										   				 			  }
-										   				 }
+														 MATCH (b:person)
+														 WHERE EXISTS {
+																	   MATCH (c:person)
+																	   WHERE a.name = 'Takeshi'
+																	   RETURN c
+																	  }
+														}
 										   RETURN (a) $$) AS (result agtype);
                                               result                                               
 ---------------------------------------------------------------------------------------------------
@@ -289,19 +310,20 @@ SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
 (7 rows)
 
 --nesting, accessing indirection 2+ levels up
---EXISTS subquery is currently implemented naively, without constraints in the
---subquery. the results of this regression test may change upon implementation
+--EXISTS subquery is currently implemented with postgres subqueries, which do not
+--constrain the outer query results. the results of this regression test may change
+--upon implementation
 --TODO: implement inner subquery constraints
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
-										   WHERE EXISTS {
-										   				 MATCH (b:person)
-										   				 WHERE EXISTS {
-										   				 			   MATCH (c:person)
-										   				 			   WHERE a = b
-										   				 			   RETURN c
-										   				 			  }
-										   				 }
-										   RETURN (a) $$) AS (result agtype);
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									WHERE EXISTS {
+												  MATCH (b:person)
+												  WHERE EXISTS {
+																MATCH (c:person)
+																WHERE a = b
+																RETURN c
+															  }
+												}
+									RETURN (a) $$) AS (result agtype);
                                               result                                               
 ---------------------------------------------------------------------------------------------------
  {"id": 844424930131969, "label": "person", "properties": {"age": 32, "name": "Briggite"}}::vertex
@@ -314,9 +336,9 @@ SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
 (7 rows)
 
 --EXISTS outside of WHERE
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person) 
-										   RETURN a, EXISTS {(a:person)-[]->(:pet)}
-										   $$) AS (a agtype, exists agtype);
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									RETURN a, EXISTS {(a:person)-[]->(:pet)}
+									$$) AS (a agtype, exists agtype);
                                                  a                                                 | exists 
 ---------------------------------------------------------------------------------------------------+--------
  {"id": 844424930131969, "label": "person", "properties": {"age": 32, "name": "Briggite"}}::vertex | false
@@ -329,27 +351,205 @@ SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
 (7 rows)
 
 --Var doesnt exist in outside scope, should fail
-SELECT * FROM cypher('exists_subquery', $$ RETURN 1, 
-										   		  EXISTS {
-									   					  MATCH (b:person)-[]->(:pet)
-									   					  RETURN a
-									   					 }
-										   $$) AS (a agtype, exists agtype);
+SELECT * FROM cypher('subquery', $$ RETURN 1,
+										   EXISTS {
+												   MATCH (b:person)-[]->(:pet)
+												   RETURN a
+												  }
+									$$) AS (a agtype, exists agtype);
 ERROR:  could not find rte for a
-LINE 4:                    RETURN a
-                                  ^
+LINE 4:                RETURN a
+                              ^
+--- COUNT
+--count pattern subquery in where
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									WHERE COUNT {(a:person)} > 1
+									RETURN (a) $$) AS (result agtype);
+                                              result                                               
+---------------------------------------------------------------------------------------------------
+ {"id": 844424930131969, "label": "person", "properties": {"age": 32, "name": "Briggite"}}::vertex
+ {"id": 844424930131970, "label": "person", "properties": {"age": 28, "name": "Takeshi"}}::vertex
+ {"id": 844424930131971, "label": "person", "properties": {"age": 25, "name": "Faye"}}::vertex
+ {"id": 844424930131972, "label": "person", "properties": {"age": 34, "name": "Tony"}}::vertex
+ {"id": 844424930131973, "label": "person", "properties": {"age": 33, "name": "Valerie"}}::vertex
+ {"id": 844424930131974, "label": "person", "properties": {"age": 6, "name": "Calvin"}}::vertex
+ {"id": 844424930131975, "label": "person", "properties": {"age": 8, "name": "Charlie"}}::vertex
+(7 rows)
+
+--count pattern in return
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									RETURN COUNT{(a)-[]->(:pet)} $$) AS (result agtype);
+ result 
+--------
+ 0
+ 0
+ 0
+ 0
+ 0
+ 1
+ 1
+(7 rows)
+
+--count pattern with WHERE
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									RETURN COUNT{(a)-[]->(b:pet) WHERE b.name = 'Hobbes'} $$) AS (result agtype);
+ result 
+--------
+ 0
+ 0
+ 0
+ 0
+ 0
+ 1
+ 0
+(7 rows)
+
+--solo match in where
+--COUNT subquery is currently implemented with postgres subqueries, which do not
+--constrain the outer query results. the results of this regression test may change
+--upon implementation
+--TODO: implement inner subquery constraints
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									WHERE COUNT{MATCH (a:person)-[]-(:pet)} > 1 RETURN a $$) AS (result agtype);
+                                              result                                               
+---------------------------------------------------------------------------------------------------
+ {"id": 844424930131969, "label": "person", "properties": {"age": 32, "name": "Briggite"}}::vertex
+ {"id": 844424930131970, "label": "person", "properties": {"age": 28, "name": "Takeshi"}}::vertex
+ {"id": 844424930131971, "label": "person", "properties": {"age": 25, "name": "Faye"}}::vertex
+ {"id": 844424930131972, "label": "person", "properties": {"age": 34, "name": "Tony"}}::vertex
+ {"id": 844424930131973, "label": "person", "properties": {"age": 33, "name": "Valerie"}}::vertex
+ {"id": 844424930131974, "label": "person", "properties": {"age": 6, "name": "Calvin"}}::vertex
+ {"id": 844424930131975, "label": "person", "properties": {"age": 8, "name": "Charlie"}}::vertex
+(7 rows)
+
+--solo match in return
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									RETURN COUNT{MATCH (a)} $$) AS (result agtype);
+ result 
+--------
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+(7 rows)
+
+--match return in where
+--COUNT subquery is currently implemented with postgres subqueries, which do not
+--constrain the outer query results. the results of this regression test may change
+--upon implementation
+--TODO: implement inner subquery constraints
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									WHERE COUNT{MATCH (a) RETURN a} > 1 RETURN a $$) AS (result agtype);
+                                              result                                               
+---------------------------------------------------------------------------------------------------
+ {"id": 844424930131969, "label": "person", "properties": {"age": 32, "name": "Briggite"}}::vertex
+ {"id": 844424930131970, "label": "person", "properties": {"age": 28, "name": "Takeshi"}}::vertex
+ {"id": 844424930131971, "label": "person", "properties": {"age": 25, "name": "Faye"}}::vertex
+ {"id": 844424930131972, "label": "person", "properties": {"age": 34, "name": "Tony"}}::vertex
+ {"id": 844424930131973, "label": "person", "properties": {"age": 33, "name": "Valerie"}}::vertex
+ {"id": 844424930131974, "label": "person", "properties": {"age": 6, "name": "Calvin"}}::vertex
+ {"id": 844424930131975, "label": "person", "properties": {"age": 8, "name": "Charlie"}}::vertex
+(7 rows)
+
+--match return in return
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									RETURN COUNT{MATCH (a) RETURN a} $$) AS (result agtype);
+ result 
+--------
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+ 1
+(7 rows)
+
+--match where return
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									RETURN COUNT{MATCH (a)
+												 WHERE a.age > 25
+												 RETURN a} $$) AS (result agtype);
+ result 
+--------
+ 1
+ 1
+ 0
+ 1
+ 1
+ 0
+ 0
+(7 rows)
+
+--counting number of relationships per node
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									RETURN a.name, COUNT{(a)-[]-()} $$) AS (name agtype, count agtype);
+    name    | count 
+------------+-------
+ "Briggite" | 1
+ "Takeshi"  | 1
+ "Faye"     | 1
+ "Tony"     | 2
+ "Valerie"  | 1
+ "Calvin"   | 1
+ "Charlie"  | 1
+(7 rows)
+
+--nested counts
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									RETURN a.name, COUNT{MATCH (a) WHERE COUNT {MATCH (a) WHERE a.age < 23 RETURN a } > 0 } $$) AS (name agtype, count agtype);
+    name    | count 
+------------+-------
+ "Briggite" | 0
+ "Takeshi"  | 0
+ "Faye"     | 0
+ "Tony"     | 0
+ "Valerie"  | 0
+ "Calvin"   | 1
+ "Charlie"  | 1
+(7 rows)
+
+--incorrect variable reference
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									RETURN a.name, COUNT{MATCH (a) RETURN b} $$) AS (name agtype, count agtype);
+ERROR:  could not find rte for b
+LINE 2:          RETURN a.name, COUNT{MATCH (a) RETURN b} $$) AS (na...
+                                                       ^
+--incorrect nested variable reference
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									RETURN a.name, COUNT{MATCH (a) WHERE COUNT {MATCH (b) RETURN b } > 1 RETURN b} $$) AS (name agtype count agtype);
+ERROR:  syntax error at or near "count"
+LINE 2: ... (b) RETURN b } > 1 RETURN b} $$) AS (name agtype count agty...
+                                                             ^
+--count nested with exists
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									RETURN a.name, COUNT{MATCH (a) WHERE EXISTS {MATCH (a) RETURN a }} $$) AS (name agtype, count agtype);
+    name    | count 
+------------+-------
+ "Briggite" | 1
+ "Takeshi"  | 1
+ "Faye"     | 1
+ "Tony"     | 1
+ "Valerie"  | 1
+ "Calvin"   | 1
+ "Charlie"  | 1
+(7 rows)
+
 --
 -- Cleanup
 --
-SELECT * FROM drop_graph('exists_subquery', true);
+SELECT * FROM drop_graph('subquery', true);
 NOTICE:  drop cascades to 6 other objects
-DETAIL:  drop cascades to table exists_subquery._ag_label_vertex
-drop cascades to table exists_subquery._ag_label_edge
-drop cascades to table exists_subquery.person
-drop cascades to table exists_subquery.knows
-drop cascades to table exists_subquery.loved
-drop cascades to table exists_subquery.pet
-NOTICE:  graph "exists_subquery" has been dropped
+DETAIL:  drop cascades to table subquery._ag_label_vertex
+drop cascades to table subquery._ag_label_edge
+drop cascades to table subquery.person
+drop cascades to table subquery.knows
+drop cascades to table subquery.loved
+drop cascades to table subquery.pet
+NOTICE:  graph "subquery" has been dropped
  drop_graph 
 ------------
  

--- a/regress/sql/cypher_subquery.sql
+++ b/regress/sql/cypher_subquery.sql
@@ -1,200 +1,275 @@
 LOAD 'age';
 SET search_path TO ag_catalog;
 
-SELECT * FROM create_graph('exists_subquery');
+SELECT * FROM create_graph('subquery');
 
-SELECT * FROM cypher('exists_subquery', $$ 
-										CREATE (:person {name: "Briggite", age: 32})-[:knows]->(:person {name: "Takeshi", age: 28}),
-											   (:person {name: "Faye", age: 25})-[:knows]->(:person {name: "Tony", age: 34})-[:loved]->(:person {name : "Valerie", age: 33}),
-											   (:person {name: "Calvin", age: 6})-[:knows]->(:pet {name: "Hobbes"}),
-											   (:person {name: "Charlie", age: 8})-[:knows]->(:pet {name : "Snoopy"})
-										$$) AS (result agtype);
+SELECT * FROM cypher('subquery', $$
+								   CREATE (:person {name: "Briggite", age: 32})-[:knows]->(:person {name: "Takeshi", age: 28}),
+										  (:person {name: "Faye", age: 25})-[:knows]->(:person {name: "Tony", age: 34})-[:loved]->(:person {name : "Valerie", age: 33}),
+										  (:person {name: "Calvin", age: 6})-[:knows]->(:pet {name: "Hobbes"}),
+										  (:person {name: "Charlie", age: 8})-[:knows]->(:pet {name : "Snoopy"})
+								 $$) AS (result agtype);
 
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a) RETURN (a) $$) AS (result agtype);
+SELECT * FROM cypher('subquery', $$ MATCH (a) RETURN (a) $$) AS (result agtype);
 
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person) 
-										   WHERE EXISTS {(a:person)-[]->(:pet)}
-										   RETURN (a) $$) AS (result agtype);
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									WHERE EXISTS {(a:person)-[]->(:pet)}
+									RETURN (a) $$) AS (result agtype);
 --trying to use b when not defined, should fail
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person) 
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
 										   WHERE EXISTS {(a:person)-[]->(b:pet)}
 										   RETURN (a) $$) AS (result agtype);
 --query inside
---EXISTS subquery is currently implemented naively, without constraints in the
---subquery. the results of this regression test may change upon implementation
+--EXISTS subquery is currently implemented with postgres subqueries, which do not
+--constrain the outer query results. the results of this regression test may change
+--upon implementation
 --TODO: implement inner subquery constraints
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
-										   WHERE EXISTS {MATCH (a:person)-[]->(b:pet) RETURN b}
-										   RETURN (a) $$) AS (result agtype);
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									WHERE EXISTS {MATCH (a:person)-[]->(b:pet) RETURN b}
+									RETURN (a) $$) AS (result agtype);
 
 --repeat variable in match
---EXISTS subquery is currently implemented naively, without constraints in the
---subquery. the results of this regression test may change upon implementation
+--EXISTS subquery is currently implemented with postgres subqueries, which do not
+--constrain the outer query results. the results of this regression test may change
+--upon implementation
 --TODO: implement inner subquery constraints
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
-										   WHERE EXISTS {
-						   				 			     MATCH (a:person)
-						   				 			     WHERE a.name = 'Takeshi'
-						   				 			     RETURN a
-										   				 }
-										   RETURN (a) $$) AS (result agtype);
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									WHERE EXISTS {
+												  MATCH (a:person)
+												  WHERE a.name = 'Takeshi'
+												  RETURN a
+												 }
+									RETURN (a) $$) AS (result agtype);
 --query inside, with WHERE
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
-										   WHERE EXISTS {MATCH (a:person)-[]->(b:pet)
-										   				 WHERE b.name = 'Briggite'
-										   				 RETURN b}
-										   RETURN (a) $$) AS (result agtype);
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									WHERE EXISTS {MATCH (a:person)-[]->(b:pet)
+												  WHERE b.name = 'Briggite'
+												  RETURN b}
+									RETURN (a) $$) AS (result agtype);
 
 
 --no return
---EXISTS subquery is currently implemented naively, without constraints in the
---subquery. the results of this regression test may change upon implementation
+--EXISTS subquery is currently implemented with postgres subqueries, which do not
+--constrain the outer query results. the results of this regression test may change
+--upon implementation
 --TODO: implement inner subquery constraints
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
-										   WHERE EXISTS {MATCH (a:person)-[]->(b:pet)
-										   				 WHERE a.name = 'Calvin'}
-										   RETURN (a) $$) AS (result agtype);
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									WHERE EXISTS {MATCH (a:person)-[]->(b:pet)
+												  WHERE a.name = 'Calvin'}
+									RETURN (a) $$) AS (result agtype);
 
 --union
---EXISTS subquery is currently implemented naively, without constraints in the
---subquery. the results of this regression test may change upon implementation
+--EXISTS subquery is currently implemented with postgres subqueries, which do not
+--constrain the outer query results. the results of this regression test may change
+--upon implementation
 --TODO: implement inner subquery constraints
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
-										   WHERE EXISTS {
-										   				 MATCH (a:person)-[]->(b:pet)
-										   				 WHERE b.name = 'Hobbes'
-										   				 RETURN b
-										   				 UNION
-										   				 MATCH (c:person)-[]->(d:person)
-										   				 RETURN c
-										   				}
-										   RETURN (a) $$) AS (result agtype);
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									WHERE EXISTS {
+												  MATCH (a:person)-[]->(b:pet)
+												  WHERE b.name = 'Hobbes'
+												  RETURN b
+												  UNION
+												  MATCH (c:person)-[]->(d:person)
+												  RETURN c
+												 }
+									RETURN (a) $$) AS (result agtype);
 
 -- union, mismatched var, should fail
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
-										   WHERE EXISTS {
-										   				 MATCH (a:person)-[]->(b:pet)
-										   				 WHERE b.name = 'Snoopy'
-										   				 RETURN c
-										   				 UNION
-										   				 MATCH (c:person)-[]->(d:person)
-										   				 RETURN c
-										   				 }
-										   RETURN (a) $$) AS (result agtype);
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									WHERE EXISTS {
+												  MATCH (a:person)-[]->(b:pet)
+												  WHERE b.name = 'Snoopy'
+												  RETURN c
+												  UNION
+												  MATCH (c:person)-[]->(d:person)
+												  RETURN c
+												 }
+									RETURN (a) $$) AS (result agtype);
 
 --union, no returns
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
-										   WHERE EXISTS {
-										   				 MATCH (a:person)-[]->(b:pet)
-										   				 WHERE a.name = 'Charlie'
-										   				 UNION
-										   				 MATCH (c:person)-[]->(d:person)
-										   				}
-										   RETURN (a) $$) AS (result agtype);
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									WHERE EXISTS {
+												  MATCH (a:person)-[]->(b:pet)
+												  WHERE a.name = 'Charlie'
+												  UNION
+												  MATCH (c:person)-[]->(d:person)
+												 }
+									RETURN (a) $$) AS (result agtype);
 
 --union, mismatched returns, should fail
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
-										   WHERE EXISTS {
-										   				 MATCH (a:person)-[]->(b:pet)
-										   				 WHERE a.name = 'Faye'
-										   				 RETURN a
-										   				 UNION
-										   				 MATCH (c:person)-[]->(d:person)
-										   				}
-										   RETURN (a) $$) AS (result agtype);
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									WHERE EXISTS {
+												  MATCH (a:person)-[]->(b:pet)
+												  WHERE a.name = 'Faye'
+												  RETURN a
+												  UNION
+												  MATCH (c:person)-[]->(d:person)
+												 }
+									RETURN (a) $$) AS (result agtype);
 
 --nesting
---EXISTS subquery is currently implemented naively, without constraints in the
---subquery. the results of this regression test may change upon implementation
+--EXISTS subquery is currently implemented with postgres subqueries, which do not
+--constrain the outer query results. the results of this regression test may change
+--upon implementation
 --TODO: implement inner subquery constraints
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
-										   WHERE EXISTS {
-										   				 MATCH (b:person)
-										   				 WHERE EXISTS {
-										   				 			   MATCH (c:person)
-										   				 			   WHERE c.name = 'Takeshi'
-										   				 			   RETURN c
-										   				 			  }
-										   				 }
-										   RETURN (a) $$) AS (result agtype);
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									WHERE EXISTS {
+												  MATCH (b:person)
+												  WHERE EXISTS {
+																MATCH (c:person)
+																WHERE c.name = 'Takeshi'
+																RETURN c
+															   }
+												 }
+									RETURN (a) $$) AS (result agtype);
 
 --nesting, accessing var in outer scope
---EXISTS subquery is currently implemented naively, without constraints in the
---subquery. the results of this regression test may change upon implementation
+--EXISTS subquery is currently implemented with postgres subqueries, which do not
+--constrain the outer query results. the results of this regression test may change
+--upon implementation
 --TODO: implement inner subquery constraints
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
-										   WHERE EXISTS {
-										   				 MATCH (b:person)
-										   				 WHERE EXISTS {
-										   				 			   MATCH (c:person)
-										   				 			   WHERE b = c
-										   				 			   RETURN c
-										   				 			  }
-										   				 }
-										   RETURN (a) $$) AS (result agtype);
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									WHERE EXISTS {
+												  MATCH (b:person)
+												  WHERE EXISTS {
+																MATCH (c:person)
+																WHERE b = c
+																RETURN c
+															   }
+												 }
+									RETURN (a) $$) AS (result agtype);
 
 --nesting, accessing indirection in outer scope
---EXISTS subquery is currently implemented naively, without constraints in the
---subquery. the results of this regression test may change upon implementation
+--EXISTS subquery is currently implemented with postgres subqueries, which do not
+--constrain the outer query results. the results of this regression test may change
+--upon implementation
 --TODO: implement inner subquery constraints
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
 										   WHERE EXISTS {
-										   				 MATCH (b:person)
-										   				 WHERE EXISTS {
-										   				 			   MATCH (c:person)
-										   				 			   WHERE b.name = 'Takeshi'
-										   				 			   RETURN c
-										   				 			  }
-										   				 }
+														 MATCH (b:person)
+														 WHERE EXISTS {
+																	   MATCH (c:person)
+																	   WHERE b.name = 'Takeshi'
+																	   RETURN c
+																	  }
+														}
 										   RETURN (a) $$) AS (result agtype);
 
 --nesting, accessing var 2+ levels up
---EXISTS subquery is currently implemented naively, without constraints in the
---subquery. the results of this regression test may change upon implementation
+--EXISTS subquery is currently implemented with postgres subqueries, which do not
+--constrain the outer query results. the results of this regression test may change
+--upon implementation
 --TODO: implement inner subquery constraints
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
 										   WHERE EXISTS {
-										   				 MATCH (b:person)
-										   				 WHERE EXISTS {
-										   				 			   MATCH (c:person)
-										   				 			   WHERE a.name = 'Takeshi'
-										   				 			   RETURN c
-										   				 			  }
-										   				 }
+														 MATCH (b:person)
+														 WHERE EXISTS {
+																	   MATCH (c:person)
+																	   WHERE a.name = 'Takeshi'
+																	   RETURN c
+																	  }
+														}
 										   RETURN (a) $$) AS (result agtype);
 
 --nesting, accessing indirection 2+ levels up
---EXISTS subquery is currently implemented naively, without constraints in the
---subquery. the results of this regression test may change upon implementation
+--EXISTS subquery is currently implemented with postgres subqueries, which do not
+--constrain the outer query results. the results of this regression test may change
+--upon implementation
 --TODO: implement inner subquery constraints
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person)
-										   WHERE EXISTS {
-										   				 MATCH (b:person)
-										   				 WHERE EXISTS {
-										   				 			   MATCH (c:person)
-										   				 			   WHERE a = b
-										   				 			   RETURN c
-										   				 			  }
-										   				 }
-										   RETURN (a) $$) AS (result agtype);
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									WHERE EXISTS {
+												  MATCH (b:person)
+												  WHERE EXISTS {
+																MATCH (c:person)
+																WHERE a = b
+																RETURN c
+															  }
+												}
+									RETURN (a) $$) AS (result agtype);
 
 --EXISTS outside of WHERE
-SELECT * FROM cypher('exists_subquery', $$ MATCH (a:person) 
-										   RETURN a, EXISTS {(a:person)-[]->(:pet)}
-										   $$) AS (a agtype, exists agtype);
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									RETURN a, EXISTS {(a:person)-[]->(:pet)}
+									$$) AS (a agtype, exists agtype);
 
 --Var doesnt exist in outside scope, should fail
-SELECT * FROM cypher('exists_subquery', $$ RETURN 1, 
-										   		  EXISTS {
-									   					  MATCH (b:person)-[]->(:pet)
-									   					  RETURN a
-									   					 }
-										   $$) AS (a agtype, exists agtype);
+SELECT * FROM cypher('subquery', $$ RETURN 1,
+										   EXISTS {
+												   MATCH (b:person)-[]->(:pet)
+												   RETURN a
+												  }
+									$$) AS (a agtype, exists agtype);
+
+--- COUNT
+
+--count pattern subquery in where
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									WHERE COUNT {(a:person)} > 1
+									RETURN (a) $$) AS (result agtype);
+
+--count pattern in return
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									RETURN COUNT{(a)-[]->(:pet)} $$) AS (result agtype);
+
+--count pattern with WHERE
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									RETURN COUNT{(a)-[]->(b:pet) WHERE b.name = 'Hobbes'} $$) AS (result agtype);
+
+--solo match in where
+--COUNT subquery is currently implemented with postgres subqueries, which do not
+--constrain the outer query results. the results of this regression test may change
+--upon implementation
+--TODO: implement inner subquery constraints
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									WHERE COUNT{MATCH (a:person)-[]-(:pet)} > 1 RETURN a $$) AS (result agtype);
+
+--solo match in return
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									RETURN COUNT{MATCH (a)} $$) AS (result agtype);
+
+--match return in where
+--COUNT subquery is currently implemented with postgres subqueries, which do not
+--constrain the outer query results. the results of this regression test may change
+--upon implementation
+--TODO: implement inner subquery constraints
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									WHERE COUNT{MATCH (a) RETURN a} > 1 RETURN a $$) AS (result agtype);
+
+--match return in return
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									RETURN COUNT{MATCH (a) RETURN a} $$) AS (result agtype);
+
+--match where return
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									RETURN COUNT{MATCH (a)
+												 WHERE a.age > 25
+												 RETURN a} $$) AS (result agtype);
+
+--counting number of relationships per node
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									RETURN a.name, COUNT{(a)-[]-()} $$) AS (name agtype, count agtype);
+
+--nested counts
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									RETURN a.name, COUNT{MATCH (a) WHERE COUNT {MATCH (a) WHERE a.age < 23 RETURN a } > 0 } $$) AS (name agtype, count agtype);
+
+--incorrect variable reference
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									RETURN a.name, COUNT{MATCH (a) RETURN b} $$) AS (name agtype, count agtype);
+
+--incorrect nested variable reference
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									RETURN a.name, COUNT{MATCH (a) WHERE COUNT {MATCH (b) RETURN b } > 1 RETURN b} $$) AS (name agtype count agtype);
+
+
+--count nested with exists
+SELECT * FROM cypher('subquery', $$ MATCH (a:person)
+									RETURN a.name, COUNT{MATCH (a) WHERE EXISTS {MATCH (a) RETURN a }} $$) AS (name agtype, count agtype);
 
 --
 -- Cleanup
 --
-SELECT * FROM drop_graph('exists_subquery', true);
+SELECT * FROM drop_graph('subquery', true);
 
 --
 -- End of tests

--- a/src/backend/parser/cypher_gram.y
+++ b/src/backend/parser/cypher_gram.y
@@ -100,6 +100,7 @@
 
 %type <list> subquery_stmt subquery_stmt_with_return subquery_stmt_no_return
              single_subquery single_subquery_no_return subquery_part_init
+%type <node> subquery_pattern
 
 /* RETURN and WITH clause */
 %type <node> return return_item sort_item skip_opt limit_opt with
@@ -682,6 +683,31 @@ single_subquery_no_return:
 
             $$ = list_concat($1, lappend($2, n));
 
+        }
+        | subquery_pattern
+        {
+            ColumnRef *cr;
+            ResTarget *rt;
+            cypher_return *n;
+
+            cr = makeNode(ColumnRef);
+            cr->fields = list_make1(makeNode(A_Star));
+            cr->location = @1;
+
+            rt = makeNode(ResTarget);
+            rt->name = NULL;
+            rt->indirection = NIL;
+            rt->val = (Node *)cr;
+            rt->location = @1;
+
+            n = make_ag_node(cypher_return);
+            n->distinct = false;
+            n->items = list_make1((Node *)rt);
+            n->order_by = NULL;
+            n->skip = NULL;
+            n->limit = NULL;
+
+            $$ = lappend(list_make1($1), n);
         }
     ;
 
@@ -1896,32 +1922,7 @@ expr_func_subexpr:
     ;
 
 expr_subquery:
-    EXISTS '{' anonymous_path '}'
-        {
-            /*
-             * EXISTS subquery with an anonymous path is almost
-             * the same as a EXISTS sub pattern, so we reuse that
-             * logic here to simplify more complex subquery transformations.
-             * TODO: Add WHERE clause support for anonymous paths in functions.
-             */
-
-            cypher_sub_pattern *sub;
-            SubLink    *n;
-
-            sub = make_ag_node(cypher_sub_pattern);
-            sub->kind = CSP_EXISTS;
-            sub->pattern = list_make1($3);
-
-            n = makeNode(SubLink);
-            n->subLinkType = EXISTS_SUBLINK;
-            n->subLinkId = 0;
-            n->testexpr = NULL;
-            n->operName = NIL;
-            n->subselect = (Node *) sub;
-            n->location = @1;
-            $$ = (Node *)node_to_agtype((Node *)n, "boolean", @1);
-        }
-    | EXISTS '{' subquery_stmt '}'
+    EXISTS '{' subquery_stmt '}'
         {
             cypher_sub_query *sub;
             SubLink    *n;
@@ -1939,6 +1940,76 @@ expr_subquery:
             n->subselect = (Node *) sub;
             n->location = @1;
             $$ = (Node *)node_to_agtype((Node *)n, "boolean", @1);
+        }
+    | func_name '{' subquery_stmt '}'
+        {
+            List *func_name = $1;
+            if(list_length(func_name) != 1)
+            {
+                ereport(ERROR,
+                        (errcode(ERRCODE_SYNTAX_ERROR),
+                         errmsg("Invalid subquery function"),
+                         ag_scanner_errposition(@3, scanner)));
+            }
+            else
+            {
+                char *name;
+
+                name = ((String*)linitial(func_name))->sval;
+
+                if (pg_strcasecmp(name, "count") == 0)
+                {
+                    SubLink    *n;
+                    cypher_sub_query *sub;
+                    cypher_return *r;
+                    ResTarget *rt;
+                    FuncCall *func;
+
+                    func = (FuncCall *)make_star_function_expr($1, NIL, @1);
+
+                    rt = makeNode(ResTarget);
+                    rt->name = NULL;
+                    rt->indirection = NIL;
+                    rt->val = (Node *)func;
+                    rt->location = @1;
+
+                    r = make_ag_node(cypher_return);
+                    r->items = list_make1((Node *)rt);
+
+                    sub = make_ag_node(cypher_sub_query);
+                    sub->query = lappend($3, r);
+
+                    n = makeNode(SubLink);
+                    n->subLinkType = EXPR_SUBLINK;
+                    n->subLinkId = 0;
+                    n->testexpr = NULL;
+                    n->operName = NIL;
+                    n->subselect = (Node *)sub;
+                    n->location = @1;
+
+                    $$ = (Node *) n;
+                }
+                else
+                {
+                    ereport(ERROR,
+                            (errcode(ERRCODE_SYNTAX_ERROR),
+                             errmsg("Invalid subquery function"),
+                             ag_scanner_errposition(@3, scanner)));
+                }
+            }
+        }
+    ;
+
+subquery_pattern:
+    anonymous_path where_opt
+        {
+            cypher_match *n;
+
+            n = make_ag_node(cypher_match);
+            n->pattern = list_make1($1);
+            n->where = $2;
+
+            $$ = (Node *)n;
         }
     ;
 


### PR DESCRIPTION
Implements a version of COUNT subquery that evaluates the underlying subquery according to Postgres subquery specifications.

Modifies the grammar to accept all valid input for both COUNT and EXISTS subqueries.

Add regression tests related to COUNT

Modify the subquery regression tests to accomodate changes introduced in this update.