### PR TITLE
Minor VLE and agtype_eq/ne performance updates (#1808)

### DIFF
--- a/src/backend/utils/adt/agtype_ops.c
+++ b/src/backend/utils/adt/agtype_ops.c
@@ -27,6 +27,7 @@
 #include <limits.h>
 
 #include "utils/agtype.h"
+#include "utils/datum.h"
 #include "utils/builtins.h"
 
 static agtype *agtype_concat_impl(agtype *agt1, agtype *agt2);
@@ -1009,9 +1010,22 @@ PG_FUNCTION_INFO_V1(agtype_eq);
 
 Datum agtype_eq(PG_FUNCTION_ARGS)
 {
-    agtype *agtype_lhs = AG_GET_ARG_AGTYPE_P(0);
-    agtype *agtype_rhs = AG_GET_ARG_AGTYPE_P(1);
-    bool result;
+    Datum lhs = PG_GETARG_DATUM(0);
+    Datum rhs = PG_GETARG_DATUM(1);
+    agtype *agtype_lhs = NULL;
+    agtype *agtype_rhs = NULL;
+    uint32 hash_lhs = datum_image_hash(lhs, false, -1);
+    uint32 hash_rhs = datum_image_hash(rhs, false, -1);
+    bool result = false;
+
+    if (hash_lhs == hash_rhs &&
+        datum_image_eq(lhs, rhs, false, -1))
+    {
+        PG_RETURN_BOOL(true);
+    }
+
+    agtype_lhs = DATUM_GET_AGTYPE_P(lhs);
+    agtype_rhs = DATUM_GET_AGTYPE_P(rhs);
 
     result = (compare_agtype_containers_orderability(&agtype_lhs->root,
                                                      &agtype_rhs->root) == 0);
@@ -1048,9 +1062,22 @@ PG_FUNCTION_INFO_V1(agtype_ne);
 
 Datum agtype_ne(PG_FUNCTION_ARGS)
 {
-    agtype *agtype_lhs = AG_GET_ARG_AGTYPE_P(0);
-    agtype *agtype_rhs = AG_GET_ARG_AGTYPE_P(1);
-    bool result = true;
+    Datum lhs = PG_GETARG_DATUM(0);
+    Datum rhs = PG_GETARG_DATUM(1);
+    uint32 hash_lhs = datum_image_hash(lhs, false, -1);
+    uint32 hash_rhs = datum_image_hash(rhs, false, -1);
+    agtype *agtype_lhs = NULL;
+    agtype *agtype_rhs = NULL;
+    bool result = false;
+
+    if (hash_lhs == hash_rhs &&
+        datum_image_eq(lhs, rhs, false, -1))
+    {
+        PG_RETURN_BOOL(false);
+    }
+
+    agtype_lhs = DATUM_GET_AGTYPE_P(lhs);
+    agtype_rhs = DATUM_GET_AGTYPE_P(rhs);
 
     result = (compare_agtype_containers_orderability(&agtype_lhs->root,
                                                      &agtype_rhs->root) != 0);

--- a/src/include/catalog/ag_label.h
+++ b/src/include/catalog/ag_label.h
@@ -72,7 +72,6 @@ void delete_label(Oid relation);
 int32 get_label_id(const char *label_name, Oid graph_oid);
 Oid get_label_relation(const char *label_name, Oid graph_oid);
 char *get_label_relation_name(const char *label_name, Oid graph_oid);
-Oid get_label_oid(const char *label_name, Oid label_graph);
 char get_label_kind(const char *label_name, Oid label_graph);
 
 bool label_id_exists(Oid graph_oid, int32 label_id);


### PR DESCRIPTION
Integrated datum_image_hash and datum_image_eq to the logic for the VLE edge property datum match.

Additionally, both were added to agtype_eq and agtype_ne.

The hope is that, for large datums, these routines will improve performance.

No impact to regression tests.