### PR TITLE
Prevent object access hook from accesing not installed namespace

### DIFF
--- a/src/backend/catalog/ag_catalog.c
+++ b/src/backend/catalog/ag_catalog.c
@@ -20,6 +20,7 @@
 #include "postgres.h"
 
 #include "catalog/dependency.h"
+#include "catalog/namespace.h"
 #include "catalog/objectaccess.h"
 #include "catalog/pg_class_d.h"
 #include "catalog/pg_namespace_d.h"
@@ -172,6 +173,13 @@ static void object_access(ObjectAccessType access, Oid class_id, Oid object_id,
 
     /* We are interested in DROP SCHEMA and DROP TABLE commands. */
     if (access != OAT_DROP)
+        return;
+
+    /*
+     * Age might be installed into shared_preload_libraries before extension is
+     * created. In this case we must bail out from this hook.
+     */
+    if (!OidIsValid(get_namespace_oid("ag_catalog", true)))
         return;
 
     drop_arg = arg;


### PR DESCRIPTION
Currently we cannot install Age to shared_preload_libraries if pg_cron is installed.

To prevent following error we must bail out early.
postgres=# set backtrace_functions to 'get_namespace_oid'; SET
postgres=# create extension pg_cron ;
2025-04-15 16:59:49.867 +05 [30402] ERROR:  schema "ag_catalog" does not exist 2025-04-15 16:59:49.867 +05 [30402] BACKTRACE:
	2   postgres                            0x0000000102401ab0 get_namespace_oid + 204
	3   age.so                              0x0000000103285cd0 ag_catalog_namespace_id + 28
	4   age.so                              0x00000001032846fc ag_relation_id + 32
	5   age.so                              0x00000001032efe9c search_label_relation_cache_miss + 84
	6   age.so                              0x00000001032efe30 search_label_relation_cache + 100
	7   age.so                              0x00000001032842f4 object_access + 384
	8   postgres                            0x000000010240a7a0 RunObjectDropHook + 136
	9   postgres                            0x00000001023ee85c deleteOneObject + 108
	10  postgres                            0x00000001023eb860 deleteObjectsInList + 476
	11  postgres                            0x00000001023eba14 performMultipleDeletions + 316
	12  postgres                            0x0000000102560244 ATPostAlterTypeCleanup + 2144
	13  postgres                            0x0000000102559fb4 ATRewriteCatalogs + 516
	14  postgres                            0x00000001025543a8 ATController + 284
	15  postgres                            0x00000001025541bc AlterTable + 96
	16  postgres                            0x00000001028b8240 ProcessUtilitySlow + 1812
	17  postgres                            0x00000001028b600c standard_ProcessUtility + 3684
	18  age.so                              0x00000001032844f8 ag_ProcessUtility_hook + 200
	19  postgres                            0x00000001028b516c ProcessUtility + 392
	20  postgres                            0x000000010250e5b4 execute_sql_string + 812
	21  postgres                            0x000000010250d438 execute_extension_script + 2264
	22  postgres                            0x000000010250b330 ApplyExtensionUpdates + 1320
	23  postgres                            0x0000000102507954 CreateExtensionInternal + 1896
	24  postgres                            0x0000000102506ea4 CreateExtension + 1152
	25  postgres                            0x00000001028b8ed4 ProcessUtilitySlow + 5032
	26  postgres                            0x00000001028b600c standard_ProcessUtility + 3684
	27  age.so                              0x00000001032844f8 ag_ProcessUtility_hook + 200
	28  postgres                            0x00000001028b516c ProcessUtility + 392
	29  postgres                            0x00000001028b4768 PortalRunUtility + 232
	30  postgres                            0x00000001028b3660 PortalRunMulti + 756
	31  postgres                            0x00000001028b2abc PortalRun + 1008
	32  postgres                            0x00000001028ad870 exec_simple_query + 1436
	33  postgres                            0x00000001028ac990 PostgresMain + 2472
	34  postgres                            0x00000001027a49ac report_fork_failure_to_client + 0
	35  postgres                            0x00000001027a3e54 BackendStartup + 520
	36  postgres                            0x00000001027a29f0 ServerLoop + 812
	37  postgres                            0x000000010279fe0c PostmasterMain + 6484
	38  postgres                            0x000000010266acd0 startup_hacks + 0
	39  dyld                                0x000000018a3ab154 start + 2476