### PR TITLE
Add support for PG17

### DIFF
--- a/src/backend/nodes/ag_nodes.c
+++ b/src/backend/nodes/ag_nodes.c
@@ -156,7 +156,7 @@ ExtensibleNode *_new_ag_node(Size size, ag_node_tag tag)
 {
     ExtensibleNode *n;
 
-    n = (ExtensibleNode *)palloc0fast(size);
+    n = (ExtensibleNode *)palloc0(size);
     n->type = T_ExtensibleNode;
     n->extnodename = node_names[tag];
 

--- a/src/backend/parser/cypher_analyze.c
+++ b/src/backend/parser/cypher_analyze.c
@@ -174,6 +174,8 @@ static bool convert_cypher_walker(Node *node, ParseState *pstate)
          * OpExpr - expression node for an operator invocation
          * Const - constant value or expression node
          * BoolExpr - expression node for the basic Boolean operators AND, OR, NOT
+         * JsonConstructorExpr - wrapper over FuncExpr/Aggref/WindowFunc for
+         *                       SQL/JSON constructors
          *
          * These are a special case that needs to be ignored.
          *
@@ -181,7 +183,8 @@ static bool convert_cypher_walker(Node *node, ParseState *pstate)
         if (IsA(funcexpr, SQLValueFunction)
                 || IsA(funcexpr, CoerceViaIO)
                 || IsA(funcexpr, Var)   || IsA(funcexpr, OpExpr)
-                || IsA(funcexpr, Const) || IsA(funcexpr, BoolExpr))
+                || IsA(funcexpr, Const) || IsA(funcexpr, BoolExpr)
+                || IsA(funcexpr, JsonConstructorExpr))
         {
             return false;
         }
@@ -346,6 +349,8 @@ static bool is_func_cypher(FuncExpr *funcexpr)
      * OpExpr - expression node for an operator invocation
      * Const - constant value or expression node
      * BoolExpr - expression node for the basic Boolean operators AND, OR, NOT
+     * JsonConstructorExpr - wrapper over FuncExpr/Aggref/WindowFunc for
+     *                       SQL/JSON constructors
      *
      * These are a special case that needs to be ignored.
      *
@@ -353,7 +358,8 @@ static bool is_func_cypher(FuncExpr *funcexpr)
     if (IsA(funcexpr, SQLValueFunction)
             || IsA(funcexpr, CoerceViaIO)
             || IsA(funcexpr, Var)   || IsA(funcexpr, OpExpr)
-            || IsA(funcexpr, Const) || IsA(funcexpr, BoolExpr))
+            || IsA(funcexpr, Const) || IsA(funcexpr, BoolExpr)
+            || IsA(funcexpr, JsonConstructorExpr))
     {
         return false;
     }


### PR DESCRIPTION
- A new node type is introduced for JSON support, that is JsonConstructorExpr - wrapper over FuncExpr/Aggref/WindowFunc for SQL/JSON constructors.
- Added additional checks for JsonConstructorExpr expression node for which the walker would crash.
- Removed palloc0fast function call (which is not available in PG17)

With these fixes `make installcheck` regression passed on MacOS 11.x and Ubuntu 20.04 LTS with following summary
```
umarhayat@Umars-MacBook-Pro age % make installcheck
echo "# +++ regress install-check in  +++" && /Users/umarhayat/dev/pg_out/pg_17/lib/postgresql/pgxs/src/makefiles/../../src/test/regress/pg_regress --inputdir=./ --bindir='/Users/umarhayat/dev/pg_out/pg_17/bin'    --load-extension=age --inputdir=.//regress --outputdir=.//regress --temp-instance=.//regress/instance --port=61958 --encoding=UTF-8 --temp-config .//regress/age_regression.conf --dbname=contrib_regression scan graphid agtype agtype_hash_cmp catalog cypher expr cypher_create cypher_match cypher_unwind cypher_set cypher_remove cypher_delete cypher_with cypher_vle cypher_union cypher_call cypher_merge cypher_subquery age_global_graph age_load index analyze graph_generation name_validation jsonb_operators list_comprehension map_projection drop
# +++ regress install-check in  +++
# initializing database system by running initdb
# using temp instance on port 61958 with PID 2824
ok 1         - scan                                      186 ms
ok 2         - graphid                                     9 ms
ok 3         - agtype                                     54 ms
ok 4         - agtype_hash_cmp                             7 ms
ok 5         - catalog                                    43 ms
ok 6         - cypher                                     25 ms
ok 7         - expr                                      378 ms
ok 8         - cypher_create                              57 ms
ok 9         - cypher_match                              269 ms
ok 10        - cypher_unwind                              25 ms
ok 11        - cypher_set                                 60 ms
ok 12        - cypher_remove                              36 ms
ok 13        - cypher_delete                             212 ms
ok 14        - cypher_with                                33 ms
ok 15        - cypher_vle                                506 ms
ok 16        - cypher_union                               15 ms
ok 17        - cypher_call                                19 ms
ok 18        - cypher_merge                              165 ms
ok 19        - cypher_subquery                            33 ms
ok 20        - age_global_graph                           91 ms
ok 21        - age_load                                  831 ms
ok 22        - index                                      47 ms
ok 23        - analyze                                    14 ms
ok 24        - graph_generation                           32 ms
ok 25        - name_validation                            62 ms
ok 26        - jsonb_operators                            45 ms
ok 27        - list_comprehension                         33 ms
ok 28        - map_projection                             19 ms
ok 29        - drop                                      119 ms
1..29
# All 29 tests passed.
```
