### PR TITLE
Revamp age csv loader (#2044)

### DIFF
--- a/regress/expected/age_load.out
+++ b/regress/expected/age_load.out
@@ -19,6 +19,7 @@
 \! cp -r regress/age_load/data regress/instance/data/age_load
 LOAD 'age';
 SET search_path TO ag_catalog;
+-- Create a country using CREATE clause
 SELECT create_graph('agload_test_graph');
 NOTICE:  graph "agload_test_graph" has been created
  create_graph 
@@ -26,34 +27,79 @@ NOTICE:  graph "agload_test_graph" has been created
  
 (1 row)
 
-SELECT create_vlabel('agload_test_graph','Country');
-NOTICE:  VLabel "Country" has been created
- create_vlabel 
----------------
- 
+SELECT * FROM cypher('agload_test_graph', $$CREATE (n:Country {__id__:1}) RETURN n$$) as (n agtype);
+                                        n                                         
+----------------------------------------------------------------------------------
+ {"id": 844424930131969, "label": "Country", "properties": {"__id__": 1}}::vertex
 (1 row)
 
+--
+-- Load countries with id
+--
 SELECT load_labels_from_file('agload_test_graph', 'Country',
-    'age_load/countries.csv');
+    'age_load/countries.csv', true);
  load_labels_from_file 
 -----------------------
  
 (1 row)
 
-SELECT create_vlabel('agload_test_graph','City');
-NOTICE:  VLabel "City" has been created
- create_vlabel 
----------------
- 
+-- A temporary table should have been created with 54 ids; 1 from CREATE and 53 from file
+SELECT COUNT(*)=54 FROM "_agload_test_graph_ag_vertex_ids";
+ ?column? 
+----------
+ t
 (1 row)
 
+-- Sequence should be equal to max entry id i.e. 248
+SELECT currval('agload_test_graph."Country_id_seq"')=248;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Should error out on loading the same file again due to duplicate id
+SELECT load_labels_from_file('agload_test_graph', 'Country',
+    'age_load/countries.csv', true);
+ERROR:  Cannot insert duplicate vertex id: 844424930131970
+HINT:  Entry id 2 is already used
+--
+-- Load cities with id
+--
+-- Should create City label automatically and load cities
 SELECT load_labels_from_file('agload_test_graph', 'City',
-    'age_load/cities.csv');
+    'age_load/cities.csv', true);
+NOTICE:  VLabel "City" has been created
  load_labels_from_file 
 -----------------------
  
 (1 row)
 
+-- Temporary table should have 54+72485 rows now
+SELECT COUNT(*)=54+72485 FROM "_agload_test_graph_ag_vertex_ids";
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Sequence should be equal to max entry id i.e. 146941
+SELECT currval('agload_test_graph."City_id_seq"')=146941;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Should error out on loading the same file again due to duplicate id
+SELECT load_labels_from_file('agload_test_graph', 'City',
+    'age_load/cities.csv', true);
+ERROR:  Cannot insert duplicate vertex id: 1125899906842777
+HINT:  Entry id 153 is already used
+--
+-- Load edges -- Connects cities to countries
+--
+-- Should error out for using vertex label
+SELECT load_edges_from_file('agload_test_graph', 'Country',
+    'age_load/edges.csv');
+ERROR:  label "Country" already exists as edge label
 SELECT create_elabel('agload_test_graph','has_city');
 NOTICE:  ELabel "has_city" has been created
  create_elabel 
@@ -68,6 +114,17 @@ SELECT load_edges_from_file('agload_test_graph', 'has_city',
  
 (1 row)
 
+-- Sequence should be equal to number of edges loaded i.e. 72485
+SELECT currval('agload_test_graph."has_city_id_seq"')=72485;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Should error out for using edge label
+SELECT load_labels_from_file('agload_test_graph', 'has_city',
+     'age_load/cities.csv');
+ERROR:  label "has_city" already exists as vertex label
 SELECT table_catalog, table_schema, lower(table_name) as table_name, table_type
 FROM information_schema.tables
 WHERE table_schema = 'agload_test_graph' ORDER BY table_name ASC;
@@ -83,7 +140,7 @@ WHERE table_schema = 'agload_test_graph' ORDER BY table_name ASC;
 SELECT COUNT(*) FROM agload_test_graph."Country";
  count 
 -------
-    53
+    54
 (1 row)
 
 SELECT COUNT(*) FROM agload_test_graph."City";
@@ -101,13 +158,24 @@ SELECT COUNT(*) FROM agload_test_graph."has_city";
 SELECT COUNT(*) FROM cypher('agload_test_graph', $$MATCH(n) RETURN n$$) as (n agtype);
  count 
 -------
- 72538
+ 72539
 (1 row)
 
 SELECT COUNT(*) FROM cypher('agload_test_graph', $$MATCH (a)-[e]->(b) RETURN e$$) as (n agtype);
  count 
 -------
  72485
+(1 row)
+
+--
+-- Load countries and cities without id
+--
+-- Should load countries in Country label without error since it should use sequence now
+SELECT load_labels_from_file('agload_test_graph', 'Country',
+    'age_load/countries.csv', false);
+ load_labels_from_file 
+-----------------------
+ 
 (1 row)
 
 SELECT create_vlabel('agload_test_graph','Country2');
@@ -153,6 +221,7 @@ SELECT COUNT(*) FROM agload_test_graph."City2";
 SELECT id FROM agload_test_graph."Country" LIMIT 10;
        id        
 -----------------
+ 844424930131969
  844424930131970
  844424930131971
  844424930131974
@@ -162,7 +231,6 @@ SELECT id FROM agload_test_graph."Country" LIMIT 10;
  844424930131996
  844424930132002
  844424930132023
- 844424930132025
 (10 rows)
 
 SELECT id FROM agload_test_graph."Country2" LIMIT 10;
@@ -180,13 +248,16 @@ SELECT id FROM agload_test_graph."Country2" LIMIT 10;
  1688849860263946
 (10 rows)
 
+-- Should return 2 rows for Country with same properties, but different ids
 SELECT * FROM cypher('agload_test_graph', $$MATCH(n:Country {iso2 : 'BE'})
     RETURN id(n), n.name, n.iso2 $$) as ("id(n)" agtype, "n.name" agtype, "n.iso2" agtype);
       id(n)      |  n.name   | n.iso2 
 -----------------+-----------+--------
  844424930131990 | "Belgium" | "BE"
-(1 row)
+ 844424930132223 | "Belgium" | "BE"
+(2 rows)
 
+-- Should return 1 row
 SELECT * FROM cypher('agload_test_graph', $$MATCH(n:Country2 {iso2 : 'BE'})
     RETURN id(n), n.name, n.iso2 $$) as ("id(n)" agtype, "n.name" agtype, "n.iso2" agtype);
       id(n)       |  n.name   | n.iso2 
@@ -194,13 +265,16 @@ SELECT * FROM cypher('agload_test_graph', $$MATCH(n:Country2 {iso2 : 'BE'})
  1688849860263942 | "Belgium" | "BE"
 (1 row)
 
+-- Should return 2 rows for Country with same properties, but different ids
 SELECT * FROM cypher('agload_test_graph', $$MATCH(n:Country {iso2 : 'AT'})
     RETURN id(n), n.name, n.iso2 $$) as ("id(n)" agtype, "n.name" agtype, "n.iso2" agtype);
       id(n)      |  n.name   | n.iso2 
 -----------------+-----------+--------
  844424930131983 | "Austria" | "AT"
-(1 row)
+ 844424930132221 | "Austria" | "AT"
+(2 rows)
 
+-- Should return 1 row
 SELECT * FROM cypher('agload_test_graph', $$MATCH(n:Country2 {iso2 : 'AT'})
     RETURN id(n), n.name, n.iso2 $$) as ("id(n)" agtype, "n.name" agtype, "n.iso2" agtype);
       id(n)       |  n.name   | n.iso2 
@@ -208,14 +282,23 @@ SELECT * FROM cypher('agload_test_graph', $$MATCH(n:Country2 {iso2 : 'AT'})
  1688849860263940 | "Austria" | "AT"
 (1 row)
 
+-- Should return 2 rows for Country with same properties, but different ids
 SELECT * FROM cypher('agload_test_graph', $$
     MATCH (u:Country {region : "Europe"})
     WHERE u.name =~ 'Cro.*'
-    RETURN u.name, u.region
-$$) AS (result_1 agtype, result_2 agtype);
- result_1  | result_2 
------------+----------
- "Croatia" | "Europe"
+    RETURN id(u), u.name, u.region
+$$) AS ("id(u)" agtype, result_1 agtype, result_2 agtype);
+      id(u)      | result_1  | result_2 
+-----------------+-----------+----------
+ 844424930132023 | "Croatia" | "Europe"
+ 844424930132226 | "Croatia" | "Europe"
+(2 rows)
+
+-- There shouldn't be any duplicates
+SELECT * FROM cypher('agload_test_graph', $$return graph_stats('agload_test_graph')$$) as (a agtype);
+                                            a                                             
+------------------------------------------------------------------------------------------
+ {"graph": "agload_test_graph", "num_loaded_edges": 72485, "num_loaded_vertices": 145130}
 (1 row)
 
 SELECT drop_graph('agload_test_graph', true);
@@ -236,22 +319,11 @@ NOTICE:  graph "agload_test_graph" has been dropped
 --
 -- Test property type conversion
 --
-SELECT create_graph('agload_conversion');
-NOTICE:  graph "agload_conversion" has been created
- create_graph 
---------------
- 
-(1 row)
-
 -- vertex: load as agtype
-SELECT create_vlabel('agload_conversion','Person1');
-NOTICE:  VLabel "Person1" has been created
- create_vlabel 
----------------
- 
-(1 row)
-
+-- Should create graph and label automatically
 SELECT load_labels_from_file('agload_conversion', 'Person1', 'age_load/conversion_vertices.csv', true, true);
+NOTICE:  graph "agload_conversion" has been created
+NOTICE:  VLabel "Person1" has been created
  load_labels_from_file 
 -----------------------
  

--- a/regress/sql/age_load.sql
+++ b/regress/sql/age_load.sql
@@ -22,19 +22,64 @@
 LOAD 'age';
 
 SET search_path TO ag_catalog;
+
+-- Create a country using CREATE clause
 SELECT create_graph('agload_test_graph');
 
-SELECT create_vlabel('agload_test_graph','Country');
-SELECT load_labels_from_file('agload_test_graph', 'Country',
-    'age_load/countries.csv');
+SELECT * FROM cypher('agload_test_graph', $$CREATE (n:Country {__id__:1}) RETURN n$$) as (n agtype);
 
-SELECT create_vlabel('agload_test_graph','City');
+--
+-- Load countries with id
+--
+SELECT load_labels_from_file('agload_test_graph', 'Country',
+    'age_load/countries.csv', true);
+
+-- A temporary table should have been created with 54 ids; 1 from CREATE and 53 from file
+SELECT COUNT(*)=54 FROM "_agload_test_graph_ag_vertex_ids";
+
+-- Sequence should be equal to max entry id i.e. 248
+SELECT currval('agload_test_graph."Country_id_seq"')=248;
+
+-- Should error out on loading the same file again due to duplicate id
+SELECT load_labels_from_file('agload_test_graph', 'Country',
+    'age_load/countries.csv', true);
+
+--
+-- Load cities with id
+--
+
+-- Should create City label automatically and load cities
 SELECT load_labels_from_file('agload_test_graph', 'City',
-    'age_load/cities.csv');
+    'age_load/cities.csv', true);
+
+-- Temporary table should have 54+72485 rows now
+SELECT COUNT(*)=54+72485 FROM "_agload_test_graph_ag_vertex_ids";
+
+-- Sequence should be equal to max entry id i.e. 146941
+SELECT currval('agload_test_graph."City_id_seq"')=146941;
+
+-- Should error out on loading the same file again due to duplicate id
+SELECT load_labels_from_file('agload_test_graph', 'City',
+    'age_load/cities.csv', true);
+
+--
+-- Load edges -- Connects cities to countries
+--
+
+-- Should error out for using vertex label
+SELECT load_edges_from_file('agload_test_graph', 'Country',
+    'age_load/edges.csv');
 
 SELECT create_elabel('agload_test_graph','has_city');
 SELECT load_edges_from_file('agload_test_graph', 'has_city',
      'age_load/edges.csv');
+
+-- Sequence should be equal to number of edges loaded i.e. 72485
+SELECT currval('agload_test_graph."has_city_id_seq"')=72485;
+
+-- Should error out for using edge label
+SELECT load_labels_from_file('agload_test_graph', 'has_city',
+     'age_load/cities.csv');
 
 SELECT table_catalog, table_schema, lower(table_name) as table_name, table_type
 FROM information_schema.tables
@@ -47,6 +92,14 @@ SELECT COUNT(*) FROM agload_test_graph."has_city";
 SELECT COUNT(*) FROM cypher('agload_test_graph', $$MATCH(n) RETURN n$$) as (n agtype);
 
 SELECT COUNT(*) FROM cypher('agload_test_graph', $$MATCH (a)-[e]->(b) RETURN e$$) as (n agtype);
+
+--
+-- Load countries and cities without id
+--
+
+-- Should load countries in Country label without error since it should use sequence now
+SELECT load_labels_from_file('agload_test_graph', 'Country',
+    'age_load/countries.csv', false);
 
 SELECT create_vlabel('agload_test_graph','Country2');
 SELECT load_labels_from_file('agload_test_graph', 'Country2',
@@ -62,31 +115,39 @@ SELECT COUNT(*) FROM agload_test_graph."City2";
 SELECT id FROM agload_test_graph."Country" LIMIT 10;
 SELECT id FROM agload_test_graph."Country2" LIMIT 10;
 
+-- Should return 2 rows for Country with same properties, but different ids
 SELECT * FROM cypher('agload_test_graph', $$MATCH(n:Country {iso2 : 'BE'})
     RETURN id(n), n.name, n.iso2 $$) as ("id(n)" agtype, "n.name" agtype, "n.iso2" agtype);
+-- Should return 1 row
 SELECT * FROM cypher('agload_test_graph', $$MATCH(n:Country2 {iso2 : 'BE'})
     RETURN id(n), n.name, n.iso2 $$) as ("id(n)" agtype, "n.name" agtype, "n.iso2" agtype);
 
+-- Should return 2 rows for Country with same properties, but different ids
 SELECT * FROM cypher('agload_test_graph', $$MATCH(n:Country {iso2 : 'AT'})
     RETURN id(n), n.name, n.iso2 $$) as ("id(n)" agtype, "n.name" agtype, "n.iso2" agtype);
+-- Should return 1 row
 SELECT * FROM cypher('agload_test_graph', $$MATCH(n:Country2 {iso2 : 'AT'})
     RETURN id(n), n.name, n.iso2 $$) as ("id(n)" agtype, "n.name" agtype, "n.iso2" agtype);
 
+-- Should return 2 rows for Country with same properties, but different ids
 SELECT * FROM cypher('agload_test_graph', $$
     MATCH (u:Country {region : "Europe"})
     WHERE u.name =~ 'Cro.*'
-    RETURN u.name, u.region
-$$) AS (result_1 agtype, result_2 agtype);
+    RETURN id(u), u.name, u.region
+$$) AS ("id(u)" agtype, result_1 agtype, result_2 agtype);
+
+-- There shouldn't be any duplicates
+SELECT * FROM cypher('agload_test_graph', $$return graph_stats('agload_test_graph')$$) as (a agtype);
 
 SELECT drop_graph('agload_test_graph', true);
 
 --
 -- Test property type conversion
 --
-SELECT create_graph('agload_conversion');
 
 -- vertex: load as agtype
-SELECT create_vlabel('agload_conversion','Person1');
+
+-- Should create graph and label automatically
 SELECT load_labels_from_file('agload_conversion', 'Person1', 'age_load/conversion_vertices.csv', true, true);
 SELECT * FROM cypher('agload_conversion', $$ MATCH (n:Person1) RETURN properties(n) $$) as (a agtype);
 

--- a/src/backend/catalog/ag_label.c
+++ b/src/backend/catalog/ag_label.c
@@ -174,6 +174,11 @@ char get_label_kind(const char *label_name, Oid label_graph)
     }
 }
 
+char *get_label_seq_relation_name(const char *label_name)
+{
+    return psprintf("%s_id_seq", label_name);
+}
+
 PG_FUNCTION_INFO_V1(_label_name);
 
 /*

--- a/src/backend/utils/load/age_load.c
+++ b/src/backend/utils/load/age_load.c
@@ -28,6 +28,9 @@
 
 static agtype_value *csv_value_to_agtype_value(char *csv_val);
 static bool json_validate(text *json);
+static Oid get_or_create_graph(const Name graph_name);
+static int32 get_or_create_label(Oid graph_oid, char *graph_name,
+                                 char *label_name, char label_kind);
 
 agtype *create_empty_agtype(void)
 {
@@ -281,6 +284,34 @@ void insert_vertex_simple(Oid graph_oid, char *label_name, graphid vertex_id,
     CommandCounterIncrement();
 }
 
+void insert_batch(batch_insert_state *batch_state, char *label_name,
+                  Oid graph_oid)
+{
+    Relation label_relation;
+    BulkInsertState bistate;
+    Oid relid;
+
+    // Get the relation OID
+    relid = get_label_relation(label_name, graph_oid);
+
+    // Open the relation
+    label_relation = table_open(relid, RowExclusiveLock);
+
+    // Prepare the BulkInsertState
+    bistate = GetBulkInsertState();
+
+    // Perform the bulk insert
+    heap_multi_insert(label_relation, batch_state->slots,
+                      batch_state->num_tuples, GetCurrentCommandId(true),
+                      0, bistate);
+
+    // Clean up
+    FreeBulkInsertState(bistate);
+    table_close(label_relation, RowExclusiveLock);
+
+    CommandCounterIncrement();
+}
+
 PG_FUNCTION_INFO_V1(load_labels_from_file);
 Datum load_labels_from_file(PG_FUNCTION_ARGS)
 {
@@ -319,19 +350,24 @@ Datum load_labels_from_file(PG_FUNCTION_ARGS)
     id_field_exists = PG_GETARG_BOOL(3);
     load_as_agtype = PG_GETARG_BOOL(4);
 
-
     graph_name_str = NameStr(*graph_name);
     label_name_str = NameStr(*label_name);
+
+    if (strcmp(label_name_str, "") == 0)
+    {
+        label_name_str = AG_DEFAULT_LABEL_VERTEX;
+    }
+
     file_path_str = text_to_cstring(file_path);
 
-    graph_oid = get_graph_oid(graph_name_str);
-    label_id = get_label_id(label_name_str, graph_oid);
+    graph_oid = get_or_create_graph(graph_name);
+    label_id = get_or_create_label(graph_oid, graph_name_str,
+                                   label_name_str, LABEL_KIND_VERTEX);
 
     create_labels_from_csv_file(file_path_str, graph_name_str, graph_oid,
                                 label_name_str, label_id, id_field_exists,
                                 load_as_agtype);
     PG_RETURN_VOID();
-
 }
 
 PG_FUNCTION_INFO_V1(load_edges_from_file);
@@ -373,13 +409,91 @@ Datum load_edges_from_file(PG_FUNCTION_ARGS)
 
     graph_name_str = NameStr(*graph_name);
     label_name_str = NameStr(*label_name);
+
+    if (strcmp(label_name_str, "") == 0)
+    {
+        label_name_str = AG_DEFAULT_LABEL_EDGE;
+    }
+
     file_path_str = text_to_cstring(file_path);
 
-    graph_oid = get_graph_oid(graph_name_str);
-    label_id = get_label_id(label_name_str, graph_oid);
+    graph_oid = get_or_create_graph(graph_name);
+    label_id = get_or_create_label(graph_oid, graph_name_str,
+                                   label_name_str, LABEL_KIND_EDGE);
 
     create_edges_from_csv_file(file_path_str, graph_name_str, graph_oid,
                                label_name_str, label_id, load_as_agtype);
     PG_RETURN_VOID();
+}
 
+/*
+ * Helper function to create a graph if it does not exist.
+ * Just returns Oid of the graph if it already exists.
+ */
+static Oid get_or_create_graph(const Name graph_name)
+{
+    Oid graph_oid;
+    char *graph_name_str;
+
+    graph_name_str = NameStr(*graph_name);
+    graph_oid = get_graph_oid(graph_name_str);
+
+    if (OidIsValid(graph_oid))
+    {
+        return graph_oid;
+    }
+
+    graph_oid = create_graph_internal(graph_name);
+    ereport(NOTICE,
+            (errmsg("graph \"%s\" has been created", NameStr(*graph_name))));
+    
+    return graph_oid;
+}
+
+/*
+ * Helper function to create a label if it does not exist.
+ * Just returns label_id of the label if it already exists.
+ */
+static int32 get_or_create_label(Oid graph_oid, char *graph_name,
+                                 char *label_name, char label_kind)
+{
+    int32 label_id;
+
+    label_id = get_label_id(label_name, graph_oid);
+
+    /* Check if label exists */
+    if (label_id_is_valid(label_id))
+    {
+        char *label_kind_full = (label_kind == LABEL_KIND_VERTEX)
+                                ? "vertex" : "edge";
+        char opposite_label_kind = (label_kind == LABEL_KIND_VERTEX)
+                                    ? LABEL_KIND_EDGE : LABEL_KIND_VERTEX;
+
+        /* If it exists, but as another label_kind, throw an error */
+        if (get_label_kind(label_name, graph_oid) == opposite_label_kind)
+        {
+            ereport(ERROR,
+                    (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                     errmsg("label \"%s\" already exists as %s label",
+                            label_name, label_kind_full)));
+        }
+    }
+    else
+    {
+        /* Create a label */
+        RangeVar *rv;
+        List *parent;
+        char *default_label = (label_kind == LABEL_KIND_VERTEX)
+                               ? AG_DEFAULT_LABEL_VERTEX : AG_DEFAULT_LABEL_EDGE;
+        rv = get_label_range_var(graph_name, graph_oid, default_label);
+        parent = list_make1(rv);
+
+        create_label(graph_name, label_name, label_kind, parent);
+        label_id = get_label_id(label_name, graph_oid);
+
+        ereport(NOTICE,
+                (errmsg("VLabel \"%s\" has been created", label_name)));
+    }
+
+    return label_id;
 }

--- a/src/include/catalog/ag_label.h
+++ b/src/include/catalog/ag_label.h
@@ -73,6 +73,8 @@ int32 get_label_id(const char *label_name, Oid graph_oid);
 Oid get_label_relation(const char *label_name, Oid graph_oid);
 char *get_label_relation_name(const char *label_name, Oid graph_oid);
 char get_label_kind(const char *label_name, Oid label_graph);
+char *get_label_seq_relation_name(const char *label_name);
+
 
 bool label_id_exists(Oid graph_oid, int32 label_id);
 RangeVar *get_label_range_var(char *graph_name, Oid graph_oid,

--- a/src/include/commands/graph_commands.h
+++ b/src/include/commands/graph_commands.h
@@ -21,5 +21,6 @@
 #define AG_GRAPH_COMMANDS_H
 
 Datum create_graph(PG_FUNCTION_ARGS);
+Oid create_graph_internal(const Name graph_name);
 
 #endif

--- a/src/include/utils/graphid.h
+++ b/src/include/utils/graphid.h
@@ -36,7 +36,7 @@ typedef int64 graphid;
 
 #define label_id_is_valid(id) (id >= LABEL_ID_MIN && id <= LABEL_ID_MAX)
 
-#define ENTRY_ID_MIN INT64CONST(1)
+#define ENTRY_ID_MIN INT64CONST(0)
 /* 0x0000ffffffffffff */
 #define ENTRY_ID_MAX INT64CONST(281474976710655)
 #define INVALID_ENTRY_ID INT64CONST(0)

--- a/src/include/utils/load/ag_load_edges.h
+++ b/src/include/utils/load/ag_load_edges.h
@@ -17,6 +17,9 @@
  * under the License.
  */
 
+#include "access/heapam.h"
+#include "utils/load/age_load.h"
+
 #ifndef AG_LOAD_EDGES_H
 #define AG_LOAD_EDGES_H
 
@@ -34,12 +37,13 @@ typedef struct {
     size_t curr_row_length;
     char *graph_name;
     Oid graph_oid;
-    char *object_name;
-    int object_id;
+    char *label_name;
+    int label_id;
+    Oid label_seq_relid;
     char *start_vertex;
     char *end_vertex;
     bool load_as_agtype;
-
+    batch_insert_state *batch_state;
 } csv_edge_reader;
 
 
@@ -47,7 +51,7 @@ void edge_field_cb(void *field, size_t field_len, void *data);
 void edge_row_cb(int delim __attribute__((unused)), void *data);
 
 int create_edges_from_csv_file(char *file_path, char *graph_name, Oid graph_oid,
-                                char *object_name, int object_id,
+                                char *label_name, int label_id,
                                 bool load_as_agtype);
 
 #endif /*AG_LOAD_EDGES_H */

--- a/src/include/utils/load/ag_load_labels.h
+++ b/src/include/utils/load/ag_load_labels.h
@@ -22,6 +22,7 @@
 #define AG_LOAD_LABELS_H
 
 #include "access/heapam.h"
+#include "utils/load/age_load.h"
 
 #define AGE_VERTIX 1
 #define AGE_EDGE 2
@@ -47,10 +48,14 @@ typedef struct {
     size_t curr_row_length;
     char *graph_name;
     Oid graph_oid;
-    char *object_name;
-    int object_id;
+    char *label_name;
+    int label_id;
+    Oid label_seq_relid;
+    Oid temp_table_relid;
     bool id_field_exists;
     bool load_as_agtype;
+    int curr_seq_num;
+    batch_insert_state *batch_state;
 } csv_vertex_reader;
 
 
@@ -58,7 +63,7 @@ void vertex_field_cb(void *field, size_t field_len, void *data);
 void vertex_row_cb(int delim __attribute__((unused)), void *data);
 
 int create_labels_from_csv_file(char *file_path, char *graph_name, Oid graph_oid,
-                                char *object_name, int object_id,
+                                char *label_name, int label_id,
                                 bool id_field_exists, bool load_as_agtype);
 
 #endif /* AG_LOAD_LABELS_H */

--- a/src/include/utils/load/age_load.h
+++ b/src/include/utils/load/age_load.h
@@ -24,10 +24,25 @@
 #include "catalog/ag_graph.h"
 #include "catalog/ag_label.h"
 #include "commands/label_commands.h"
+#include "commands/graph_commands.h"
 #include "utils/ag_cache.h"
 
 #ifndef AGE_ENTITY_CREATOR_H
 #define AGE_ENTITY_CREATOR_H
+
+#define TEMP_VERTEX_ID_TABLE_SUFFIX "_ag_vertex_ids"
+#define GET_TEMP_VERTEX_ID_TABLE(graph_name) \
+    psprintf("_%s%s", graph_name, TEMP_VERTEX_ID_TABLE_SUFFIX)
+
+#define BATCH_SIZE 1000
+
+typedef struct
+{
+    TupleTableSlot **slots;
+    TupleTableSlot **temp_id_slots;
+    int num_tuples;
+    int max_tuples;
+} batch_insert_state;
 
 agtype* create_empty_agtype(void);
 
@@ -42,5 +57,7 @@ void insert_vertex_simple(Oid graph_oid, char *label_name, graphid vertex_id,
 void insert_edge_simple(Oid graph_oid, char *label_name, graphid edge_id,
                         graphid start_id, graphid end_id,
                         agtype* end_properties);
+void insert_batch(batch_insert_state *batch_state, char *label_name,
+                  Oid graph_oid);
 
 #endif /* AGE_ENTITY_CREATOR_H */


### PR DESCRIPTION
- Allow 0 as entry_id
- Use batch inserts to improve performance
    - Changed heap_insert to heap_multi_insert since it is faster than calling heap_insert() in a loop. When multiple tuples can be inserted on a single page, just a single WAL record covering all of them, and only need to lock/unlock the page once.
    - BATCH_SIZE is set to 1000, which is the number of tuples to insert in a single batch. This number was chosen after some experimentation.
    - Change some of the field names to avoid confusion.
- Use sequence for generating ids for edge and vertex
     - Sequence is not used if the id_field_exists is true in load_labels_from_file function, since the entry id is present in the csv.
- Add function to create temporary table for ids, this is only used for loading vertices
    - A temporary table is created and populated with already generated vertex ids when first time load_labels_from_file function is called. A unique index is created on id column to ensure that new ids generated (using entry id from csv) are unique. This table and index will be deleted automatically whenever the session ends.
    - Whenever a row is inserted in labels, the corresponding id is inserted into temp table as well. 
- Add functions to create graph and label automatically
    - These functions will check existence of graph and label, and create them if they don't exist.
