### PR TITLE
Add additional user variables during node and edge transform

### DIFF
--- a/regress/expected/cypher_match.out
+++ b/regress/expected/cypher_match.out
@@ -3535,9 +3535,105 @@ SELECT * FROM cypher('test_enable_containment', $$ EXPLAIN (costs off) MATCH (x:
    Filter: ((agtype_access_operator(VARIADIC ARRAY[properties, '"school"'::agtype]) = '{"name": "XYZ College", "program": {"major": "Psyc", "degree": "BSc"}}'::agtype) AND (agtype_access_operator(VARIADIC ARRAY[properties, '"phone"'::agtype]) = '[123456789, 987654321, 456987123]'::agtype))
 (2 rows)
 
+---
+--- tests for the additional variables added during node and edge transform 
+---
+SELECT FROM create_graph('special_vars');
+NOTICE:  graph "special_vars" has been created
+--
+(1 row)
+
+SELECT * FROM cypher('special_vars', $$ CREATE (u:Object {id: 1}) RETURN u $$) AS (u agtype);
+                                      u                                      
+-----------------------------------------------------------------------------
+ {"id": 844424930131969, "label": "Object", "properties": {"id": 1}}::vertex
+(1 row)
+
+SELECT * FROM cypher('special_vars', $$ CREATE (u:Object {id: 2}) RETURN u $$) AS (u agtype);
+                                      u                                      
+-----------------------------------------------------------------------------
+ {"id": 844424930131970, "label": "Object", "properties": {"id": 2}}::vertex
+(1 row)
+
+SELECT * FROM cypher('special_vars', $$ CREATE (u:Object {id: 3}) RETURN u $$) AS (u agtype);
+                                      u                                      
+-----------------------------------------------------------------------------
+ {"id": 844424930131971, "label": "Object", "properties": {"id": 3}}::vertex
+(1 row)
+
+SELECT * FROM cypher('special_vars', $$ MATCH (u) MATCH (v) CREATE(u)-[e:KNOWS {start: u_idc, end: v_idc}]->(v) RETURN e $$) AS (edge agtype);
+                                                                                    edge                                                                                    
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"id": 1125899906842625, "label": "KNOWS", "end_id": 844424930131969, "start_id": 844424930131969, "properties": {"end": 844424930131969, "start": 844424930131969}}::edge
+ {"id": 1125899906842626, "label": "KNOWS", "end_id": 844424930131970, "start_id": 844424930131969, "properties": {"end": 844424930131970, "start": 844424930131969}}::edge
+ {"id": 1125899906842627, "label": "KNOWS", "end_id": 844424930131971, "start_id": 844424930131969, "properties": {"end": 844424930131971, "start": 844424930131969}}::edge
+ {"id": 1125899906842628, "label": "KNOWS", "end_id": 844424930131969, "start_id": 844424930131970, "properties": {"end": 844424930131969, "start": 844424930131970}}::edge
+ {"id": 1125899906842629, "label": "KNOWS", "end_id": 844424930131970, "start_id": 844424930131970, "properties": {"end": 844424930131970, "start": 844424930131970}}::edge
+ {"id": 1125899906842630, "label": "KNOWS", "end_id": 844424930131971, "start_id": 844424930131970, "properties": {"end": 844424930131971, "start": 844424930131970}}::edge
+ {"id": 1125899906842631, "label": "KNOWS", "end_id": 844424930131969, "start_id": 844424930131971, "properties": {"end": 844424930131969, "start": 844424930131971}}::edge
+ {"id": 1125899906842632, "label": "KNOWS", "end_id": 844424930131970, "start_id": 844424930131971, "properties": {"end": 844424930131970, "start": 844424930131971}}::edge
+ {"id": 1125899906842633, "label": "KNOWS", "end_id": 844424930131971, "start_id": 844424930131971, "properties": {"end": 844424930131971, "start": 844424930131971}}::edge
+(9 rows)
+
+SELECT * FROM cypher('special_vars', $$ MATCH (u)-[e]->(v) RETURN e_idc, e_start_idc, e_end_idc, e_propertiesc $$) AS (e_idc agtype, e_start_idc agtype, e_end_idc agtype, e_propertiesc agtype);
+      e_idc       |   e_start_idc   |    e_end_idc    |                   e_propertiesc                    
+------------------+-----------------+-----------------+----------------------------------------------------
+ 1125899906842628 | 844424930131970 | 844424930131969 | {"end": 844424930131969, "start": 844424930131970}
+ 1125899906842625 | 844424930131969 | 844424930131969 | {"end": 844424930131969, "start": 844424930131969}
+ 1125899906842631 | 844424930131971 | 844424930131969 | {"end": 844424930131969, "start": 844424930131971}
+ 1125899906842629 | 844424930131970 | 844424930131970 | {"end": 844424930131970, "start": 844424930131970}
+ 1125899906842626 | 844424930131969 | 844424930131970 | {"end": 844424930131970, "start": 844424930131969}
+ 1125899906842632 | 844424930131971 | 844424930131970 | {"end": 844424930131970, "start": 844424930131971}
+ 1125899906842627 | 844424930131969 | 844424930131971 | {"end": 844424930131971, "start": 844424930131969}
+ 1125899906842633 | 844424930131971 | 844424930131971 | {"end": 844424930131971, "start": 844424930131971}
+ 1125899906842630 | 844424930131970 | 844424930131971 | {"end": 844424930131971, "start": 844424930131970}
+(9 rows)
+
+SELECT * FROM cypher('special_vars', $$ MATCH (u)-[e]->(v) RETURN u_idc, u_propertiesc, v_idc, v_propertiesc $$) AS (u_idc agtype, u_propertiesc agtype, v_idc agtype, v_propertiesc agtype);
+      u_idc      | u_propertiesc |      v_idc      | v_propertiesc 
+-----------------+---------------+-----------------+---------------
+ 844424930131970 | {"id": 2}     | 844424930131969 | {"id": 1}
+ 844424930131969 | {"id": 1}     | 844424930131969 | {"id": 1}
+ 844424930131971 | {"id": 3}     | 844424930131969 | {"id": 1}
+ 844424930131970 | {"id": 2}     | 844424930131970 | {"id": 2}
+ 844424930131969 | {"id": 1}     | 844424930131970 | {"id": 2}
+ 844424930131971 | {"id": 3}     | 844424930131970 | {"id": 2}
+ 844424930131969 | {"id": 1}     | 844424930131971 | {"id": 3}
+ 844424930131971 | {"id": 3}     | 844424930131971 | {"id": 3}
+ 844424930131970 | {"id": 2}     | 844424930131971 | {"id": 3}
+(9 rows)
+
+SELECT * FROM cypher('special_vars', $$ MATCH (u)-[e]->() RETURN count(*), u_idc ORDER BY count(*) DESC $$) AS (count agtype, u_idc agtype);
+ count |      u_idc      
+-------+-----------------
+ 3     | 844424930131969
+ 3     | 844424930131970
+ 3     | 844424930131971
+(3 rows)
+
+SELECT * FROM cypher('special_vars', $$ MATCH (u)-[e]->() RETURN count(*), id(u) ORDER BY count(*) DESC $$) AS (count agtype, idu agtype);
+ count |       idu       
+-------+-----------------
+ 3     | 844424930131969
+ 3     | 844424930131970
+ 3     | 844424930131971
+(3 rows)
+
 --
 -- Clean up
 --
+SELECT drop_graph('special_vars', true);
+NOTICE:  drop cascades to 4 other objects
+DETAIL:  drop cascades to table special_vars._ag_label_vertex
+drop cascades to table special_vars._ag_label_edge
+drop cascades to table special_vars."Object"
+drop cascades to table special_vars."KNOWS"
+NOTICE:  graph "special_vars" has been dropped
+ drop_graph 
+------------
+ 
+(1 row)
+
 SELECT drop_graph('cypher_match', true);
 NOTICE:  drop cascades to 17 other objects
 DETAIL:  drop cascades to table cypher_match._ag_label_vertex

--- a/regress/sql/cypher_match.sql
+++ b/regress/sql/cypher_match.sql
@@ -1437,9 +1437,23 @@ SELECT count(*) FROM cypher('test_enable_containment', $$ MATCH p=(x:Customer)-[
 SELECT * FROM cypher('test_enable_containment', $$ EXPLAIN (costs off) MATCH (x:Customer)-[:bought ={store: 'Amazon', addr:{city: 'Vancouver', street: 30}}]->(y:Product) RETURN 0 $$) as (a agtype);
 SELECT * FROM cypher('test_enable_containment', $$ EXPLAIN (costs off) MATCH (x:Customer ={school: { name: 'XYZ College',program: { major: 'Psyc', degree: 'BSc'} },phone: [ 123456789, 987654321, 456987123 ]}) RETURN 0 $$) as (a agtype);
 
+---
+--- tests for the additional variables added during node and edge transform 
+---
+SELECT FROM create_graph('special_vars');
+SELECT * FROM cypher('special_vars', $$ CREATE (u:Object {id: 1}) RETURN u $$) AS (u agtype);
+SELECT * FROM cypher('special_vars', $$ CREATE (u:Object {id: 2}) RETURN u $$) AS (u agtype);
+SELECT * FROM cypher('special_vars', $$ CREATE (u:Object {id: 3}) RETURN u $$) AS (u agtype);
+SELECT * FROM cypher('special_vars', $$ MATCH (u) MATCH (v) CREATE(u)-[e:KNOWS {start: u_idc, end: v_idc}]->(v) RETURN e $$) AS (edge agtype);
+SELECT * FROM cypher('special_vars', $$ MATCH (u)-[e]->(v) RETURN e_idc, e_start_idc, e_end_idc, e_propertiesc $$) AS (e_idc agtype, e_start_idc agtype, e_end_idc agtype, e_propertiesc agtype);
+SELECT * FROM cypher('special_vars', $$ MATCH (u)-[e]->(v) RETURN u_idc, u_propertiesc, v_idc, v_propertiesc $$) AS (u_idc agtype, u_propertiesc agtype, v_idc agtype, v_propertiesc agtype);
+SELECT * FROM cypher('special_vars', $$ MATCH (u)-[e]->() RETURN count(*), u_idc ORDER BY count(*) DESC $$) AS (count agtype, u_idc agtype);
+SELECT * FROM cypher('special_vars', $$ MATCH (u)-[e]->() RETURN count(*), id(u) ORDER BY count(*) DESC $$) AS (count agtype, idu agtype);
+
 --
 -- Clean up
 --
+SELECT drop_graph('special_vars', true);
 SELECT drop_graph('cypher_match', true);
 SELECT drop_graph('test_retrieve_var', true);
 SELECT drop_graph('test_enable_containment', true);

--- a/src/backend/utils/adt/agtype.c
+++ b/src/backend/utils/adt/agtype.c
@@ -12058,11 +12058,12 @@ Datum agtype_volatile_wrapper(PG_FUNCTION_ARGS)
             agtv_result.type = AGTV_BOOL;
             agtv_result.val.boolean = DatumGetBool(arg);
         }
-        else if (type == INT2OID || type == INT4OID || type == INT8OID)
+        else if (type == INT2OID || type == INT4OID || type == INT8OID ||
+                 type == GRAPHIDOID)
         {
             agtv_result.type = AGTV_INTEGER;
 
-            if (type == INT8OID)
+            if (type == INT8OID || GRAPHIDOID)
             {
                 agtv_result.val.int_value = DatumGetInt64(arg);
             }

--- a/src/include/parser/cypher_parse_node.h
+++ b/src/include/parser/cypher_parse_node.h
@@ -31,6 +31,18 @@
 #define AGE_DEFAULT_ALIAS_PREFIX AGE_DEFAULT_PREFIX"alias_"
 #define AGE_DEFAULT_VARNAME_PREFIX AGE_DEFAULT_PREFIX"varname_"
 
+/*
+ * Every vertex or edge creation, that is labeled, will additionally add
+ * variables to point directly to their respective columns. Below are the
+ * suffixes used.
+ */
+#define VERTEX_ID_COLUMN_SUFFIX "_idc"
+#define VERTEX_PROPERTIES_COLUMN_SUFFIX "_propertiesc"
+#define EDGE_ID_COLUMN_SUFFIX "_idc"
+#define EDGE_START_ID_COLUMN_SUFFIX "_start_idc"
+#define EDGE_END_ID_COLUMN_SUFFIX "_end_idc"
+#define EDGE_PROPERTIES_COLUMN_SUFFIX "_propertiesc"
+
 typedef struct cypher_parsestate
 {
     ParseState pstate;


### PR DESCRIPTION
This PR adds additional variables to a node and edge during the transform node/edge phase, provided that a variable was specified for the node or edge.

These additional variables are added to allow direct access to the columns of the specific node or edge. These variables can be used to improve the performance of some queries.

Variables added have the following suffixes to the node or edge variable name -

    _idc            ID Column
    _propertiesc    PROPERTIES Column
    _start_idc      EDGE START_ID Column
    _end_idc        EDGE END_ID Column

For example -

    MATCH (u) RETURN u, u_idc, u_propertiesc

Regression tests added.

    modified:   regress/expected/cypher_match.out
    modified:   regress/sql/cypher_match.sql
    modified:   src/backend/parser/cypher_clause.c
    modified:   src/backend/parser/cypher_item.c
    modified:   src/backend/utils/adt/agtype.c
    modified:   src/include/parser/cypher_parse_node.h