### PR TITLE
Add PGXN release workflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+.gitignore export-ignore
+.gitattributes export-ignore
+.github export-ignore
+dockerignore export-ignore

--- a/.github/workflows/pgxn-release.yml
+++ b/.github/workflows/pgxn-release.yml
@@ -1,0 +1,20 @@
+name: 🚀 Release on PGXN
+on:
+  push:
+    # Release on semantic version tag.
+    tags: ['v[0-9]+.[0-9]+.[0-9]+']
+jobs:
+  release:
+    name: Release on PGXN
+    runs-on: ubuntu-latest
+    container: pgxn/pgxn-tools
+    steps:
+    - name: Check out the repo
+      uses: actions/checkout@v4
+    - name: Bundle the Release
+      run: pgxn-bundle
+    - name: Release on PGXN
+      env:
+        PGXN_USERNAME: ${{ secrets.PGXN_USERNAME }}
+        PGXN_PASSWORD: ${{ secrets.PGXN_PASSWORD }}
+      run: pgxn-release

--- a/META.json
+++ b/META.json
@@ -1,24 +1,24 @@
 {
    "name": "ApacheAGE",
-   "abstract": "Apache AGE is a PostgreSQL Extension that provides graph database functionality",
-   "description": "Apache AGE is a PostgreSQL Extension that provides graph database functionality. AGE is an acronym for A Graph Extension, and is inspired by Bitnine's fork of PostgreSQL 10, AgensGraph, which is a multi-model database. The goal of the project is to create single storage that can handle both relational and graph model data so that users can use standard ANSI SQL along with openCypher, the Graph query language. A graph consists of a set of vertices (also called nodes) and edges, where each individual vertex and edge possesses a map of properties. A vertex is the basic object of a graph, that can exist independently of everything else in the graph. An edge creates a directed connection between two vertices. A graph database is simply composed of vertices and edges. This type of database is useful when the meaning is in the relationships between the data. Relational databases can easily handle direct relationships, but indirect relationships are more difficult to deal with in relational databases. A graph database stores relationship information as a first-class entity. Apache AGE gives you the best of both worlds, simultaneously.",
-   "version": "1.3.0",
+   "abstract": "Graph database functionality for PostgreSQL",
+   "description": "Apache AGE is a PostgreSQL Extension that provides graph database functionality. The goal of the project is to create single storage that can handle both relational and graph model data so that users can use standard ANSI SQL along with openCypher, the Graph query language.",
+   "version": "1.5.0",
    "maintainer": [
       "users@age.apache.org"
    ],
    "license": "apache_2_0",
    "provides": {
-      "ApacheAGE": {
+      "age": {
          "abstract": "Apache AGE is a PostgreSQL Extension that provides graph database functionality",
-         "file": "age--1.3.0.sql",
+         "file": "age--1.5.0.sql",
          "docfile": "README.md",
-         "version": "1.3.0"
+         "version": "1.5.0"
       }
    },
    "prereqs": {
       "runtime": {
          "requires": {
-            "PostgreSQL": "14.0.0"
+            "PostgreSQL": "11.0.0"
          }
       }
    },

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,14 @@
 # specific language governing permissions and limitations
 # under the License.
 
-MODULE_big = age
+MODULE_big   = age
+EXTENSION    = $(MODULE_big)
+EXTVERSION   = $(shell grep -m 1 '[[:space:]]\{6\}"version":' META.json | \
+               sed -e 's/[[:space:]]*"version":[[:space:]]*"\([^"]*\)",\{0,1\}/\1/')
+DISTVERSION  = $(shell grep -m 1 '[[:space:]]\{3\}"version":' META.json | \
+               sed -e 's/[[:space:]]*"version":[[:space:]]*"\([^"]*\)",\{0,1\}/\1/')
 
-age_sql = age--1.5.0.sql
+age_sql = age--$(DISTVERSION).sql
 
 OBJS = src/backend/age.o \
        src/backend/catalog/ag_catalog.o \
@@ -72,8 +77,6 @@ OBJS = src/backend/age.o \
        src/backend/utils/load/libcsv.o \
        src/backend/utils/name_validation.o \
        src/backend/utils/ag_guc.o
-
-EXTENSION = age
 
 # to allow cleaning of previous (old) age--.sql files
 all_age_sql = $(shell find . -maxdepth 1 -type f -regex './age--[0-9]+\.[0-9]+\.[0-9]+\.sql')
@@ -149,3 +152,6 @@ $(age_sql):
 src/backend/parser/ag_scanner.c: FLEX_NO_BACKUP=yes
 
 installcheck: export LC_COLLATE=C
+
+dist:
+	git archive --format zip --prefix=$(EXTENSION)-$(DISTVERSION)/ -o $(EXTENSION)-$(DISTVERSION).zip HEAD


### PR DESCRIPTION
It's triggered by a semver tag. I don't see any tags on this repo, but do notice that the [version on PGXN](https://pgxn.org/dist/apacheage/) appears to be a couple versions back. Use this workflow if you'd like to automate its release; change the `on` triggers to trigger a release by some other means.

Be sure to add workflow secrets to this project named `PGXN_USERNAME` and `PGXN_PASSWORD` to allow it to authenticate to publish the extension.

Other stuff:

* Add `.gitattributes` so that the contents of `.github` and `.git` are excluded from the exported archive
* Fix the extension name in the `META.json` file to the actual extension name (same as the control file name)
* Updated the version in the `META.json` and shortened the abstract and description a bit (otherwise they take up a lot of space on the [PGXN page](https://pgxn.org/dist/apacheage/).
* Read the versions from the `META.json` file and set the extension name from `MODULE_big`.
* Add a `dist` make target to produce a zip file to manually upload to PGXN.