### PR TITLE
Migrate python driver configuration to pyproject.toml

### DIFF
--- a/.github/workflows/python-driver.yaml
+++ b/.github/workflows/python-driver.yaml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.12'
 
     - name: Install pre-requisites
       run: |
@@ -33,7 +33,7 @@ jobs:
 
     - name: Build
       run: |
-        python setup.py install
+        pip install .
 
     - name: Test
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,7 @@ age--*.*.*.sql
 !age--*--*sql
 __pycache__
 **/__pycache__
+**/.venv
+**/apache_age_python.egg-info
 
 drivers/python/build

--- a/drivers/python/README.md
+++ b/drivers/python/README.md
@@ -62,7 +62,7 @@ python -m unittest -v test_agtypes.py
 
 ### Build from source
 ```
-python setup.py install
+pip install .
 ```
 
 ### For more information about [Apache AGE](https://age.apache.org/)

--- a/drivers/python/pyproject.toml
+++ b/drivers/python/pyproject.toml
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "apache-age-python"
+version = "0.0.7"
+description = "Python driver support for Apache AGE"
+readme = "README.md"
+requires-python = ">=3.9"
+license = "Apache-2.0"
+keywords = ["Graph Database", "Apache AGE", "PostgreSQL"]
+authors = [
+    {name = "Ikchan Kwon, Apache AGE", email = "dev-subscribe@age.apache.org"}
+]
+classifiers = [
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+]
+dependencies = [
+    "psycopg",
+    "antlr4-python3-runtime==4.11.1",
+]
+
+[project.urls]
+Homepage = "https://github.com/apache/age/tree/master/drivers/python"
+Download = "https://github.com/apache/age/releases"
+
+[tool.setuptools]
+packages = ["age", "age.gen", "age.networkx"]

--- a/drivers/python/setup.py
+++ b/drivers/python/setup.py
@@ -13,28 +13,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from setuptools import setup, find_packages
-from age import VERSION 
+# This setup.py is maintained for backward compatibility.
+# All package configuration is in pyproject.toml. For installation,
+# use: pip install .
 
-with open("README.md", "r", encoding='utf8') as fh:
-    long_description = fh.read()
+from setuptools import setup
 
-setup(
-    name             = 'apache-age-python',
-    version          = '0.0.7',
-    description      = 'Python driver support for Apache AGE',
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    author           = 'Ikchan Kwon, Apache AGE',
-    author_email     = 'dev-subscribe@age.apache.org',
-    url              = 'https://github.com/apache/age/tree/master/drivers/python',
-    download_url     = 'https://github.com/apache/age/releases' ,
-    license          = 'Apache2.0',
-    install_requires = [ 'psycopg', 'antlr4-python3-runtime==4.11.1'],
-    packages         = ['age', 'age.gen','age.networkx'],
-    keywords         = ['Graph Database', 'Apache AGE', 'PostgreSQL'],
-    python_requires  = '>=3.9',
-    classifiers      = [
-        'Programming Language :: Python :: 3.9'
-    ]
-)
+setup()


### PR DESCRIPTION
- Add pyproject.toml with package configuration
- Simplify setup.py to minimal backward-compatible wrapper.
- Updated CI workflow and .gitignore.
- Resolves warning about using setup.py directly.