### PR TITLE
Order some regression tests for stability on big-endian

### DIFF
--- a/regress/expected/cypher_match.out
+++ b/regress/expected/cypher_match.out
@@ -1520,13 +1520,13 @@ NOTICE:  graph "for_isEmpty" has been dropped
 SELECT * FROM cypher('cypher_match', $$
 	MATCH (u)
 	RETURN DISTINCT u.id
-$$) AS (i agtype);
+$$) AS (i agtype) ORDER BY i;
      i     
 -----------
- 
  "end"
  "initial"
  "middle"
+ 
 (4 rows)
 
 SELECT * FROM cypher('cypher_match', $$
@@ -1556,7 +1556,7 @@ $$) AS (i agtype);
 SELECT * FROM cypher('cypher_match', $$
 	MATCH p=(:duplicate)-[]-(:other_v)
 	RETURN DISTINCT p
-$$) AS (i agtype);
+$$) AS (i agtype) ORDER BY i;
                                                                                                                                                 i                                                                                                                                                 
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  [{"id": 3377699720527873, "label": "duplicate", "properties": {}}::vertex, {"id": 3659174697238529, "label": "dup_edge", "end_id": 3940649673949185, "start_id": 3377699720527873, "properties": {"id": 1}}::edge, {"id": 3940649673949185, "label": "other_v", "properties": {}}::vertex]::path

--- a/regress/sql/cypher_match.sql
+++ b/regress/sql/cypher_match.sql
@@ -725,7 +725,7 @@ SELECT drop_graph('for_isEmpty', true);
 SELECT * FROM cypher('cypher_match', $$
 	MATCH (u)
 	RETURN DISTINCT u.id
-$$) AS (i agtype);
+$$) AS (i agtype) ORDER BY i;
 
 SELECT * FROM cypher('cypher_match', $$
 	CREATE (u:duplicate)-[:dup_edge {id:1 }]->(:other_v)
@@ -744,7 +744,7 @@ $$) AS (i agtype);
 SELECT * FROM cypher('cypher_match', $$
 	MATCH p=(:duplicate)-[]-(:other_v)
 	RETURN DISTINCT p
-$$) AS (i agtype);
+$$) AS (i agtype) ORDER BY i;
 
 --
 -- Limit


### PR DESCRIPTION
On Debian's s390x architecture, some regression tests were failing because the result set was reordered. Fix by attaching ORDER BY in problematic cases.