### PR TITLE
Mironathome issue 2027 fix ( branch PG12 )

### DIFF
--- a/src/include/catalog/ag_graph.h
+++ b/src/include/catalog/ag_graph.h
@@ -37,7 +37,7 @@ void insert_graph(const Name graph_name, const Oid nsp_id);
 void delete_graph(const Name graph_name);
 void update_graph_name(const Name graph_name, const Name new_name);
 
-uint32 get_graph_oid(const char *graph_name);
+Oid get_graph_oid(const char *graph_name);
 char *get_graph_namespace_name(const char *graph_name);
 
 List *get_graphnames(void);


### PR DESCRIPTION
Fix issue #2027
get_graph_oid function declaration return type uint32 definition Oid
Make both return Oid