### PR TITLE
Fix issue 1956 - null key name passed. (#1957)

### DIFF
--- a/regress/expected/expr.out
+++ b/regress/expected/expr.out
@@ -8346,6 +8346,15 @@ SELECT * FROM cypher('expanded_map', $$ MATCH (u) RETURN u $$) as (result agtype
 (8 rows)
 
 --
+-- Issue 1956 - null key
+--
+SELECT agtype_build_map('null'::agtype, 1);
+ERROR:  argument 1: key must not be null
+SELECT agtype_build_map(null, 1);
+ERROR:  argument 1: key must not be null
+SELECT agtype_build_map('name', 'John', 'null'::agtype, 1);
+ERROR:  argument 3: key must not be null
+--
 -- Cleanup
 --
 SELECT * FROM drop_graph('expanded_map', true);

--- a/regress/sql/expr.sql
+++ b/regress/sql/expr.sql
@@ -3398,6 +3398,13 @@ SELECT * FROM cypher('expanded_map', $$ CREATE (u {n0: 0, n1: 1, n2: 2, n3: 3, n
 SELECT * FROM cypher('expanded_map', $$ MATCH (u) RETURN u $$) as (result agtype);
 
 --
+-- Issue 1956 - null key
+--
+SELECT agtype_build_map('null'::agtype, 1);
+SELECT agtype_build_map(null, 1);
+SELECT agtype_build_map('name', 'John', 'null'::agtype, 1);
+
+--
 -- Cleanup
 --
 SELECT * FROM drop_graph('expanded_map', true);

--- a/src/backend/utils/adt/agtype.c
+++ b/src/backend/utils/adt/agtype.c
@@ -2402,6 +2402,14 @@ static agtype_value *agtype_build_map_as_agtype_value(FunctionCallInfo fcinfo)
 
             agtv = tostring_helper(args[i], types[i],
                                    "agtype_build_map_as_agtype_value");
+            if (agtv == NULL)
+            {
+                ereport(ERROR,
+                    (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                     errmsg("argument %d: key must not be null", i + 1)));
+
+            }
+
             result.res = push_agtype_value(&result.parse_state, WAGT_KEY, agtv);
 
             /* free the agtype_value from tostring_helper */
@@ -6804,7 +6812,7 @@ Datum age_tostring(PG_FUNCTION_ARGS)
 
 /*
  * Helper function to take any valid type and convert it to an agtype string.
- * Returns NULL for NULL output.
+ * Returns NULL for NULL input.
  */
 static agtype_value *tostring_helper(Datum arg, Oid type, char *msghdr)
 {


### PR DESCRIPTION
Fixed issue 1956 - Server crashes when executing

    SELECT agtype_build_map('null'::agtype, 1);

This issue was due to a missing check for AGTV_NULL values. The check was added and the issue was corrected.

Added regression tests.