### PR TITLE
Fix memory leaks in functions part 1

### DIFF
--- a/src/backend/utils/adt/age_vle.c
+++ b/src/backend/utils/adt/age_vle.c
@@ -2147,7 +2147,6 @@ agtype_value *agtv_materialize_vle_edges(agtype *agt_arg_vpc)
     /* build the AGTV_ARRAY of edges from the VLE_path_container */
     agtv_array = build_edge_list(vpc);
 
-    /* convert the agtype_value to agtype and return it */
     return agtv_array;
 
 }

--- a/src/backend/utils/adt/agtype_util.c
+++ b/src/backend/utils/adt/agtype_util.c
@@ -87,7 +87,6 @@ static agtype_value *push_agtype_value_scalar(agtype_parse_state **pstate,
                                               agtype_value *scalar_val);
 static int compare_two_floats_orderability(float8 lhs, float8 rhs);
 static int get_type_sort_priority(enum agtype_value_type type);
-static void pfree_agtype_value_content(agtype_value* value);
 static void pfree_iterator_agtype_value_token(agtype_iterator_token token,
                                               agtype_value *agtv);
 
@@ -2365,7 +2364,7 @@ void pfree_agtype_value(agtype_value* value)
  * of the passed agtype_value only. It does not deallocate
  * `value` itself.
  */
-static void pfree_agtype_value_content(agtype_value* value)
+void pfree_agtype_value_content(agtype_value* value)
 {
     int i;
 

--- a/src/include/utils/agtype.h
+++ b/src/include/utils/agtype.h
@@ -551,6 +551,7 @@ agtype_iterator *get_next_list_element(agtype_iterator *it,
                                        agtype_container *agtc,
                                        agtype_value *elem);
 void pfree_agtype_value(agtype_value* value);
+void pfree_agtype_value_content(agtype_value* value);
 void pfree_agtype_in_state(agtype_in_state* value);
 agtype_value *agtype_value_from_cstring(char *str, int len);
 


### PR DESCRIPTION
Fixing memory leaks in functions due to contexts not clearing out the memory soon enough.

Background: Destroying a context will free up its associated memory. However, before that happens, a process can still accumulate a lot of memory working on large data sets if it expects the context free to do it for it. For example, when PG does quicksort the context isn't destroyed until after the qs has finished. This can cause memory to be exhausted.

Put in more aggressive freeing of memory. However, there are a lot of areas that need this applied. So, this is part 1 of at least 3 or 4 parts.

Worked mainly on `agtype.c` However, dealt with linked functions in other files.

    modified:   src/backend/utils/adt/age_vle.c
    modified:   src/backend/utils/adt/agtype.c
    modified:   src/backend/utils/adt/agtype_util.c
    modified:   src/include/utils/agtype.h