### PR TITLE
Minor VLE and agtype_eq/ne performance updates (#1808)

### DIFF
--- a/src/include/catalog/ag_label.h
+++ b/src/include/catalog/ag_label.h
@@ -72,7 +72,6 @@ void delete_label(Oid relation);
 int32 get_label_id(const char *label_name, Oid graph_oid);
 Oid get_label_relation(const char *label_name, Oid graph_oid);
 char *get_label_relation_name(const char *label_name, Oid graph_oid);
-Oid get_label_oid(const char *label_name, Oid label_graph);
 char get_label_kind(const char *label_name, Oid label_graph);
 
 bool label_id_exists(Oid graph_oid, int32 label_id);


### PR DESCRIPTION
Integrated datum_image_hash and datum_image_eq to the logic for the VLE edge property datum match.

Additionally, both were added to agtype_eq and agtype_ne.

The hope is that, for large datums, these routines will improve performance.

No impact to regression tests.