### PR TITLE
Refactor Dockerfile to use multi-stage builds (#2004)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,24 +16,15 @@
 # limitations under the License.
 #
 
-
-FROM postgres:11-buster
+# Build stage: Install necessary development tools for compilation and installation
+FROM postgres:11-buster AS build
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends --no-install-suggests \
        bison \
        build-essential \
        flex \
-       postgresql-server-dev-11 \
-       locales
-
-ENV LANG=en_US.UTF-8
-ENV LC_COLLATE=en_US.UTF-8
-ENV LC_CTYPE=en_US.UTF-8
-
-RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
-    && locale-gen \
-    && update-locale LANG=en_US.UTF-8
+       postgresql-server-dev-11
 
 COPY . /age
 
@@ -41,6 +32,25 @@ WORKDIR /age
 
 RUN make && make install
 
+
+# Final stage: Create a final image by copying the files created in the build stage
+FROM postgres:11-buster
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends --no-install-suggests \
+    locales
+
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
+    && locale-gen \
+    && update-locale LANG=en_US.UTF-8
+
+ENV LANG=en_US.UTF-8
+ENV LC_COLLATE=en_US.UTF-8
+ENV LC_CTYPE=en_US.UTF-8
+
+COPY --from=build /usr/lib/postgresql/11/lib/age.so /usr/lib/postgresql/11/lib/
+COPY --from=build /usr/share/postgresql/11/extension/age--1.5.0.sql /usr/share/postgresql/11/extension/
+COPY --from=build /usr/share/postgresql/11/extension/age.control /usr/share/postgresql/11/extension/
 COPY docker/docker-entrypoint-initdb.d/00-create-extension-age.sql /docker-entrypoint-initdb.d/00-create-extension-age.sql
 
 CMD ["postgres", "-c", "shared_preload_libraries=age"]


### PR DESCRIPTION
Refactored Dockerfile to use multi-stage builds for reduction image size.

The installation of the packages required for the build and the build process are carried out at the build stage. The built binaries are then placed in the final image.

This changes has reduces the image size about 1/3.
```
$ docker image ls apache/age
REPOSITORY   TAG       IMAGE ID       CREATED          SIZE
apache/age   tmp       5ffd0b539a88   22 minutes ago   458MB <-- New image
apache/age   latest    fb44b5789198   2 months ago     1.5GB <-- Original image
```