### PR TITLE
Remove duplicate check for label validity

### DIFF
--- a/src/backend/commands/label_commands.c
+++ b/src/backend/commands/label_commands.c
@@ -265,12 +265,6 @@ void create_label(char *graph_name, char *label_name, char label_type,
                         errmsg("label name is invalid")));
     }
 
-    if (!is_valid_label(label_name, label_type))
-    {
-        ereport(ERROR, (errcode(ERRCODE_UNDEFINED_SCHEMA),
-                        errmsg("label name is invalid")));
-    }
-
     cache_data = search_graph_name_cache(graph_name);
     if (!cache_data)
     {


### PR DESCRIPTION
While looking through the code, I noticed a redundant check to see if the supplied label name was valid. This PR removed that redundant check.