### PR TITLE
Fix issue 2020: Memory leak (#2028)

### DIFF
--- a/src/backend/utils/adt/age_graphid_ds.c
+++ b/src/backend/utils/adt/age_graphid_ds.c
@@ -145,9 +145,11 @@ void free_ListGraphId(ListGraphId *container)
         next_node = curr_node->next;
         /* we can do this because this is just a list of ints */
         pfree(curr_node);
+        container->size--;
         curr_node = next_node;
     }
 
+    Assert(container->size == 0);
     /* free the container */
     pfree(container);
 }


### PR DESCRIPTION
Fixed issue 2020: Memory leak in the VLE cache cleanup routines. Or, at least I fixed a good part of it.

NOTE: We should look further into this, resources permitting.

What was causing the leaks were the property datums in the hash tables. The property datums were copied via datumCopy into the hash tables for easier access when rebuilding an edge. However, they needed to be freed when no longer needed.

No regression tests were impacted.
No regression tests were needed.