### PR TITLE
Add EmitWarningsOnPlaceholders("age")

### DIFF
--- a/regress/expected/name_validation.out
+++ b/regress/expected/name_validation.out
@@ -476,5 +476,13 @@ NOTICE:  graph "graph123" has been dropped
 (1 row)
 
 --
+-- Test GUC names
+--
+SET age.enable_containment TO ON;
+SET age.invalid_parameter TO ON;
+ERROR:  invalid configuration parameter name "age.invalid_parameter"
+DETAIL:  "age" is a reserved prefix.
+SET any_placeholder.any_parameter TO ON;
+--
 -- End of test
 --

--- a/regress/sql/name_validation.sql
+++ b/regress/sql/name_validation.sql
@@ -179,5 +179,12 @@ SELECT create_elabel('graph123', 'elabel0123456789012345678901234567890123456789
 SELECT drop_graph('graph123', true);
 
 --
+-- Test GUC names
+--
+SET age.enable_containment TO ON;
+SET age.invalid_parameter TO ON;
+SET any_placeholder.any_parameter TO ON;
+
+--
 -- End of test
 --

--- a/src/backend/utils/ag_guc.c
+++ b/src/backend/utils/ag_guc.c
@@ -42,4 +42,5 @@ void define_config_params(void)
                              NULL,
                              NULL,
                              NULL);
+    EmitWarningsOnPlaceholders("age");
 }


### PR DESCRIPTION
Added EmitWarningsOnPlaceholders("age") to warn when an undefined GUC parameter is set for a placeholder named "age".

Warnings are issued when PostgreSQL starts and when SET statements are executed.

When PostgreSQL starts
```
2024-08-01 18:32:31.220 JST [2039799] WARNING: invalid configuration parameter name "age.invalid_parameter", removing it
```

When SET statement is executed
```
ERROR: invalid configuration parameter name "age.invalid_parameter"
DETAIL: "age" is a reserved prefix.
```

Regression tests were added.