### PR TITLE
Fix obsolete docker-compose command in CIs

### DIFF
--- a/.github/workflows/go-driver.yml
+++ b/.github/workflows/go-driver.yml
@@ -19,12 +19,10 @@ jobs:
         working-directory: drivers/golang/age/
   
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Run apache/age docker image
-      run: |
-        export TAG=$TAG
-        docker-compose up -d
+      run: docker compose up -d
 
     - name: Set up Go
       uses: actions/setup-go@v3

--- a/.github/workflows/jdbc-driver.yaml
+++ b/.github/workflows/jdbc-driver.yaml
@@ -16,7 +16,7 @@ jobs:
         working-directory: drivers/jdbc
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Java
       uses: actions/setup-java@v3

--- a/.github/workflows/nodejs-driver.yaml
+++ b/.github/workflows/nodejs-driver.yaml
@@ -16,10 +16,10 @@ jobs:
         working-directory: drivers/nodejs/
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Run apache/age docker image
-      run: docker-compose up -d
+      run: docker compose up -d
 
     - name: Set up Node
       uses: actions/setup-node@v3

--- a/.github/workflows/python-driver.yaml
+++ b/.github/workflows/python-driver.yaml
@@ -16,10 +16,10 @@ jobs:
         working-directory: drivers/python
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Run apache/age docker image
-      run: docker-compose up -d
+      run: docker compose up -d
 
     - name: Set up python
       uses: actions/setup-python@v4


### PR DESCRIPTION
- This issue occurred because docker Compose v1 is now removed from images.
- Related links: actions/runner-images#9557 https://github.com/orgs/community/discussions/116610