### PR TITLE
Fix slow running regression test expr

### DIFF
--- a/regress/expected/expr.out
+++ b/regress/expected/expr.out
@@ -19,7 +19,6 @@
 SET extra_float_digits = 0;
 LOAD 'age';
 SET search_path TO ag_catalog;
-SET force_parallel_mode TO regress;
 SELECT * FROM create_graph('expr');
 NOTICE:  graph "expr" has been created
  create_graph 
@@ -7264,6 +7263,7 @@ SELECT * FROM cypher('keys', $$MATCH (v) RETURN keys(v)$$) AS (vertex_keys agtyp
  ["age", "job", "name"]
 (4 rows)
 
+SET force_parallel_mode TO regress;
 SELECT * FROM cypher('keys', $$MATCH ()-[e]-() RETURN keys(e) ORDER BY e DESC $$) AS (edge_keys agtype);
  edge_keys 
 -----------
@@ -7275,6 +7275,7 @@ SELECT * FROM cypher('keys', $$MATCH ()-[e]-() RETURN keys(e) ORDER BY e DESC $$
  ["song"]
 (6 rows)
 
+RESET force_parallel_mode;
 SELECT * FROM cypher('keys', $$RETURN keys({a:1,b:'two',c:[1,2,3]})$$) AS (keys agtype);
       keys       
 -----------------

--- a/regress/sql/expr.sql
+++ b/regress/sql/expr.sql
@@ -20,7 +20,6 @@
 SET extra_float_digits = 0;
 LOAD 'age';
 SET search_path TO ag_catalog;
-SET force_parallel_mode TO regress;
 SELECT * FROM create_graph('expr');
 
 --
@@ -3024,7 +3023,9 @@ SELECT * FROM cypher('keys', $$CREATE ({name: 'keiko fuji', age: 62, job: 'singe
 SELECT * FROM cypher('keys', $$MATCH (a),(b) WHERE a.name = 'hikaru utada' AND b.name = 'alexander guy cook' CREATE (a)-[:collaborated_with {song:"one last kiss"}]->(b)$$) AS (result agtype);
 SELECT * FROM cypher('keys', $$MATCH (a),(b) WHERE a.name = 'hikaru utada' AND b.name = 'keiko fuji' CREATE (a)-[:knows]->(b)$$) AS (result agtype);
 SELECT * FROM cypher('keys', $$MATCH (v) RETURN keys(v)$$) AS (vertex_keys agtype);
+SET force_parallel_mode TO regress;
 SELECT * FROM cypher('keys', $$MATCH ()-[e]-() RETURN keys(e) ORDER BY e DESC $$) AS (edge_keys agtype);
+RESET force_parallel_mode;
 SELECT * FROM cypher('keys', $$RETURN keys({a:1,b:'two',c:[1,2,3]})$$) AS (keys agtype);
 
 --should return empty list


### PR DESCRIPTION
Fixes slow runtime, introduced in PR #1678, of the regression test expr. This patch sets the config param `force_parallel_mode TO regress` only to a selective query rather than the entire expr.sql file.