### PR TITLE
Fix DockerHub build warning messages

### DIFF
--- a/src/include/nodes/ag_nodes.h
+++ b/src/include/nodes/ag_nodes.h
@@ -78,6 +78,9 @@ typedef enum ag_node_tag
     cypher_merge_information_t
 } ag_node_tag;
 
+extern const char *node_names[];
+extern const ExtensibleNodeMethods node_methods[];
+
 void register_ag_nodes(void);
 
 ExtensibleNode *_new_ag_node(Size size, ag_node_tag tag);

--- a/src/include/optimizer/cypher_createplan.h
+++ b/src/include/optimizer/cypher_createplan.h
@@ -20,6 +20,8 @@
 #ifndef AG_CYPHER_CREATEPLAN_H
 #define AG_CYPHER_CREATEPLAN_H
 
+#include "nodes/extensible.h"
+
 Plan *plan_cypher_create_path(PlannerInfo *root, RelOptInfo *rel,
                               CustomPath *best_path, List *tlist,
                               List *clauses, List *custom_plans);
@@ -35,5 +37,10 @@ Plan *plan_cypher_delete_path(PlannerInfo *root, RelOptInfo *rel,
 Plan *plan_cypher_merge_path(PlannerInfo *root, RelOptInfo *rel,
                              CustomPath *best_path, List *tlist,
                              List *clauses, List *custom_plans);
+
+extern const CustomScanMethods cypher_create_plan_methods;
+extern const CustomScanMethods cypher_set_plan_methods;
+extern const CustomScanMethods cypher_delete_plan_methods;
+extern const CustomScanMethods cypher_merge_plan_methods;
 
 #endif

--- a/src/include/optimizer/cypher_pathnode.h
+++ b/src/include/optimizer/cypher_pathnode.h
@@ -20,6 +20,8 @@
 #ifndef AG_CYPHER_PATHNODE_H
 #define AG_CYPHER_PATHNODE_H
 
+#include "nodes/extensible.h"
+
 #define CREATE_PATH_NAME "Cypher Create"
 #define SET_PATH_NAME "Cypher Set"
 #define DELETE_PATH_NAME "Cypher Delete"
@@ -33,5 +35,10 @@ CustomPath *create_cypher_delete_path(PlannerInfo *root, RelOptInfo *rel,
                                       List *custom_private);
 CustomPath *create_cypher_merge_path(PlannerInfo *root, RelOptInfo *rel,
                                      List *custom_private);
+
+extern const CustomPathMethods cypher_create_path_methods;
+extern const CustomPathMethods cypher_set_path_methods;
+extern const CustomPathMethods cypher_delete_path_methods;
+extern const CustomPathMethods cypher_merge_path_methods;
 
 #endif

--- a/tools/gen_keywordlist.pl
+++ b/tools/gen_keywordlist.pl
@@ -112,6 +112,7 @@ printf $kwdef <<EOM, $base_filename, uc $base_filename, uc $base_filename;
 #define %s_H
 
 #include "common/kwlookup.h"
+#include "parser/cypher_keywords.h"
 
 EOM
 


### PR DESCRIPTION
PR fixes build warning messages on DockerHub and on my local build.

No regression tests needed.

modified:   src/include/nodes/ag_nodes.h
modified:   src/include/optimizer/cypher_createplan.h
modified:   src/include/optimizer/cypher_pathnode.h
modified:   tools/gen_keywordlist.pl