### PR TITLE
Correctly parse nested arrays in the nodejs driver

### DIFF
--- a/drivers/nodejs/src/antlr4/CustomAgTypeListener.ts
+++ b/drivers/nodejs/src/antlr4/CustomAgTypeListener.ts
@@ -145,6 +145,10 @@ class CustomAgTypeListener implements AgtypeListener, ParseTreeListener {
     this.mergeArray()
   }
 
+  exitArrayValue(): void {
+    this.mergeArray();
+  }
+
   exitPair (ctx: PairContext): void {
     const name = this.stripQuotes(ctx.STRING().text)
 

--- a/drivers/nodejs/test/Agtype.test.ts
+++ b/drivers/nodejs/test/Agtype.test.ts
@@ -101,4 +101,16 @@ describe('Parsing', () => {
       }))
     })))
   })
+
+  it("Nested Array Parsing", () => {
+    expect(
+      AGTypeParse(
+        '{"id": 1125899906842627, "label": "car", "properties": {"wheels": [ "a", ["d"] ]}}::vertex',
+      ),
+    ).toStrictEqual(new Map<string, any>(Object.entries({
+      id: 1125899906842627,
+      label: "car",
+      properties: new Map<string, any>(Object.entries({ wheels: ["a", ["d"]] })),
+    })));
+  });
 })


### PR DESCRIPTION
This is a fix for #221 where parsing of nested arrays produced incorrect results in the node/js driver. 