### PR TITLE
Fix issue 2243 - Regression in string concatenation

### DIFF
--- a/regress/expected/agtype.out
+++ b/regress/expected/agtype.out
@@ -3777,8 +3777,109 @@ SELECT agtype_build_map('1', '1', 2, 2, 3.14, 3.14, 'e', 2.71);
 (1 row)
 
 --
+-- Bug found from issue 2043 - Regression in string concatenation using the + operator
+--
+-- This bug impacted specific numeric cases too.
+--
+SELECT * FROM create_graph('issue_2243');
+NOTICE:  graph "issue_2243" has been created
+ create_graph 
+--------------
+ 
+(1 row)
+
+SELECT * FROM cypher('issue_2243', $$
+    CREATE (n30164502:Node {data_id: 30164502})
+    RETURN id(n30164502) + ':test_n' + n30164502.data_id
+  $$ ) as (result agtype);
+              result              
+----------------------------------
+ "844424930131969:test_n30164502"
+(1 row)
+
+-- concat / add
+SELECT * FROM cypher('issue_2243', $$
+    RETURN 9223372036854775807::integer + ":test_n" + 9223372036854775807::integer
+  $$ ) as (result agtype);
+                     result                      
+-------------------------------------------------
+ "9223372036854775807:test_n9223372036854775807"
+(1 row)
+
+SELECT * FROM cypher('issue_2243', $$
+    RETURN 9223372036854775807::numeric + 9223372036854775807::integer
+  $$ ) as (result agtype);
+            result             
+-------------------------------
+ 18446744073709551614::numeric
+(1 row)
+
+-- sub
+SELECT * FROM cypher('issue_2243', $$
+    RETURN 9223372036854775807::numeric - 9223372036854775807::integer
+  $$ ) as (result agtype);
+   result   
+------------
+ 0::numeric
+(1 row)
+
+-- mul
+SELECT * FROM cypher('issue_2243', $$
+    RETURN 9223372036854775807::numeric * 9223372036854775807::integer
+  $$ ) as (result agtype);
+                     result                      
+-------------------------------------------------
+ 85070591730234615847396907784232501249::numeric
+(1 row)
+
+-- div
+SELECT * FROM cypher('issue_2243', $$
+    RETURN 9223372036854775807::numeric / 9223372036854775807::integer
+  $$ ) as (result agtype);
+             result              
+---------------------------------
+ 1.00000000000000000000::numeric
+(1 row)
+
+SELECT * FROM cypher('issue_2243', $$
+    RETURN 9223372036854775807::integer / 9223372036854775807::numeric
+  $$ ) as (result agtype);
+             result              
+---------------------------------
+ 1.00000000000000000000::numeric
+(1 row)
+
+-- mod
+SELECT * FROM cypher('issue_2243', $$
+    RETURN 9223372036854775807::numeric % 9223372036854775807::integer
+  $$ ) as (result agtype);
+   result   
+------------
+ 0::numeric
+(1 row)
+
+SELECT * FROM cypher('issue_2243', $$
+    RETURN 9223372036854775807::integer % 9223372036854775807::numeric
+  $$ ) as (result agtype);
+   result   
+------------
+ 0::numeric
+(1 row)
+
+--
 -- Cleanup
 --
+SELECT drop_graph('issue_2243', true);
+NOTICE:  drop cascades to 3 other objects
+DETAIL:  drop cascades to table issue_2243._ag_label_vertex
+drop cascades to table issue_2243._ag_label_edge
+drop cascades to table issue_2243."Node"
+NOTICE:  graph "issue_2243" has been dropped
+ drop_graph 
+------------
+ 
+(1 row)
+
 SELECT drop_graph('agtype_build_map', true);
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to table agtype_build_map._ag_label_vertex

--- a/regress/sql/agtype.sql
+++ b/regress/sql/agtype.sql
@@ -1076,8 +1076,55 @@ SELECT * FROM cypher('agtype_build_map', $$ RETURN ag_catalog.agtype_build_map('
 SELECT agtype_build_map('1', '1', 2, 2, 3.14, 3.14, 'e', 2.71);
 
 --
+-- Bug found from issue 2043 - Regression in string concatenation using the + operator
+--
+-- This bug impacted specific numeric cases too.
+--
+SELECT * FROM create_graph('issue_2243');
+SELECT * FROM cypher('issue_2243', $$
+    CREATE (n30164502:Node {data_id: 30164502})
+    RETURN id(n30164502) + ':test_n' + n30164502.data_id
+  $$ ) as (result agtype);
+
+-- concat / add
+SELECT * FROM cypher('issue_2243', $$
+    RETURN 9223372036854775807::integer + ":test_n" + 9223372036854775807::integer
+  $$ ) as (result agtype);
+
+SELECT * FROM cypher('issue_2243', $$
+    RETURN 9223372036854775807::numeric + 9223372036854775807::integer
+  $$ ) as (result agtype);
+
+-- sub
+SELECT * FROM cypher('issue_2243', $$
+    RETURN 9223372036854775807::numeric - 9223372036854775807::integer
+  $$ ) as (result agtype);
+
+-- mul
+SELECT * FROM cypher('issue_2243', $$
+    RETURN 9223372036854775807::numeric * 9223372036854775807::integer
+  $$ ) as (result agtype);
+
+-- div
+SELECT * FROM cypher('issue_2243', $$
+    RETURN 9223372036854775807::numeric / 9223372036854775807::integer
+  $$ ) as (result agtype);
+SELECT * FROM cypher('issue_2243', $$
+    RETURN 9223372036854775807::integer / 9223372036854775807::numeric
+  $$ ) as (result agtype);
+
+-- mod
+SELECT * FROM cypher('issue_2243', $$
+    RETURN 9223372036854775807::numeric % 9223372036854775807::integer
+  $$ ) as (result agtype);
+SELECT * FROM cypher('issue_2243', $$
+    RETURN 9223372036854775807::integer % 9223372036854775807::numeric
+  $$ ) as (result agtype);
+
+--
 -- Cleanup
 --
+SELECT drop_graph('issue_2243', true);
 SELECT drop_graph('agtype_build_map', true);
 
 DROP TABLE agtype_table;

--- a/src/backend/utils/adt/agtype_ops.c
+++ b/src/backend/utils/adt/agtype_ops.c
@@ -68,7 +68,7 @@ static char *get_string_from_agtype_value(agtype_value *agtv, int *length)
     {
     case AGTV_INTEGER:
         number = DirectFunctionCall1(int8out,
-                                     Int8GetDatum(agtv->val.int_value));
+                                     Int64GetDatum(agtv->val.int_value));
         string = DatumGetCString(number);
         *length = strlen(string);
         return string;
@@ -115,7 +115,7 @@ Datum get_numeric_datum_from_agtype_value(agtype_value *agtv)
     {
     case AGTV_INTEGER:
         return DirectFunctionCall1(int8_numeric,
-                                   Int8GetDatum(agtv->val.int_value));
+                                   Int64GetDatum(agtv->val.int_value));
     case AGTV_FLOAT:
         return DirectFunctionCall1(float8_numeric,
                                    Float8GetDatum(agtv->val.float_value));


### PR DESCRIPTION
Fixed issue 2243 - Regression in string concatenation using the + operator. The issue was in versions 1.5.0 and 1.6.0, at least. It was due to using Int8GetDatum instead of Int64GetDatum for the agtype integer field in the following functions -

    get_numeric_datum_from_agtype_value
    get_string_from_agtype_value

This impacted more than what the original issue covered, but those additional cases were resolved too.

Added regression tests.

modified:   regress/expected/agtype.out
modified:   regress/sql/agtype.sql
modified:   src/backend/utils/adt/agtype_ops.c