### PR TITLE
Add workflow for stale issues and PRs

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,26 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 45 days with no activity. Remove "Abondoned" label or comment or this will be closed in 7 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for further 7 days with no activity.'
+          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove "Abondoned" label or comment or this will be closed in 7 days.'
+          close-pr-message: 'This PR was closed because it has been stalled for further 7 days with no activity'
+          stale-issue-label: Abondoned
+          exempt-issue-labels: 'override-stale'
+          stale-pr-label: Abondoned
+          exempt-pr-labels: 'override-stale'
+          days-before-issue-stale: 45
+          days-before-issue-close: 7
+          days-before-pr-stale: 45
+          days-before-pr-close: 7
+          # only stale issue/PR created after the 1st Jan 2023:
+          start-date: '2023-01-01T00:00:00Z'
+          operations-per-run: 500


### PR DESCRIPTION
- This workflow will send the first notice to the issue/PR author after 45 days of inactivity and will close the issue/PR after 7 further days of inactivity.
- Only the issues/PRs after 1st Jan 2023 will be affected by this workflow.
- Maximum of 500 issues/PRs can be processed in one run of this workflow.
- This workflow will run after every 24 hours.
- Issues/PRs with the label `override-stale` will not be affected by this workflow.
- "Abondoned" label will be added to the issues/PRs which are closed by this workflow.