### PR TITLE
Fix Issue 2256: segmentation fault when calling coalesce function

### DIFF
--- a/regress/expected/cypher.out
+++ b/regress/expected/cypher.out
@@ -169,6 +169,22 @@ CREATE TABLE my_edges AS
 -- create a table of 4 columns, u, e, v, p. should be 5 rows
 CREATE TABLE my_detailed_paths AS
     (SELECT * FROM cypher('issue_1767', $$ MATCH p=(u)-[e]->(v) RETURN u,e,v,p $$) as (u agtype, e agtype, v agtype, p agtype));
+--
+-- Issue 2256: A segmentation fault occurs when calling the coalesce function
+--             This also occurs with the greatest function too.
+--
+SELECT * FROM coalesce(1, 0);
+ coalesce 
+----------
+        1
+(1 row)
+
+SELECT * FROM greatest(1, 0);
+ greatest 
+----------
+        1
+(1 row)
+
 -- dump out the tables
 SELECT * FROM my_vertices;
                                u                                

--- a/regress/sql/cypher.sql
+++ b/regress/sql/cypher.sql
@@ -94,6 +94,13 @@ CREATE TABLE my_edges AS
 CREATE TABLE my_detailed_paths AS
     (SELECT * FROM cypher('issue_1767', $$ MATCH p=(u)-[e]->(v) RETURN u,e,v,p $$) as (u agtype, e agtype, v agtype, p agtype));
 
+--
+-- Issue 2256: A segmentation fault occurs when calling the coalesce function
+--             This also occurs with the greatest function too.
+--
+SELECT * FROM coalesce(1, 0);
+SELECT * FROM greatest(1, 0);
+
 -- dump out the tables
 SELECT * FROM my_vertices;
 SELECT * FROM my_edges;

--- a/src/backend/parser/cypher_analyze.c
+++ b/src/backend/parser/cypher_analyze.c
@@ -171,14 +171,20 @@ static bool convert_cypher_walker(Node *node, ParseState *pstate)
          * JsonConstructorExpr - wrapper over FuncExpr/Aggref/WindowFunc for
          *                       SQL/JSON constructors
          *
-         * These are a special case that needs to be ignored.
+         * Added the following, although only the first 2 caused crashes in tests -
+         * CoalesceExpr, MinMaxExpr, CaseExpr, XmlExpr, ArrayExpr, RowExpr
+         *
+         * These are all special case that needs to be ignored.
          *
          */
         if (IsA(funcexpr, SQLValueFunction)
-                || IsA(funcexpr, CoerceViaIO)
-                || IsA(funcexpr, Var)   || IsA(funcexpr, OpExpr)
-                || IsA(funcexpr, Const) || IsA(funcexpr, BoolExpr)
-                || IsA(funcexpr, JsonConstructorExpr))
+            || IsA(funcexpr, CoerceViaIO)
+            || IsA(funcexpr, Var)   || IsA(funcexpr, OpExpr)
+            || IsA(funcexpr, Const) || IsA(funcexpr, BoolExpr)
+            || IsA(funcexpr, JsonConstructorExpr)
+            || IsA(funcexpr, CoalesceExpr) || IsA(funcexpr, MinMaxExpr)
+            || IsA(funcexpr, CaseExpr) || IsA(funcexpr, XmlExpr)
+            || IsA(funcexpr, ArrayExpr) || IsA(funcexpr, RowExpr))
         {
             return false;
         }
@@ -346,14 +352,20 @@ static bool is_func_cypher(FuncExpr *funcexpr)
      * JsonConstructorExpr - wrapper over FuncExpr/Aggref/WindowFunc for
      *                       SQL/JSON constructors
      *
-     * These are a special case that needs to be ignored.
+     * Added the following, although only the first 2 caused crashes in tests -
+     * CoalesceExpr, MinMaxExpr, CaseExpr, XmlExpr, ArrayExpr, RowExpr
+     *
+     * These are all special case that needs to be ignored.
      *
      */
     if (IsA(funcexpr, SQLValueFunction)
             || IsA(funcexpr, CoerceViaIO)
             || IsA(funcexpr, Var)   || IsA(funcexpr, OpExpr)
             || IsA(funcexpr, Const) || IsA(funcexpr, BoolExpr)
-            || IsA(funcexpr, JsonConstructorExpr))
+            || IsA(funcexpr, JsonConstructorExpr)
+            || IsA(funcexpr, CoalesceExpr) || IsA(funcexpr, MinMaxExpr)
+            || IsA(funcexpr, CaseExpr) || IsA(funcexpr, XmlExpr)
+            || IsA(funcexpr, ArrayExpr) || IsA(funcexpr, RowExpr))
     {
         return false;
     }


### PR DESCRIPTION
Fixed issue 2256: A segmentation fault occurs when calling the coalesce
function in PostgreSQL version 17. This likely predates 17 and includes
other similar types of "functions".

See issues 1124 (PR 1125) and 1303 (PR 1317) for more details.

This issue is due to coalesce() being processed differently from other
functions. Additionally, greatest() was found to exhibit the same
behavior. They were added to the list of types to ignore during the
cypher analyze phase.

A few others were added: CaseExpr, XmlExpr, ArrayExpr, & RowExpr.
Although, I wasn't able to find cases where these caused crashes.

Added regression tests.

modified:   regress/expected/cypher.out
modified:   regress/sql/cypher.sql
modified:   src/backend/parser/cypher_analyze.c
