### PR TITLE
Makefile: fix race condition on cypher_gram_def.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,8 +147,10 @@ src/include/parser/cypher_gram_def.h: src/backend/parser/cypher_gram.c
 
 src/backend/parser/cypher_gram.c: BISONFLAGS += --defines=src/include/parser/cypher_gram_def.h
 
-src/backend/parser/cypher_parser.o: src/backend/parser/cypher_gram.c
-src/backend/parser/cypher_keywords.o: src/backend/parser/cypher_gram.c
+src/backend/parser/cypher_parser.o: src/backend/parser/cypher_gram.c src/include/parser/cypher_gram_def.h
+src/backend/parser/cypher_parser.bc: src/backend/parser/cypher_gram.c src/include/parser/cypher_gram_def.h
+src/backend/parser/cypher_keywords.o: src/backend/parser/cypher_gram.c src/include/parser/cypher_gram_def.h
+src/backend/parser/cypher_keywords.bc: src/backend/parser/cypher_gram.c src/include/parser/cypher_gram_def.h
 
 $(age_sql):
 	@cat $(SQLS) > $@


### PR DESCRIPTION
The file cypher_gram.c generates cypher_gram_def.h, which is directly necessary for cypher_parser.o and cypher_keywords.o and their respective .bc files.

But that direct dependency is not reflected in the Makefile, which only had the indirect dependency of .o on .c. So on high parallel builds, the .h may not have been generated by bison yet.

Additionally, the .bc files should have the same dependencies as the .o files, but those are lacking.

Here is an example output where the .bc file fails to build, as it was running concurrently with the bison instance that was about to finalize cypher_gram_def.h:

  In file included from src/backend/parser/cypher_parser.c:24:
  clang-17 -Wno-ignored-attributes -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-unused-command-line-argument -Wno-compound-token-split-by-macro -O2  -I.//src/include -I.//src/include/parser -I. -I./ -I/usr/pgsql-17/include/server -I/usr/pgsql-17/include/internal -D_GNU_SOURCE  -I/usr/include -I/usr/include/libxml2  -flto=thin -emit-llvm -c -o src/backend/parser/cypher_parser.bc src/backend/parser/cypher_parser.c
  .//src/include/parser/cypher_gram.h:65:10: fatal error: 'parser/cypher_gram_def.h' file not found
     65 | #include "parser/cypher_gram_def.h"
        |          ^~~~~~~~~~~~~~~~~~~~~~~~~~
  1 error generated.
  make: *** [/usr/pgsql-17/lib/pgxs/src/makefiles/../../src/Makefile.global:1085: src/backend/parser/cypher_parser.bc] Error 1
  make: *** Waiting for unfinished jobs....
  gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wshadow=compatible-local -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -O2 -g -fmessage-length=0 -D_FORTIFY_SOURCE=2 -fstack-protector -funwind-tables -fasynchronous-unwind-tables -fPIC -fvisibility=hidden -I.//src/include -I.//src/include/parser -I. -I./ -I/usr/pgsql-17/include/server -I/usr/pgsql-17/include/internal -D_GNU_SOURCE  -I/usr/include -I/usr/include/libxml2   -c -o src/backend/catalog/ag_label.o src/backend/catalog/ag_label.c
  /usr/bin/bison -Wno-deprecated  --defines=src/include/parser/cypher_gram_def.h -o src/backend/parser/cypher_gram.c src/backend/parser/cypher_gram.y

Previously, cypher_parser.o was missing the dependency, so it could start before cypher_gram_def.h was available:

 Considering target file 'src/backend/parser/cypher_parser.o'.
  File 'src/backend/parser/cypher_parser.o' does not exist.
  Considering target file 'src/backend/parser/cypher_parser.c'.
  File 'src/backend/parser/cypher_parser.c' was considered already.
  Considering target file 'src/backend/parser/cypher_gram.c'.
  File 'src/backend/parser/cypher_gram.c' was considered already.
 Finished prerequisites of target file 'src/backend/parser/cypher_parser.o'.
 Must remake target 'src/backend/parser/cypher_parser.o'.

As well as cypher_parser.bc, missing the dependency on cypher_gram_def.h:

 Considering target file 'src/backend/parser/cypher_parser.bc'.
  File 'src/backend/parser/cypher_parser.bc' does not exist.
  Considering target file 'src/backend/parser/cypher_parser.c'.
  File 'src/backend/parser/cypher_parser.c' was considered already.
 Finished prerequisites of target file 'src/backend/parser/cypher_parser.bc'.
 Must remake target 'src/backend/parser/cypher_parser.bc'.

Now cypher_parser.o correctly depends on cypher_gram_def.h:

 Considering target file 'src/backend/parser/cypher_parser.o'.
  File 'src/backend/parser/cypher_parser.o' does not exist.
  Considering target file 'src/backend/parser/cypher_parser.c'.
  File 'src/backend/parser/cypher_parser.c' was considered already.
  Considering target file 'src/backend/parser/cypher_gram.c'.
  File 'src/backend/parser/cypher_gram.c' was considered already.
  Considering target file 'src/include/parser/cypher_gram_def.h'.
  File 'src/include/parser/cypher_gram_def.h' was considered already.
 Finished prerequisites of target file 'src/backend/parser/cypher_parser.o'.
 Must remake target 'src/backend/parser/cypher_parser.o'.

And cypher_parser.bc correctly depends on cypher_gram_def.h as well:

 Considering target file 'src/backend/parser/cypher_parser.bc'.
  File 'src/backend/parser/cypher_parser.bc' does not exist.
  Considering target file 'src/backend/parser/cypher_parser.c'.
  File 'src/backend/parser/cypher_parser.c' was considered already.
  Considering target file 'src/backend/parser/cypher_gram.c'.
  File 'src/backend/parser/cypher_gram.c' was considered already.
  Considering target file 'src/include/parser/cypher_gram_def.h'.
  File 'src/include/parser/cypher_gram_def.h' was considered already.
 Finished prerequisites of target file 'src/backend/parser/cypher_parser.bc'.
 Must remake target 'src/backend/parser/cypher_parser.bc'.