### PR TITLE
Fixes small typos in the python driver's README.md file

### DIFF
--- a/drivers/python/README.md
+++ b/drivers/python/README.md
@@ -13,7 +13,7 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 
-Apache AGE](https://age.apache.org/) is a PostgreSQL extension that provides graph database functionality. The goal of the Apache AGE project is to create single storage that can handle both relational and graph model data so that users can use standard ANSI SQL along with openCypher, the Graph query language. This repository hosts the development of the Python driver for this Apache extension (currently in Incubator status). Thanks for checking it out.
+[Apache AGE](https://age.apache.org/) is a PostgreSQL extension that provides graph database functionality. The goal of the Apache AGE project is to create single storage that can handle both relational and graph model data so that users can use standard ANSI SQL along with openCypher, the Graph query language. This repository hosts the development of the Python driver for this Apache extension (currently in Incubator status). Thanks for checking it out.
 
 A graph consists of a set of vertices (also called nodes) and edges, where each individual vertex and edge possesses a map of properties. A vertex is the basic object of a graph, that can exist independently of everything else in the graph. An edge creates a directed connection between two vertices. A graph database is simply composed of vertices and edges. This type of database is useful when the meaning is in the relationships between the data. Relational databases can easily handle direct relationships, but indirect relationships are more difficult to deal with in relational databases. A graph database stores relationship information as a first-class entity. Apache AGE gives you the best of both worlds, simultaneously.
 
@@ -66,7 +66,7 @@ python setup.py install
 ```
 
 ### For more information about [Apache AGE](https://age.apache.org/)
-* Apache Age : https://age.apache.org/
+* Apache AGE : https://age.apache.org/
 * GitHub : https://github.com/apache/age
 * Document : https://age.apache.org/age-manual/master/index.html
 
@@ -80,7 +80,7 @@ SET search_path = ag_catalog, "$user", public;
 ```
 
 ### Usage
-* If you are familiar with Psycopg2 driver : Go to [Jupyter Notebook : Basic Sample](samples/apache-age-basic.ipynb) 
+* If you are not familiar with Psycopg2 driver : Go to [Jupyter Notebook : Basic Sample](samples/apache-age-basic.ipynb) 
 * Simpler way to access Apache AGE [AGE Sample](samples/apache-age-note.ipynb) in Samples.
 * Agtype converting samples: [Agtype Sample](samples/apache-age-agtypes.ipynb) in Samples.
 
@@ -106,14 +106,14 @@ Here the following value required
 - `-port` : port (optional)
 
 ### Networkx to AGE
-Insert From networkx directed graph into an Age database.
+Insert From networkx directed graph into an AGE database.
 #### Parameters
 
-- `connection` (psycopg2.connect): Connection object to the Age database.
+- `connection` (psycopg2.connect): Connection object to the AGE database.
 
 - `G` (networkx.DiGraph): Networkx directed graph to be converted and inserted.
 
-- `graphName` (str): Name of the age graph.
+- `graphName` (str): Name of the AGE graph.
 
 #### Returns
 


### PR DESCRIPTION
- Fix a markdown link grammar mistake;
- Fix some "Age" misspellings to "AGE".