### PR TITLE
Restore object_access hook after dropping extension

### DIFF
--- a/regress/expected/drop.out
+++ b/regress/expected/drop.out
@@ -115,7 +115,7 @@ NOTICE:  label "issue_1305"."r" has been dropped
 (1 row)
 
 SELECT drop_label('issue_1305', 'r');
-ERROR:  rel_name not found for label "r"
+ERROR:  label "r" does not exist
 SELECT drop_label('issue_1305', 'n', false);
 NOTICE:  label "issue_1305"."n" has been dropped
  drop_label 
@@ -124,7 +124,20 @@ NOTICE:  label "issue_1305"."n" has been dropped
 (1 row)
 
 SELECT drop_label('issue_1305', 'n');
-ERROR:  rel_name not found for label "n"
+ERROR:  label "n" does not exist
+-- Validate that not only tables are dropped, but labels are also removed via object_access hook.
+SELECT COUNT(*) FROM ag_label WHERE name IN ('n', 'r');
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM pg_catalog.pg_tables WHERE schemaname = 'issue_1305' AND tablename IN ('n', 'r');
+ count 
+-------
+     0
+(1 row)
+
 SELECT * FROM drop_graph('issue_1305', true);
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to table issue_1305._ag_label_vertex

--- a/regress/sql/drop.sql
+++ b/regress/sql/drop.sql
@@ -61,6 +61,11 @@ SELECT drop_label('issue_1305', 'r', false);
 SELECT drop_label('issue_1305', 'r');
 SELECT drop_label('issue_1305', 'n', false);
 SELECT drop_label('issue_1305', 'n');
+
+-- Validate that not only tables are dropped, but labels are also removed via object_access hook.
+SELECT COUNT(*) FROM ag_label WHERE name IN ('n', 'r');
+SELECT COUNT(*) FROM pg_catalog.pg_tables WHERE schemaname = 'issue_1305' AND tablename IN ('n', 'r');
+
 SELECT * FROM drop_graph('issue_1305', true);
 
 -- END

--- a/src/backend/catalog/ag_catalog.c
+++ b/src/backend/catalog/ag_catalog.c
@@ -126,6 +126,9 @@ static void drop_age_extension(DropStmt *stmt)
     /* reset global variables for OIDs */
     clear_global_Oids_AGTYPE();
     clear_global_Oids_GRAPHID();
+
+   /* Restore the object access hook */
+   object_access_hook_init();
 }
 
 /* Check to see if the Utility Command is to drop the AGE Extension. */


### PR DESCRIPTION
Not doing so results in inconsistencies between pg_catalog and ap_catalog.label if extension was dropped and recreated in the same session.

Previously this problem resulted in crashes, and #1306 only put some safeguard checks that prevent crashes when the relation was dropped without label, however, it didn't solved the root cause.