### PR TITLE
Add SET n:Label and REMOVE n:Label

### DIFF
--- a/regress/expected/cypher_remove.out
+++ b/regress/expected/cypher_remove.out
@@ -463,7 +463,7 @@ ERROR:  REMOVE cannot be the first clause in a Cypher query
 LINE 1: SELECT * FROM cypher('cypher_remove', $$REMOVE n.i$$) AS (a ...
                                                 ^
 SELECT * FROM cypher('cypher_remove', $$MATCH (n) REMOVE n.i = NULL$$) AS (a agtype);
-ERROR:  REMOVE clause must be in the format: REMOVE variable.property_name
+ERROR:  REMOVE clause must be in the format: REMOVE variable.property_name or REMOVE variable:Label
 LINE 1: SELECT * FROM cypher('cypher_remove', $$MATCH (n) REMOVE n.i...
                                                 ^
 SELECT * FROM cypher('cypher_remove', $$MATCH (n) REMOVE wrong_var.i$$) AS (a agtype);

--- a/regress/expected/unified_vertex_table.out
+++ b/regress/expected/unified_vertex_table.out
@@ -788,10 +788,442 @@ $$) AS (cnt agtype);
 (1 row)
 
 --
+-- Test 18: SET label operation - error when vertex already has a label
+-- Multiple labels are not supported. SET only works on unlabeled vertices.
+--
+SELECT * FROM cypher('unified_test', $$
+    CREATE (:OldLabel {id: 1, name: 'vertex1'})
+$$) AS (v agtype);
+ v 
+---
+(0 rows)
+
+SELECT * FROM cypher('unified_test', $$
+    CREATE (:OldLabel {id: 2, name: 'vertex2'})
+$$) AS (v agtype);
+ v 
+---
+(0 rows)
+
+-- Verify initial label
+SELECT * FROM cypher('unified_test', $$
+    MATCH (n:OldLabel)
+    RETURN n.id, n.name, label(n) ORDER BY n.id
+$$) AS (id agtype, name agtype, lbl agtype);
+ id |   name    |    lbl     
+----+-----------+------------
+ 1  | "vertex1" | "OldLabel"
+ 2  | "vertex2" | "OldLabel"
+(2 rows)
+
+-- Try to change label on vertex1 - should FAIL because it already has a label
+SELECT * FROM cypher('unified_test', $$
+    MATCH (n:OldLabel {id: 1})
+    SET n:NewLabel
+    RETURN n.id, n.name, label(n)
+$$) AS (id agtype, name agtype, lbl agtype);
+ERROR:  SET label failed: vertex already has label "OldLabel"
+HINT:  Multiple labels are not supported. Use REMOVE to clear the label first.
+-- Verify vertex1 still has OldLabel (unchanged due to error)
+SELECT * FROM cypher('unified_test', $$
+    MATCH (n:OldLabel)
+    RETURN n.id, n.name, label(n) ORDER BY n.id
+$$) AS (id agtype, name agtype, lbl agtype);
+ id |   name    |    lbl     
+----+-----------+------------
+ 1  | "vertex1" | "OldLabel"
+ 2  | "vertex2" | "OldLabel"
+(2 rows)
+
+--
+-- Test 19: REMOVE label operation
+-- This tests removing a vertex's label using REMOVE n:Label syntax
+--
+SELECT * FROM cypher('unified_test', $$
+    CREATE (:RemoveTest {id: 1, data: 'test1'})
+$$) AS (v agtype);
+ v 
+---
+(0 rows)
+
+SELECT * FROM cypher('unified_test', $$
+    CREATE (:RemoveTest {id: 2, data: 'test2'})
+$$) AS (v agtype);
+ v 
+---
+(0 rows)
+
+-- Verify initial label
+SELECT * FROM cypher('unified_test', $$
+    MATCH (n:RemoveTest)
+    RETURN n.id, n.data, label(n) ORDER BY n.id
+$$) AS (id agtype, data agtype, lbl agtype);
+ id |  data   |     lbl      
+----+---------+--------------
+ 1  | "test1" | "RemoveTest"
+ 2  | "test2" | "RemoveTest"
+(2 rows)
+
+-- Remove label from vertex1
+SELECT * FROM cypher('unified_test', $$
+    MATCH (n:RemoveTest {id: 1})
+    REMOVE n:RemoveTest
+    RETURN n.id, n.data, label(n)
+$$) AS (id agtype, data agtype, lbl agtype);
+ id |  data   | lbl 
+----+---------+-----
+ 1  | "test1" | ""
+(1 row)
+
+-- Verify vertex1 now has no label (empty string)
+SELECT * FROM cypher('unified_test', $$
+    MATCH (n {data: 'test1'})
+    RETURN n.id, n.data, label(n)
+$$) AS (id agtype, data agtype, lbl agtype);
+ id |  data   | lbl 
+----+---------+-----
+ 1  | "test1" | ""
+(1 row)
+
+-- Verify vertex2 still has RemoveTest label
+SELECT * FROM cypher('unified_test', $$
+    MATCH (n:RemoveTest)
+    RETURN n.id, n.data, label(n)
+$$) AS (id agtype, data agtype, lbl agtype);
+ id |  data   |     lbl      
+----+---------+--------------
+ 2  | "test2" | "RemoveTest"
+(1 row)
+
+-- Verify properties are preserved after label removal
+SELECT * FROM cypher('unified_test', $$
+    MATCH (n)
+    WHERE n.data = 'test1'
+    RETURN n.id, n.data, label(n)
+$$) AS (id agtype, data agtype, lbl agtype);
+ id |  data   | lbl 
+----+---------+-----
+ 1  | "test1" | ""
+(1 row)
+
+--
+-- Test 20: SET label with property updates - error when vertex has label
+--
+SELECT * FROM cypher('unified_test', $$
+    CREATE (:CombinedTest {id: 1, val: 'original'})
+$$) AS (v agtype);
+ v 
+---
+(0 rows)
+
+-- Try to SET label and property - should FAIL because vertex has a label
+SELECT * FROM cypher('unified_test', $$
+    MATCH (n:CombinedTest {id: 1})
+    SET n:CombinedNew, n.val = 'updated'
+    RETURN n.id, n.val, label(n)
+$$) AS (id agtype, val agtype, lbl agtype);
+ERROR:  SET label failed: vertex already has label "CombinedTest"
+HINT:  Multiple labels are not supported. Use REMOVE to clear the label first.
+-- Verify vertex is unchanged
+SELECT * FROM cypher('unified_test', $$
+    MATCH (n:CombinedTest)
+    RETURN n.id, n.val, label(n) ORDER BY n.id
+$$) AS (id agtype, val agtype, lbl agtype);
+ id |    val     |      lbl       
+----+------------+----------------
+ 1  | "original" | "CombinedTest"
+(1 row)
+
+--
+-- Test 21: Proper workflow - REMOVE then SET label
+-- To change a label, first REMOVE the old one, then SET the new one
+--
+SELECT * FROM cypher('unified_test', $$
+    CREATE (:WorkflowTest {id: 50, val: 'workflow'})
+$$) AS (v agtype);
+ v 
+---
+(0 rows)
+
+-- First REMOVE the label
+SELECT * FROM cypher('unified_test', $$
+    MATCH (n:WorkflowTest {id: 50})
+    REMOVE n:WorkflowTest
+    RETURN n.id, n.val, label(n)
+$$) AS (id agtype, val agtype, lbl agtype);
+ id |    val     | lbl 
+----+------------+-----
+ 50 | "workflow" | ""
+(1 row)
+
+-- Now SET a new label (should work because vertex has no label)
+SELECT * FROM cypher('unified_test', $$
+    MATCH (n {id: 50})
+    SET n:NewWorkflowLabel
+    RETURN n.id, n.val, label(n)
+$$) AS (id agtype, val agtype, lbl agtype);
+ id |    val     |        lbl         
+----+------------+--------------------
+ 50 | "workflow" | "NewWorkflowLabel"
+(1 row)
+
+-- Verify the new label
+SELECT * FROM cypher('unified_test', $$
+    MATCH (n:NewWorkflowLabel)
+    RETURN n.id, n.val, label(n) ORDER BY n.id
+$$) AS (id agtype, val agtype, lbl agtype);
+ id |    val     |        lbl         
+----+------------+--------------------
+ 50 | "workflow" | "NewWorkflowLabel"
+(1 row)
+
+--
+-- Test 22: SET label auto-creates label when vertex has no label
+--
+-- First create and remove label to get unlabeled vertex
+SELECT * FROM cypher('unified_test', $$
+    CREATE (:TempForAuto {id: 60, name: 'auto_create_test'})
+$$) AS (v agtype);
+ v 
+---
+(0 rows)
+
+SELECT * FROM cypher('unified_test', $$
+    MATCH (n:TempForAuto {id: 60})
+    REMOVE n:TempForAuto
+    RETURN n.id, n.name, label(n)
+$$) AS (id agtype, name agtype, lbl agtype);
+ id |        name        | lbl 
+----+--------------------+-----
+ 60 | "auto_create_test" | ""
+(1 row)
+
+-- Now SET a new label that doesn't exist yet (should auto-create)
+SELECT * FROM cypher('unified_test', $$
+    MATCH (n {id: 60})
+    SET n:AutoCreatedLabel
+    RETURN n.id, n.name, label(n)
+$$) AS (id agtype, name agtype, lbl agtype);
+ id |        name        |        lbl         
+----+--------------------+--------------------
+ 60 | "auto_create_test" | "AutoCreatedLabel"
+(1 row)
+
+-- Verify the new label exists and the vertex is there
+SELECT * FROM cypher('unified_test', $$
+    MATCH (n:AutoCreatedLabel)
+    RETURN n.id, n.name, label(n)
+$$) AS (id agtype, name agtype, lbl agtype);
+ id |        name        |        lbl         
+----+--------------------+--------------------
+ 60 | "auto_create_test" | "AutoCreatedLabel"
+(1 row)
+
+--
+-- Test 23: SET label on vertex with NO label (blank -> labeled)
+--
+-- First create a vertex with a label, then remove it to get a blank label
+SELECT * FROM cypher('unified_test', $$
+    CREATE (:TempLabel {id: 100, data: 'unlabeled_test'})
+$$) AS (v agtype);
+ v 
+---
+(0 rows)
+
+-- Remove the label to make it blank
+SELECT * FROM cypher('unified_test', $$
+    MATCH (n:TempLabel {id: 100})
+    REMOVE n:TempLabel
+    RETURN n.id, n.data, label(n)
+$$) AS (id agtype, data agtype, lbl agtype);
+ id  |       data       | lbl 
+-----+------------------+-----
+ 100 | "unlabeled_test" | ""
+(1 row)
+
+-- Verify it has no label (blank)
+SELECT * FROM cypher('unified_test', $$
+    MATCH (n {id: 100})
+    RETURN n.id, n.data, label(n)
+$$) AS (id agtype, data agtype, lbl agtype);
+ id  |       data       | lbl 
+-----+------------------+-----
+ 100 | "unlabeled_test" | ""
+(1 row)
+
+-- Now SET a label on the unlabeled vertex
+SELECT * FROM cypher('unified_test', $$
+    MATCH (n {id: 100})
+    SET n:FromBlankLabel
+    RETURN n.id, n.data, label(n)
+$$) AS (id agtype, data agtype, lbl agtype);
+ id  |       data       |       lbl        
+-----+------------------+------------------
+ 100 | "unlabeled_test" | "FromBlankLabel"
+(1 row)
+
+-- Verify the label was set
+SELECT * FROM cypher('unified_test', $$
+    MATCH (n:FromBlankLabel)
+    RETURN n.id, n.data, label(n)
+$$) AS (id agtype, data agtype, lbl agtype);
+ id  |       data       |       lbl        
+-----+------------------+------------------
+ 100 | "unlabeled_test" | "FromBlankLabel"
+(1 row)
+
+--
+-- Test 24: REMOVE label on vertex that already has NO label (no-op)
+--
+-- Create another unlabeled vertex
+SELECT * FROM cypher('unified_test', $$
+    CREATE (:TempLabel2 {id: 101, data: 'already_blank'})
+$$) AS (v agtype);
+ v 
+---
+(0 rows)
+
+SELECT * FROM cypher('unified_test', $$
+    MATCH (n:TempLabel2 {id: 101})
+    REMOVE n:TempLabel2
+    RETURN n.id, n.data, label(n)
+$$) AS (id agtype, data agtype, lbl agtype);
+ id  |      data       | lbl 
+-----+-----------------+-----
+ 101 | "already_blank" | ""
+(1 row)
+
+-- Now try to REMOVE a label from already-unlabeled vertex (should be no-op)
+SELECT * FROM cypher('unified_test', $$
+    MATCH (n {id: 101})
+    REMOVE n:SomeLabel
+    RETURN n.id, n.data, label(n)
+$$) AS (id agtype, data agtype, lbl agtype);
+ id  |      data       | lbl 
+-----+-----------------+-----
+ 101 | "already_blank" | ""
+(1 row)
+
+-- Verify still has no label
+SELECT * FROM cypher('unified_test', $$
+    MATCH (n {id: 101})
+    RETURN n.id, n.data, label(n)
+$$) AS (id agtype, data agtype, lbl agtype);
+ id  |      data       | lbl 
+-----+-----------------+-----
+ 101 | "already_blank" | ""
+(1 row)
+
+--
+-- Test 25: REMOVE with wrong label name (should be no-op)
+-- REMOVE should only remove the label if it matches the specified name
+--
+SELECT * FROM cypher('unified_test', $$
+    CREATE (:KeepThisLabel {id: 103, data: 'wrong_label_test'})
+$$) AS (v agtype);
+ v 
+---
+(0 rows)
+
+-- Try to REMOVE a different label than the vertex has - should be no-op
+SELECT * FROM cypher('unified_test', $$
+    MATCH (n:KeepThisLabel {id: 103})
+    REMOVE n:WrongLabel
+    RETURN n.id, n.data, label(n)
+$$) AS (id agtype, data agtype, lbl agtype);
+ id  |        data        |       lbl       
+-----+--------------------+-----------------
+ 103 | "wrong_label_test" | "KeepThisLabel"
+(1 row)
+
+-- Verify label is still KeepThisLabel (unchanged)
+SELECT * FROM cypher('unified_test', $$
+    MATCH (n:KeepThisLabel {id: 103})
+    RETURN n.id, n.data, label(n)
+$$) AS (id agtype, data agtype, lbl agtype);
+ id  |        data        |       lbl       
+-----+--------------------+-----------------
+ 103 | "wrong_label_test" | "KeepThisLabel"
+(1 row)
+
+-- Now REMOVE with the correct label - should work
+SELECT * FROM cypher('unified_test', $$
+    MATCH (n:KeepThisLabel {id: 103})
+    REMOVE n:KeepThisLabel
+    RETURN n.id, n.data, label(n)
+$$) AS (id agtype, data agtype, lbl agtype);
+ id  |        data        | lbl 
+-----+--------------------+-----
+ 103 | "wrong_label_test" | ""
+(1 row)
+
+-- Verify label is now empty
+SELECT * FROM cypher('unified_test', $$
+    MATCH (n {id: 103})
+    RETURN n.id, n.data, label(n)
+$$) AS (id agtype, data agtype, lbl agtype);
+ id  |        data        | lbl 
+-----+--------------------+-----
+ 103 | "wrong_label_test" | ""
+(1 row)
+
+--
+-- Test 26: SET label to same label - error (vertex already has a label)
+--
+SELECT * FROM cypher('unified_test', $$
+    CREATE (:SameLabel {id: 102, data: 'same_label_test'})
+$$) AS (v agtype);
+ v 
+---
+(0 rows)
+
+-- SET to the same label it already has - should FAIL
+SELECT * FROM cypher('unified_test', $$
+    MATCH (n:SameLabel {id: 102})
+    SET n:SameLabel
+    RETURN n.id, n.data, label(n)
+$$) AS (id agtype, data agtype, lbl agtype);
+ERROR:  SET label failed: vertex already has label "SameLabel"
+HINT:  Multiple labels are not supported. Use REMOVE to clear the label first.
+-- Verify label is unchanged
+SELECT * FROM cypher('unified_test', $$
+    MATCH (n:SameLabel {id: 102})
+    RETURN n.id, n.data, label(n)
+$$) AS (id agtype, data agtype, lbl agtype);
+ id  |       data        |     lbl     
+-----+-------------------+-------------
+ 102 | "same_label_test" | "SameLabel"
+(1 row)
+
+--
+-- Test 27: Error case - SET/REMOVE label on edge (should error)
+--
+SELECT * FROM cypher('unified_test', $$
+    CREATE (:EdgeTest1 {id: 200})-[:CONNECTS]->(:EdgeTest2 {id: 201})
+$$) AS (v agtype);
+ v 
+---
+(0 rows)
+
+-- Try to SET label on an edge - should fail
+SELECT * FROM cypher('unified_test', $$
+    MATCH (:EdgeTest1)-[e:CONNECTS]->(:EdgeTest2)
+    SET e:NewEdgeLabel
+    RETURN e
+$$) AS (e agtype);
+ERROR:  SET/REMOVE label can only be used on vertices
+-- Try to REMOVE label on an edge - should fail
+SELECT * FROM cypher('unified_test', $$
+    MATCH (:EdgeTest1)-[e:CONNECTS]->(:EdgeTest2)
+    REMOVE e:CONNECTS
+    RETURN e
+$$) AS (e agtype);
+ERROR:  SET/REMOVE label can only be used on vertices
+--
 -- Cleanup
 --
 SELECT drop_graph('unified_test', true);
-NOTICE:  drop cascades to 23 other objects
+NOTICE:  drop cascades to 38 other objects
 DETAIL:  drop cascades to table unified_test._ag_label_vertex
 drop cascades to table unified_test._ag_label_edge
 drop cascades to table unified_test."Person"
@@ -815,6 +1247,21 @@ drop cascades to table unified_test."DEL_EDGE"
 drop cascades to table unified_test."UpdateTest"
 drop cascades to table unified_test."StressTest"
 drop cascades to table unified_test."ST_EDGE"
+drop cascades to table unified_test."OldLabel"
+drop cascades to table unified_test."RemoveTest"
+drop cascades to table unified_test."CombinedTest"
+drop cascades to table unified_test."WorkflowTest"
+drop cascades to table unified_test."NewWorkflowLabel"
+drop cascades to table unified_test."TempForAuto"
+drop cascades to table unified_test."AutoCreatedLabel"
+drop cascades to table unified_test."TempLabel"
+drop cascades to table unified_test."FromBlankLabel"
+drop cascades to table unified_test."TempLabel2"
+drop cascades to table unified_test."KeepThisLabel"
+drop cascades to table unified_test."SameLabel"
+drop cascades to table unified_test."EdgeTest1"
+drop cascades to table unified_test."CONNECTS"
+drop cascades to table unified_test."EdgeTest2"
 NOTICE:  graph "unified_test" has been dropped
  drop_graph 
 ------------

--- a/src/backend/nodes/cypher_copyfuncs.c
+++ b/src/backend/nodes/cypher_copyfuncs.c
@@ -126,6 +126,7 @@ void copy_cypher_update_information(ExtensibleNode *newnode, const ExtensibleNod
 }
 
 /* copy function for cypher_update_item */
+/* copy function for cypher_update_item */
 void copy_cypher_update_item(ExtensibleNode *newnode, const ExtensibleNode *from)
 {
     COPY_LOCALS(cypher_update_item);
@@ -137,6 +138,8 @@ void copy_cypher_update_item(ExtensibleNode *newnode, const ExtensibleNode *from
     COPY_NODE_FIELD(qualified_name);
     COPY_SCALAR_FIELD(remove_item);
     COPY_SCALAR_FIELD(is_add);
+    COPY_SCALAR_FIELD(is_label_op);
+    COPY_STRING_FIELD(label_name);
 }
 
 /* copy function for cypher_delete_information */

--- a/src/backend/nodes/cypher_outfuncs.c
+++ b/src/backend/nodes/cypher_outfuncs.c
@@ -159,6 +159,8 @@ void out_cypher_set_item(StringInfo str, const ExtensibleNode *node)
     WRITE_NODE_FIELD(prop);
     WRITE_NODE_FIELD(expr);
     WRITE_BOOL_FIELD(is_add);
+    WRITE_BOOL_FIELD(is_label_op);
+    WRITE_STRING_FIELD(label_name);
 }
 
 /* serialization function for the cypher_delete ExtensibleNode. */
@@ -428,6 +430,8 @@ void out_cypher_update_item(StringInfo str, const ExtensibleNode *node)
     WRITE_NODE_FIELD(qualified_name);
     WRITE_BOOL_FIELD(remove_item);
     WRITE_BOOL_FIELD(is_add);
+    WRITE_BOOL_FIELD(is_label_op);
+    WRITE_STRING_FIELD(label_name);
 }
 
 /* serialization function for the cypher_delete_information ExtensibleNode. */

--- a/src/backend/nodes/cypher_readfuncs.c
+++ b/src/backend/nodes/cypher_readfuncs.c
@@ -270,6 +270,8 @@ void read_cypher_update_item(struct ExtensibleNode *node)
     READ_NODE_FIELD(qualified_name);
     READ_BOOL_FIELD(remove_item);
     READ_BOOL_FIELD(is_add);
+    READ_BOOL_FIELD(is_label_op);
+    READ_STRING_FIELD(label_name);
 }
 
 /*

--- a/src/backend/parser/cypher_gram.y
+++ b/src/backend/parser/cypher_gram.y
@@ -1041,6 +1041,8 @@ set_item:
             n->prop = $1;
             n->expr = $3;
             n->is_add = false;
+            n->is_label_op = false;
+            n->label_name = NULL;
             n->location = @1;
 
             $$ = (Node *)n;
@@ -1053,6 +1055,28 @@ set_item:
             n->prop = $1;
             n->expr = $3;
             n->is_add = true;
+            n->is_label_op = false;
+            n->label_name = NULL;
+            n->location = @1;
+
+            $$ = (Node *)n;
+        }
+    | var_name ':' label_name
+        {
+            cypher_set_item *n;
+            ColumnRef *cref;
+
+            /* Create a ColumnRef for the variable */
+            cref = makeNode(ColumnRef);
+            cref->fields = list_make1(makeString($1));
+            cref->location = @1;
+
+            n = make_ag_node(cypher_set_item);
+            n->prop = (Node *)cref;
+            n->expr = NULL;
+            n->is_add = false;
+            n->is_label_op = true;
+            n->label_name = $3;
             n->location = @1;
 
             $$ = (Node *)n;
@@ -1093,6 +1117,28 @@ remove_item:
             n->prop = $1;
             n->expr = make_null_const(-1);
             n->is_add = false;
+            n->is_label_op = false;
+            n->label_name = NULL;
+
+            $$ = (Node *)n;
+        }
+    | var_name ':' label_name
+        {
+            cypher_set_item *n;
+            ColumnRef *cref;
+
+            /* Create a ColumnRef for the variable */
+            cref = makeNode(ColumnRef);
+            cref->fields = list_make1(makeString($1));
+            cref->location = @1;
+
+            n = make_ag_node(cypher_set_item);
+            n->prop = (Node *)cref;
+            n->expr = NULL;
+            n->is_add = false;
+            n->is_label_op = true;
+            n->label_name = $3;
+            n->location = @1;
 
             $$ = (Node *)n;
         }

--- a/src/include/nodes/cypher_nodes.h
+++ b/src/include/nodes/cypher_nodes.h
@@ -103,6 +103,8 @@ typedef struct cypher_set_item
     Node *prop; /* LHS */
     Node *expr; /* RHS */
     bool is_add; /* true if this is += */
+    bool is_label_op; /* true if this is a label SET/REMOVE operation */
+    char *label_name; /* label name for SET/REMOVE label operations */
     int location;
 } cypher_set_item;
 
@@ -453,6 +455,8 @@ typedef struct cypher_update_item
     List *qualified_name;
     bool remove_item;
     bool is_add;
+    bool is_label_op; /* true if this is a label SET/REMOVE operation */
+    char *label_name; /* label name for SET/REMOVE label operations */
 } cypher_update_item;
 
 typedef struct cypher_delete_information


### PR DESCRIPTION
NOTE: This PR was built with AI tools and verified by a human.

Implements Cypher SET and REMOVE operations for vertex labels in the unified vertex table architecture. This allows dynamic label management on vertices.

SET n:Label

* Only works on vertices with no label.

* Auto-creates the label if it doesn't exist.

* Errors with hint if vertex already has a label: "Multiple labels are not supported. Use REMOVE to clear the label first."

REMOVE n:Label

* Removes a vertex's specified label.

* Properties are preserved

* No-op if vertex already has no label

Added regression tests.

modified:   regress/expected/cypher_remove.out
modified:   regress/expected/unified_vertex_table.out
modified:   regress/sql/unified_vertex_table.sql
modified:   src/backend/executor/cypher_set.c
modified:   src/backend/nodes/cypher_copyfuncs.c
modified:   src/backend/nodes/cypher_outfuncs.c
modified:   src/backend/nodes/cypher_readfuncs.c
modified:   src/backend/parser/cypher_clause.c
modified:   src/backend/parser/cypher_gram.y
modified:   src/include/nodes/cypher_nodes.h