### PR TITLE
[PG13] Added integer conversion in toBoolean functions

### DIFF
--- a/regress/expected/expr.out
+++ b/regress/expected/expr.out
@@ -3069,6 +3069,22 @@ $$) AS (toBoolean agtype);
  false
 (1 row)
 
+SELECT * FROM cypher('expr', $$
+    RETURN toBoolean(1)
+$$) AS (toBoolean agtype);
+ toboolean 
+-----------
+ true
+(1 row)
+
+SELECT * FROM cypher('expr', $$
+    RETURN toBoolean(0)
+$$) AS (toBoolean agtype);
+ toboolean 
+-----------
+ false
+(1 row)
+
 -- should return null
 SELECT * FROM cypher('expr', $$
     RETURN toBoolean("false_")
@@ -3087,10 +3103,6 @@ $$) AS (toBoolean agtype);
 (1 row)
 
 -- should fail
-SELECT * FROM cypher('expr', $$
-    RETURN toBoolean(1)
-$$) AS (toBoolean agtype);
-ERROR:  toBoolean() unsupported argument agtype 3
 SELECT * FROM cypher('expr', $$
     RETURN toBoolean()
 $$) AS (toBoolean agtype);
@@ -3121,6 +3133,14 @@ $$) AS (toBooleanList agtype);
     tobooleanlist    
 ---------------------
  [true, false, true]
+(1 row)
+
+SELECT * FROM cypher('expr', $$
+    RETURN toBooleanList([0,1,2,3,4])
+$$) AS (toBooleanList agtype);
+          tobooleanlist          
+---------------------------------
+ [false, true, true, true, true]
 (1 row)
 
 -- should return null
@@ -3154,14 +3174,6 @@ $$) AS (toBooleanList agtype);
  tobooleanlist 
 ---------------
  [null, null]
-(1 row)
-
-SELECT * FROM cypher('expr', $$
-    RETURN toBooleanList([0,1,2,3,4])
-$$) AS (toBooleanList agtype);
-         tobooleanlist          
---------------------------------
- [null, null, null, null, null]
 (1 row)
 
 -- should fail

--- a/regress/sql/expr.sql
+++ b/regress/sql/expr.sql
@@ -1349,6 +1349,12 @@ $$) AS (toBoolean agtype);
 SELECT * FROM cypher('expr', $$
     RETURN toBoolean("false")
 $$) AS (toBoolean agtype);
+SELECT * FROM cypher('expr', $$
+    RETURN toBoolean(1)
+$$) AS (toBoolean agtype);
+SELECT * FROM cypher('expr', $$
+    RETURN toBoolean(0)
+$$) AS (toBoolean agtype);
 -- should return null
 SELECT * FROM cypher('expr', $$
     RETURN toBoolean("false_")
@@ -1357,9 +1363,6 @@ SELECT * FROM cypher('expr', $$
     RETURN toBoolean(null)
 $$) AS (toBoolean agtype);
 -- should fail
-SELECT * FROM cypher('expr', $$
-    RETURN toBoolean(1)
-$$) AS (toBoolean agtype);
 SELECT * FROM cypher('expr', $$
     RETURN toBoolean()
 $$) AS (toBoolean agtype);
@@ -1377,6 +1380,10 @@ SELECT * FROM cypher('expr', $$
     RETURN toBooleanList(["True", "False", "True"])
 $$) AS (toBooleanList agtype);
 
+SELECT * FROM cypher('expr', $$
+    RETURN toBooleanList([0,1,2,3,4])
+$$) AS (toBooleanList agtype);
+
 -- should return null
 SELECT * FROM cypher('expr', $$
     RETURN toBooleanList([])
@@ -1392,10 +1399,6 @@ $$) AS (toBooleanList agtype);
 
 SELECT * FROM cypher('expr', $$
     RETURN toBooleanList([["A", "B"], ["C", "D"]])
-$$) AS (toBooleanList agtype);
-
-SELECT * FROM cypher('expr', $$
-    RETURN toBooleanList([0,1,2,3,4])
 $$) AS (toBooleanList agtype);
 
 -- should fail


### PR DESCRIPTION
Implemented explicit integer conversion to boolean in both toBoolean and toBooleanList functions. Also made corresponding changes to regression tests.

This PR makes the toBoolean() and toBooleanList() functions convert integers to boolean, as occurs in Neo4j.