### PR TITLE
Add the `load_from_plugins` parameter in the Python driver to load AGE from the $libdir/plugins directory

### DIFF
--- a/drivers/python/README.md
+++ b/drivers/python/README.md
@@ -75,5 +75,15 @@ SET search_path = ag_catalog, "$user", public;
 * Simpler way to access Apache AGE [AGE Sample](samples/apache-age-note.ipynb) in Samples.
 * Agtype converting samples: [Agtype Sample](samples/apache-age-agtypes.ipynb) in Samples.
 
+### Non-Superuser Usage
+* For non-superuser usage see: [Allow Non-Superusers to Use Apache Age](https://age.apache.org/age-manual/master/intro/setup.html).
+* Make sure to give your non-superuser db account proper permissions to the graph schemas and corresponding objects
+* Make sure to initiate the Apache Age python driver with the ```load_from_plugins``` parameter. This parameter tries to
+  load the Apache Age extension from the PostgreSQL plugins directory located at ```$libdir/plugins/age```. Example:
+  ```python.
+  ag = age.connect(host='localhost', port=5432, user='dbuser', password='strong_password', 
+                   dbname=postgres, load_from_plugins=True, graph='graph_name)
+  ```
+
 ### License
 Apache-2.0 License

--- a/drivers/python/age/__init__.py
+++ b/drivers/python/age/__init__.py
@@ -13,6 +13,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import psycopg.conninfo as conninfo
 from . import age
 from .age import *
 from .models import *
@@ -23,10 +24,15 @@ def version():
     return VERSION.VERSION
 
 
-def connect(dsn=None, graph=None, connection_factory=None, cursor_factory=None, **kwargs):
-        ag = Age()
-        ag.connect(dsn=dsn, graph=graph, connection_factory=connection_factory, cursor_factory=cursor_factory, **kwargs)
-        return ag
+def connect(dsn=None, graph=None, connection_factory=None, cursor_factory=ClientCursor, load_from_plugins=False,
+            **kwargs):
+
+    dsn = conninfo.make_conninfo('' if dsn is None else dsn, **kwargs)
+
+    ag = Age()
+    ag.connect(dsn=dsn, graph=graph, connection_factory=connection_factory, cursor_factory=cursor_factory,
+               load_from_plugins=load_from_plugins, **kwargs)
+    return ag
 
 # Dummy ResultHandler
 rawPrinter = DummyResultHandler()

--- a/drivers/python/age/age.py
+++ b/drivers/python/age/age.py
@@ -13,13 +13,14 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import re 
-import psycopg2 
-from psycopg2 import errors
-from psycopg2 import extensions as ext
-from psycopg2 import sql
+import re
+import psycopg
+from psycopg.types import TypeInfo
+from psycopg.adapt import Loader
+from psycopg import sql
+from psycopg.client_cursor import ClientCursor
 from .exceptions import *
-from .builder import ResultHandler , parseAgeValue, newResultHandler
+from .builder import parseAgeValue
 
 
 _EXCEPTION_NoConnection = NoConnection()
@@ -27,26 +28,45 @@ _EXCEPTION_GraphNotSet = GraphNotSet()
 
 WHITESPACE = re.compile('\s')
 
-def setUpAge(conn:ext.connection, graphName:str):
+
+class AgeDumper(psycopg.adapt.Dumper):
+    def dump(self, obj: Any) -> bytes | bytearray | memoryview:
+        pass    
+    
+    
+class AgeLoader(psycopg.adapt.Loader):    
+    def load(self, data: bytes | bytearray | memoryview) -> Any | None:
+        if isinstance(data, memoryview):
+            data_bytes = data.tobytes()
+        else:
+            data_bytes = data
+
+        return parseAgeValue(data_bytes.decode('utf-8'))
+
+
+def setUpAge(conn:psycopg.connection, graphName:str, load_from_plugins:bool=False):
     with conn.cursor() as cursor:
-        cursor.execute("LOAD 'age';")
+        if load_from_plugins:
+            cursor.execute("LOAD '$libdir/plugins/age';")
+        else:
+            cursor.execute("LOAD 'age';")
+
         cursor.execute("SET search_path = ag_catalog, '$user', public;")
 
-        cursor.execute("SELECT typelem FROM pg_type WHERE typname='_agtype'")
-        oid = cursor.fetchone()[0]
-        if oid == None :
+        ag_info = TypeInfo.fetch(conn, 'agtype')
+
+        if not ag_info:
             raise AgeNotSet()
 
-        AGETYPE = ext.new_type((oid,), 'AGETYPE', parseAgeValue)
-        ext.register_type(AGETYPE)
-        # ext.register_adapter(Path, marshalAgtValue)
+        conn.adapters.register_loader(ag_info.oid, AgeLoader)
+        conn.adapters.register_loader(ag_info.array_oid, AgeLoader)
 
         # Check graph exists
         if graphName != None:
             checkGraphCreated(conn, graphName)
 
 # Create the graph, if it does not exist
-def checkGraphCreated(conn:ext.connection, graphName:str):
+def checkGraphCreated(conn:psycopg.connection, graphName:str):
     with conn.cursor() as cursor:
         cursor.execute(sql.SQL("SELECT count(*) FROM ag_graph WHERE name={graphName}").format(graphName=sql.Literal(graphName)))
         if cursor.fetchone()[0] == 0:
@@ -54,7 +74,7 @@ def checkGraphCreated(conn:ext.connection, graphName:str):
             conn.commit()
 
 
-def deleteGraph(conn:ext.connection, graphName:str):
+def deleteGraph(conn:psycopg.connection, graphName:str):
     with conn.cursor() as cursor:
         cursor.execute(sql.SQL("SELECT drop_graph({graphName}, true);").format(graphName=sql.Literal(graphName)))
         conn.commit()
@@ -82,7 +102,7 @@ def buildCypher(graphName:str, cypherStmt:str, columns:list) ->str:
     stmtArr.append(");")
     return "".join(stmtArr)
 
-def execSql(conn:ext.connection, stmt:str, commit:bool=False, params:tuple=None) -> ext.cursor :
+def execSql(conn:psycopg.connection, stmt:str, commit:bool=False, params:tuple=None) -> psycopg.cursor :
     if conn == None or conn.closed:
         raise _EXCEPTION_NoConnection
     
@@ -101,14 +121,14 @@ def execSql(conn:ext.connection, stmt:str, commit:bool=False, params:tuple=None)
         raise SqlExecutionError("Execution ERR[" + str(cause) +"](" + stmt +")", cause)
 
 
-def querySql(conn:ext.connection, stmt:str, params:tuple=None) -> ext.cursor :
+def querySql(conn:psycopg.connection, stmt:str, params:tuple=None) -> psycopg.cursor :
     return execSql(conn, stmt, False, params)
 
 # Execute cypher statement and return cursor.
 # If cypher statement changes data (create, set, remove),
 # You must commit session(ag.commit())
 # (Otherwise the execution cannot make any effect.)
-def execCypher(conn:ext.connection, graphName:str, cypherStmt:str, cols:list=None, params:tuple=None) -> ext.cursor :
+def execCypher(conn:psycopg.connection, graphName:str, cypherStmt:str, cols:list=None, params:tuple=None) -> psycopg.cursor :
     if conn == None or conn.closed:
         raise _EXCEPTION_NoConnection
 
@@ -117,7 +137,7 @@ def execCypher(conn:ext.connection, graphName:str, cypherStmt:str, cols:list=Non
     cypherStmt = cypherStmt.replace("\n", "")
     cypherStmt = cypherStmt.replace("\t", "")
     cypher = str(cursor.mogrify(cypherStmt, params))
-    cypher = cypher[2:len(cypher)-1]
+    cypher = cypher.strip()
 
     preparedStmt = "SELECT * FROM age_prepare_cypher({graphName},{cypherStmt})"
 
@@ -145,12 +165,12 @@ def execCypher(conn:ext.connection, graphName:str, cypherStmt:str, cols:list=Non
         raise SqlExecutionError("Execution ERR[" + str(cause) +"](" + stmt +")", cause)
 
 
-def cypher(cursor:ext.cursor, graphName:str, cypherStmt:str, cols:list=None, params:tuple=None) -> ext.cursor :
+def cypher(cursor:psycopg.cursor, graphName:str, cypherStmt:str, cols:list=None, params:tuple=None) -> psycopg.cursor :
     #clean up the string for mogrification
     cypherStmt = cypherStmt.replace("\n", "")
     cypherStmt = cypherStmt.replace("\t", "")
     cypher = str(cursor.mogrify(cypherStmt, params))
-    cypher = cypher[2:len(cypher)-1]
+    cypher = cypher.strip()
 
     preparedStmt = "SELECT * FROM age_prepare_cypher({graphName},{cypherStmt})"
     cursor.execute(sql.SQL(preparedStmt).format(graphName=sql.Literal(graphName),cypherStmt=sql.Literal(cypher)))
@@ -159,23 +179,24 @@ def cypher(cursor:ext.cursor, graphName:str, cypherStmt:str, cols:list=None, par
     cursor.execute(stmt)
 
 
-# def execCypherWithReturn(conn:ext.connection, graphName:str, cypherStmt:str, columns:list=None , params:tuple=None) -> ext.cursor :
+# def execCypherWithReturn(conn:psycopg.connection, graphName:str, cypherStmt:str, columns:list=None , params:tuple=None) -> psycopg.cursor :
 #     stmt = buildCypher(graphName, cypherStmt, columns)
 #     return execSql(conn, stmt, False, params)
 
-# def queryCypher(conn:ext.connection, graphName:str, cypherStmt:str, columns:list=None , params:tuple=None) -> ext.cursor :
+# def queryCypher(conn:psycopg.connection, graphName:str, cypherStmt:str, columns:list=None , params:tuple=None) -> psycopg.cursor :
 #     return execCypherWithReturn(conn, graphName, cypherStmt, columns, params)
 
 
 class Age:
     def __init__(self):
-        self.connection = None    # psycopg2 connection]
+        self.connection = None    # psycopg connection]
         self.graphName = None
 
     # Connect to PostgreSQL Server and establish session and type extension environment.
-    def connect(self, graph:str=None, dsn:str=None, connection_factory=None, cursor_factory=None, **kwargs):
-        conn = psycopg2.connect(dsn, connection_factory, cursor_factory, **kwargs)
-        setUpAge(conn, graph)
+    def connect(self, graph:str=None, dsn:str=None, connection_factory=None, cursor_factory=ClientCursor,
+                load_from_plugins:bool=False, **kwargs):
+        conn = psycopg.connect(dsn, cursor_factory=cursor_factory, **kwargs)
+        setUpAge(conn, graph, load_from_plugins)
         self.connection = conn
         self.graphName = graph
         return self
@@ -194,21 +215,21 @@ class Age:
     def rollback(self):
         self.connection.rollback()
 
-    def execCypher(self, cypherStmt:str, cols:list=None, params:tuple=None) -> ext.cursor :
+    def execCypher(self, cypherStmt:str, cols:list=None, params:tuple=None) -> psycopg.cursor :
         return execCypher(self.connection, self.graphName, cypherStmt, cols=cols, params=params)
 
-    def cypher(self, cursor:ext.cursor, cypherStmt:str, cols:list=None, params:tuple=None) -> ext.cursor :
+    def cypher(self, cursor:psycopg.cursor, cypherStmt:str, cols:list=None, params:tuple=None) -> psycopg.cursor :
         return cypher(cursor, self.graphName, cypherStmt, cols=cols, params=params)
 
-    # def execSql(self, stmt:str, commit:bool=False, params:tuple=None) -> ext.cursor :
+    # def execSql(self, stmt:str, commit:bool=False, params:tuple=None) -> psycopg.cursor :
     #     return execSql(self.connection, stmt, commit, params)
 
 
-    # def execCypher(self, cypherStmt:str, commit:bool=False, params:tuple=None) -> ext.cursor :
+    # def execCypher(self, cypherStmt:str, commit:bool=False, params:tuple=None) -> psycopg.cursor :
     #     return execCypher(self.connection, self.graphName, cypherStmt, commit, params)
 
-    # def execCypherWithReturn(self, cypherStmt:str, columns:list=None , params:tuple=None) -> ext.cursor :
+    # def execCypherWithReturn(self, cypherStmt:str, columns:list=None , params:tuple=None) -> psycopg.cursor :
     #     return execCypherWithReturn(self.connection, self.graphName, cypherStmt, columns, params)
 
-    # def queryCypher(self, cypherStmt:str, columns:list=None , params:tuple=None) -> ext.cursor :
+    # def queryCypher(self, cypherStmt:str, columns:list=None , params:tuple=None) -> psycopg.cursor :
     #     return queryCypher(self.connection, self.graphName, cypherStmt, columns, params)


### PR DESCRIPTION
Add the `load_from_plugins` parameter in the Python driver to load AGE from the $libdir/plugins directory

This is useful when a non-superuser login is used for the connection.

Additionally, fixed a small bug where a memoryview was not transformed to bytes before decoding into a UTF-8 string.