### PR TITLE
Fix upgrade script for 1.5.0 to 1.6.0

### DIFF
--- a/age--1.5.0--1.6.0.sql
+++ b/age--1.5.0--1.6.0.sql
@@ -78,13 +78,18 @@ ALTER EXTENSION age
 ALTER EXTENSION age
     DROP OPERATOR ?| (agtype, text[]);
 ALTER EXTENSION age
-    DROP OPERATOR ?& (agtype, agtype[]);
+    DROP OPERATOR ?& (agtype, agtype);
 ALTER EXTENSION age
-    DROP OPERATOR ?& (agtype, text);
+    DROP OPERATOR ?& (agtype, text[]);
+ALTER EXTENSION age
+    DROP OPERATOR @> (agtype, agtype);
+ALTER EXTENSION age
+    DROP OPERATOR <@ (agtype, agtype);
 
 DROP OPERATOR ? (agtype, agtype), ? (agtype, text),
               ?| (agtype, agtype), ?| (agtype, text[]),
-              ?& (agtype, agtype[]), ?& (agtype, text);
+              ?& (agtype, agtype), ?& (agtype, text[]),
+              @> (agtype, agtype), <@ (agtype, agtype);
 
 CREATE OPERATOR ? (
   LEFTARG = agtype,
@@ -134,30 +139,23 @@ CREATE OPERATOR ?& (
   JOIN = matchingjoinsel
 );
 
-ALTER EXTENSION age
-    ADD OPERATOR ? (agtype, agtype);
-ALTER EXTENSION age
-    ADD OPERATOR ? (agtype, text);
-ALTER EXTENSION age
-    ADD OPERATOR ?| (agtype, agtype);
-ALTER EXTENSION age
-    ADD OPERATOR ?| (agtype, text[]);
-ALTER EXTENSION age
-    ADD OPERATOR ?& (agtype, agtype[]);
-ALTER EXTENSION age
-    ADD OPERATOR ?& (agtype, text);
+CREATE OPERATOR @> (
+  LEFTARG = agtype,
+  RIGHTARG = agtype,
+  FUNCTION = ag_catalog.agtype_contains,
+  COMMUTATOR = '<@',
+  RESTRICT = matchingsel,
+  JOIN = matchingjoinsel
+);
 
-ALTER OPERATOR @> (agtype, agtype)
-  SET (RESTRICT = matchingsel, JOIN = matchingjoinsel);
-
-ALTER OPERATOR @> (agtype, agtype)
-  SET (RESTRICT = matchingsel, JOIN = matchingjoinsel);
-
-ALTER OPERATOR <@ (agtype, agtype)
-  SET (RESTRICT = matchingsel, JOIN = matchingjoinsel);
-
-ALTER OPERATOR <@ (agtype, agtype)
-  SET (RESTRICT = matchingsel, JOIN = matchingjoinsel);
+CREATE OPERATOR <@ (
+  LEFTARG = agtype,
+  RIGHTARG = agtype,
+  FUNCTION = ag_catalog.agtype_contained_by,
+  COMMUTATOR = '@>',
+  RESTRICT = matchingsel,
+  JOIN = matchingjoinsel
+);
 
 /*
  * Since there is no option to add or drop operator from class,
@@ -169,6 +167,7 @@ ALTER EXTENSION age
     DROP OPERATOR CLASS ag_catalog.gin_agtype_ops USING gin;
 
 DROP OPERATOR CLASS ag_catalog.gin_agtype_ops USING gin;
+DROP OPERATOR FAMILY ag_catalog.gin_agtype_ops USING gin;
 
 CREATE OPERATOR CLASS ag_catalog.gin_agtype_ops
 DEFAULT FOR TYPE agtype USING gin AS
@@ -188,9 +187,6 @@ DEFAULT FOR TYPE agtype USING gin AS
   FUNCTION 6 ag_catalog.gin_triconsistent_agtype(internal, int2, agtype, int4,
                                                  internal, internal, internal),
 STORAGE text;
-
-ALTER EXTENSION age
-    ADD OPERATOR CLASS ag_catalog.gin_agtype_ops USING gin;
 
 -- this function went from variadic "any" to just "any" type
 CREATE OR REPLACE FUNCTION ag_catalog.age_tostring("any")


### PR DESCRIPTION
- Since there are modifications to agtype gin operators, users will have to drop the gin indexes before running this script and recreate them.