### PR TITLE
Remove duplicate check (#1740) (#1833)

### DIFF
--- a/src/backend/commands/label_commands.c
+++ b/src/backend/commands/label_commands.c
@@ -279,12 +279,6 @@ void create_label(char *graph_name, char *label_name, char label_type,
                         errmsg("label name is invalid")));
     }
 
-    if (!is_valid_label(label_name, label_type))
-    {
-        ereport(ERROR, (errcode(ERRCODE_UNDEFINED_SCHEMA),
-                        errmsg("label name is invalid")));
-    }
-
     cache_data = search_graph_name_cache(graph_name);
     if (!cache_data)
     {


### PR DESCRIPTION
Remove duplicate check (#1740) (#1833)

This commit removes [a benign] redundant check for label validity

Based on earlier checkins by jrgemignani and jberzy <john.berzy@gmail.com>