### PR TITLE
[WIP] Proof of concept for view-backed verticies and edges

### DIFF
--- a/sql/age_main.sql
+++ b/sql/age_main.sql
@@ -110,6 +110,16 @@ CREATE FUNCTION ag_catalog.create_elabel(graph_name name, label_name name)
     LANGUAGE c
     AS 'MODULE_PATHNAME';
 
+CREATE FUNCTION ag_catalog.create_computed_vlabel(graph_name name, label_name name, view_name name)
+    RETURNS void
+    LANGUAGE c
+    AS 'MODULE_PATHNAME';
+
+CREATE FUNCTION ag_catalog.create_computed_elabel(graph_name name, label_name name, view_name name)
+    RETURNS void
+    LANGUAGE c
+    AS 'MODULE_PATHNAME';    
+
 CREATE FUNCTION ag_catalog.alter_graph(graph_name name, operation cstring,
                                        new_value name)
     RETURNS void

--- a/src/include/commands/label_commands.h
+++ b/src/include/commands/label_commands.h
@@ -55,8 +55,15 @@
 void create_label(char *graph_name, char *label_name, char label_type,
                   List *parents);
 
+void create_computed_label(char *graph_name, char *label_name, char *rel_name, 
+                           char label_type);
+
 Datum create_vlabel(PG_FUNCTION_ARGS);
 
 Datum create_elabel(PG_FUNCTION_ARGS);
+
+Datum create_computed_vlabel(PG_FUNCTION_ARGS);
+
+Datum create_computed_elabel(PG_FUNCTION_ARGS);
 
 #endif


### PR DESCRIPTION
Hello,

This is a minimal POC for vertices and edges backed by views. I'm new to contributing to this repo, and there is still a lot to do, so thought I'd get feedback early in case this is not such a good idea...

There are a few use cases for this feature that come to mind:

- Creating labels backed by other data sources without explicitly loading the data into the graph
- Pre-computing complex queries in materialized views but still have a uniform way to query that data
- Ad-hoc categorization of multiple labels
- Filtered labels
- Labels derived from FDWs?

here is a little example that works so far:

```
CREATE EXTENSION age;
LOAD 'age';
SET search_path = ag_catalog, "$user", public;

SELECT create_graph('graphdb');

SELECT * FROM cypher('graphdb', $$
CREATE (:Person {name: 'Daedalus'})-[:FATHER_OF]->(:Person {name: 'Icarus'})
$$) AS (a agtype);

CREATE VIEW graphdb.filtered_person as
    SELECT p.* from graphdb."Person" p
	Where p.properties ->> 'name'::text = 'Daedalus'

SELECT create_computed_vlabel('graphdb', 'FilteredPerson', 'filtered_person');

SELECT * FROM cypher('graphdb', $$
match (a:FilteredPerson)
return a
$$) AS (a agtype);
```

There was really not that many changes to get the above working. But quite a bit more needs to get done such as validating the view's schema, error messages when attempting to write, handling dropping computed label, testing, etc.

It would be great to get some feedback about this idea in general.

Thanks,
John