### PR TITLE
Fix bogus failure of test expr

### DIFF
--- a/regress/expected/expr.out
+++ b/regress/expected/expr.out
@@ -19,6 +19,7 @@
 SET extra_float_digits = 0;
 LOAD 'age';
 SET search_path TO ag_catalog;
+SET force_parallel_mode TO regress;
 SELECT * FROM create_graph('expr');
 NOTICE:  graph "expr" has been created
  create_graph 
@@ -7263,7 +7264,7 @@ SELECT * FROM cypher('keys', $$MATCH (v) RETURN keys(v)$$) AS (vertex_keys agtyp
  ["age", "job", "name"]
 (4 rows)
 
-SELECT * FROM cypher('keys', $$MATCH ()-[e]-() RETURN keys(e)$$) AS (edge_keys agtype);
+SELECT * FROM cypher('keys', $$MATCH ()-[e]-() RETURN keys(e) ORDER BY e DESC $$) AS (edge_keys agtype);
  edge_keys 
 -----------
  []

--- a/regress/sql/expr.sql
+++ b/regress/sql/expr.sql
@@ -20,7 +20,7 @@
 SET extra_float_digits = 0;
 LOAD 'age';
 SET search_path TO ag_catalog;
-
+SET force_parallel_mode TO regress;
 SELECT * FROM create_graph('expr');
 
 --
@@ -3024,7 +3024,7 @@ SELECT * FROM cypher('keys', $$CREATE ({name: 'keiko fuji', age: 62, job: 'singe
 SELECT * FROM cypher('keys', $$MATCH (a),(b) WHERE a.name = 'hikaru utada' AND b.name = 'alexander guy cook' CREATE (a)-[:collaborated_with {song:"one last kiss"}]->(b)$$) AS (result agtype);
 SELECT * FROM cypher('keys', $$MATCH (a),(b) WHERE a.name = 'hikaru utada' AND b.name = 'keiko fuji' CREATE (a)-[:knows]->(b)$$) AS (result agtype);
 SELECT * FROM cypher('keys', $$MATCH (v) RETURN keys(v)$$) AS (vertex_keys agtype);
-SELECT * FROM cypher('keys', $$MATCH ()-[e]-() RETURN keys(e)$$) AS (edge_keys agtype);
+SELECT * FROM cypher('keys', $$MATCH ()-[e]-() RETURN keys(e) ORDER BY e DESC $$) AS (edge_keys agtype);
 SELECT * FROM cypher('keys', $$RETURN keys({a:1,b:'two',c:[1,2,3]})$$) AS (keys agtype);
 
 --should return empty list


### PR DESCRIPTION
All discussions were conducted in #1439 
Changes:

1) force_parallel_mode was set to 'regress' to avoid "CONTEXT: parallel worker" message appear
2) fixed unsorted output in the specified query