### PR TITLE
Adjust CI for PG17 after rename from PG17_prepare

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,6 +13,9 @@ PG14:
 PG15:
 - base-branch: 'PG15'
 
+PG16:
+- base-branch: 'PG16'
+
 PG17:
 - base-branch: 'PG17'
 

--- a/.github/workflows/go-driver.yml
+++ b/.github/workflows/go-driver.yml
@@ -2,10 +2,10 @@ name: Go Driver Tests
 
 on:
   push:
-    branches: [ "PG17_prepare" ]
+    branches: [ "PG17" ]
 
   pull_request:
-    branches: [ "PG17_prepare" ]
+    branches: [ "PG17" ]
 
 jobs:
   build:

--- a/.github/workflows/installcheck.yaml
+++ b/.github/workflows/installcheck.yaml
@@ -2,9 +2,9 @@ name: Build / Regression
 
 on:
   push:
-    branches: [ "PG17_prepare" ]
+    branches: [ "PG17" ]
   pull_request:
-    branches: [ "PG17_prepare" ]
+    branches: [ "PG17" ]
 
 jobs:
   build:
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Get latest commit id of PostgreSQL 17
         run: |
-          echo "PG_COMMIT_HASH=$(git ls-remote git://git.postgresql.org/git/postgresql.git refs/heads/REL_17_STABLE | awk '{print $1}')" >> $GITHUB_ENV
+          echo "PG_COMMIT_HASH=$(git ls-remote https://git.postgresql.org/git/postgresql.git refs/heads/REL_17_STABLE | awk '{print $1}')" >> $GITHUB_ENV
 
       - name: Cache PostgreSQL 17
         uses: actions/cache@v3
@@ -30,7 +30,7 @@ jobs:
       - name: Install PostgreSQL 17 and some extensions
         if: steps.pg17cache.outputs.cache-hit != 'true'
         run: |
-          git clone --depth 1 --branch REL_17_STABLE git://git.postgresql.org/git/postgresql.git ~/pg17source
+          git clone --depth 1 --branch REL_17_STABLE https://git.postgresql.org/git/postgresql.git ~/pg17source
           cd ~/pg17source
           ./configure --prefix=$HOME/pg17 CFLAGS="-std=gnu99 -ggdb -O0" --enable-cassert
           make install -j$(nproc) > /dev/null

--- a/.github/workflows/jdbc-driver.yaml
+++ b/.github/workflows/jdbc-driver.yaml
@@ -2,10 +2,10 @@ name: JDBC Driver Tests
 
 on:
   push:
-    branches: [ "PG17_prepare" ]
+    branches: [ "PG17" ]
 
   pull_request:
-    branches: [ "PG17_prepare" ]
+    branches: [ "PG17" ]
 
 jobs:
   build:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,6 +10,9 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
     - name: Apply branch labels
       uses: actions/labeler@v5.0.0
 

--- a/.github/workflows/nodejs-driver.yaml
+++ b/.github/workflows/nodejs-driver.yaml
@@ -2,10 +2,10 @@ name: Nodejs Driver Tests
 
 on:
   push:
-    branches: [ "PG17_prepare" ]
+    branches: [ "PG17" ]
 
   pull_request:
-    branches: [ "PG17_prepare" ]
+    branches: [ "PG17" ]
 
 jobs:
   build:

--- a/.github/workflows/python-driver.yaml
+++ b/.github/workflows/python-driver.yaml
@@ -2,10 +2,10 @@ name: Python Driver Tests
 
 on:
   push:
-    branches: [ "PG17_prepare" ]
+    branches: [ "PG17" ]
 
   pull_request:
-    branches: [ "PG17_prepare" ]
+    branches: [ "PG17" ]
 
 jobs:
   build:

--- a/drivers/docker-compose.yml
+++ b/drivers/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
   db:
-    image: apache/age:dev_snapshot_PG17_prepare
+    image: apache/age:dev_snapshot_PG17
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=agens


### PR DESCRIPTION
Adjusted the following CI files (workflows) for PG17, they originally pointed to PG17_prepare -

modified:   .github/workflows/go-driver.yml
modified:   .github/workflows/installcheck.yaml
modified:   .github/workflows/jdbc-driver.yaml
modified:   .github/workflows/nodejs-driver.yaml
modified:   .github/workflows/python-driver.yaml
modified:   drivers/docker-compose.yml