### PR TITLE
[CI] Update labeler github action

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,4 +9,19 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v5.0.0-alpha.1
+    - name: Apply branch labels
+      uses: actions/labeler@v5.0.0
+
+    - name: Apply label based on author
+      if: |
+        contains('["jrgemignani", "dehowef", "eyab" "rafsun42", "Zainab-Saad", "MuhammadTahaNaveed"]', github.event.pull_request.user.login)
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const labelsToAdd = ['override-stale'];
+          github.rest.issues.addLabels({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            labels: labelsToAdd
+          });


### PR DESCRIPTION
- This action will now add "override-stale" label to the PRs that are by apache/age committers, this will prevent stale action from touching these PRs.