### PR TITLE
Add support for fuzzystrmatch and other external extensions (#2083)

### DIFF
--- a/regress/expected/expr.out
+++ b/regress/expected/expr.out
@@ -8770,8 +8770,37 @@ SELECT * FROM cypher('issue_1988', $$
 (4 rows)
 
 --
+-- Test external extension function logic for fuzzystrmatch
+--
+SELECT * FROM create_graph('fuzzystrmatch');
+NOTICE:  graph "fuzzystrmatch" has been created
+ create_graph 
+--------------
+ 
+(1 row)
+
+-- These should fail with extension not installed
+SELECT * FROM cypher('fuzzystrmatch', $$ RETURN soundex("hello world!") $$) AS (result agtype);
+ERROR:  extension fuzzystrmatch is not installed for function soundex
+LINE 1: SELECT * FROM cypher('fuzzystrmatch', $$ RETURN soundex("hel...
+                                               ^
+SELECT * FROM cypher('fuzzystrmatch', $$ RETURN difference("hello world!", "hello world!") $$) AS (result agtype);
+ERROR:  extension fuzzystrmatch is not installed for function difference
+LINE 1: SELECT * FROM cypher('fuzzystrmatch', $$ RETURN difference("...
+                                               ^
+--
 -- Cleanup
 --
+SELECT * FROM drop_graph('fuzzystrmatch', true);
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table fuzzystrmatch._ag_label_vertex
+drop cascades to table fuzzystrmatch._ag_label_edge
+NOTICE:  graph "fuzzystrmatch" has been dropped
+ drop_graph 
+------------
+ 
+(1 row)
+
 SELECT * FROM drop_graph('issue_1988', true);
 NOTICE:  drop cascades to 4 other objects
 DETAIL:  drop cascades to table issue_1988._ag_label_vertex

--- a/regress/sql/expr.sql
+++ b/regress/sql/expr.sql
@@ -3538,8 +3538,17 @@ SELECT * FROM cypher('issue_1988', $$
     MATCH (p) RETURN p $$) as (p agtype);
 
 --
+-- Test external extension function logic for fuzzystrmatch
+--
+SELECT * FROM create_graph('fuzzystrmatch');
+-- These should fail with extension not installed
+SELECT * FROM cypher('fuzzystrmatch', $$ RETURN soundex("hello world!") $$) AS (result agtype);
+SELECT * FROM cypher('fuzzystrmatch', $$ RETURN difference("hello world!", "hello world!") $$) AS (result agtype);
+
+--
 -- Cleanup
 --
+SELECT * FROM drop_graph('fuzzystrmatch', true);
 SELECT * FROM drop_graph('issue_1988', true);
 SELECT * FROM drop_graph('issue_1953', true);
 SELECT * FROM drop_graph('expanded_map', true);

--- a/sql/agtype_coercions.sql
+++ b/sql/agtype_coercions.sql
@@ -32,6 +32,15 @@ AS 'MODULE_PATHNAME';
 CREATE CAST (agtype AS text)
     WITH FUNCTION ag_catalog.agtype_to_text(agtype);
 
+-- text -> agtype
+CREATE FUNCTION ag_catalog.text_to_agtype(text)
+    RETURNS agtype
+    LANGUAGE c
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
 -- agtype -> boolean (implicit)
 CREATE FUNCTION ag_catalog.agtype_to_bool(agtype)
     RETURNS boolean
@@ -69,7 +78,7 @@ AS 'MODULE_PATHNAME';
 CREATE CAST (float8 AS agtype)
     WITH FUNCTION ag_catalog.float8_to_agtype(float8);
 
--- agtype -> float8 (implicit)
+-- agtype -> float8 (exmplicit)
 CREATE FUNCTION ag_catalog.agtype_to_float8(agtype)
     RETURNS float8
     LANGUAGE c
@@ -105,6 +114,18 @@ AS 'MODULE_PATHNAME';
 CREATE CAST (agtype AS bigint)
     WITH FUNCTION ag_catalog.agtype_to_int8(variadic "any")
 AS ASSIGNMENT;
+
+-- int4 -> agtype (explicit)
+CREATE FUNCTION ag_catalog.int4_to_agtype(int4)
+    RETURNS agtype
+    LANGUAGE c
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
+CREATE CAST (int4 AS agtype)
+    WITH FUNCTION ag_catalog.int4_to_agtype(int4);
 
 -- agtype -> int4
 CREATE FUNCTION ag_catalog.agtype_to_int4(variadic "any")

--- a/src/backend/utils/adt/agtype.c
+++ b/src/backend/utils/adt/agtype.c
@@ -3199,6 +3199,49 @@ Datum agtype_to_text(PG_FUNCTION_ARGS)
     PG_RETURN_TEXT_P(text_value);
 }
 
+PG_FUNCTION_INFO_V1(text_to_agtype);
+
+/*
+ * Cast text to agtype.
+ */
+Datum text_to_agtype(PG_FUNCTION_ARGS)
+{
+    agtype *result = NULL;
+    agtype_value agtv;
+    text *text_value = NULL;
+    char *string = NULL;
+    int len = 0;
+
+    if (PG_ARGISNULL(0))
+    {
+        PG_RETURN_NULL();
+    }
+
+    /* get the text value */
+    text_value = PG_GETARG_TEXT_PP(0);
+    /* convert it to a string */
+    string = text_to_cstring(text_value);
+    /* get the length */
+    len = strlen(string);
+
+    /* create a temporary agtype string */
+    agtv.type = AGTV_STRING;
+    agtv.val.string.len = len;
+    agtv.val.string.val = pstrdup(string);
+
+    /* free the string */
+    pfree(string);
+
+    /* convert to agtype */
+    result = agtype_value_to_agtype(&agtv);
+
+    /* free the input arg if necessary */
+    PG_FREE_IF_COPY(text_value, 0);
+
+    /* return our result */
+    PG_RETURN_POINTER(result);
+}
+
 PG_FUNCTION_INFO_V1(agtype_to_json);
 
 /*
@@ -3263,11 +3306,20 @@ Datum float8_to_agtype(PG_FUNCTION_ARGS)
 PG_FUNCTION_INFO_V1(int8_to_agtype);
 
 /*
- * Cast float8 to agtype.
+ * Cast int8 to agtype.
  */
 Datum int8_to_agtype(PG_FUNCTION_ARGS)
 {
     return integer_to_agtype(PG_GETARG_INT64(0));
+}
+
+PG_FUNCTION_INFO_V1(int4_to_agtype);
+/*
+ * Cast int to agtype.
+ */
+Datum int4_to_agtype(PG_FUNCTION_ARGS)
+{
+    return integer_to_agtype((int64)PG_GETARG_INT32(0));
 }
 
 PG_FUNCTION_INFO_V1(agtype_to_int4_array);


### PR DESCRIPTION
Added support for the fuzzystrmatch extension and for other external extensions.

Added support for typecasting `::pg_text` to TEXTOID.

Added regression tests.

   modified:   sql/agtype_coercions.sql
   modified:   src/backend/parser/cypher_expr.c
   modified:   src/backend/utils/adt/agtype.c
   modified:   regress/expected/expr.out
   modified:   regress/sql/expr.sql