### PR TITLE
Fix SyntaxWarning for invalid escape sequence in Python 3.6+

### DIFF
--- a/drivers/python/age/age.py
+++ b/drivers/python/age/age.py
@@ -26,7 +26,7 @@ from .builder import parseAgeValue
 _EXCEPTION_NoConnection = NoConnection()
 _EXCEPTION_GraphNotSet = GraphNotSet()
 
-WHITESPACE = re.compile('\s')
+WHITESPACE = re.compile(r'\s')
 
 
 class AgeDumper(psycopg.adapt.Dumper):
@@ -233,3 +233,4 @@ class Age:
 
     # def queryCypher(self, cypherStmt:str, columns:list=None , params:tuple=None) -> psycopg.cursor :
     #     return queryCypher(self.connection, self.graphName, cypherStmt, columns, params)
+


### PR DESCRIPTION
_Closes #2268_
## Problem
When using apache-age-python with Python 3.6+, a SyntaxWarning is raised:

```
SyntaxWarning: invalid escape sequence '\s'
  WHITESPACE = re.compile('\s')
```

This warning occurs because `\s` is not a valid Python string escape sequence. While it currently works (Python interprets unrecognized escape sequences as literal backslash + character), this behavior is deprecated.

## Solution
Use a raw string literal (`r'\s'`) to properly declare the regex pattern. Raw strings treat backslashes as literal characters, which is the correct way to define regex patterns in Python.

## Changes
**File:** `age/age.py`
- Line 28: Changed `WHITESPACE = re.compile('\s')` to `WHITESPACE = re.compile(r'\s')`

## Testing
- ✅ Existing functionality unchanged (regex pattern behaves identically)
- ✅ Warning eliminated when running with Python 3.12+
- ✅ Forward compatible with Python 3.14+

## References
- [PEP 701](https://peps.python.org/pep-0701/) - Python 3.12 enhanced error messages
- [Python Docs: String Literals](https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals)
- [Why does Python log a DeprecationWarning saying "invalid escape sequence"?](https://adamj.eu/tech/2022/11/04/why-does-python-deprecationwarning-invalid-escape-sequence/)
- [bpo-27364](https://bugs.python.org/issue27364) - Python 3.6 deprecation of invalid escape sequences

---

**Diff:**
```diff
-WHITESPACE = re.compile('\s')
+WHITESPACE = re.compile(r'\s')
```

