### PR TITLE
Add GROUP BY and ORDER BY optimization

### DIFF
--- a/regress/expected/unified_vertex_table.out
+++ b/regress/expected/unified_vertex_table.out
@@ -1320,6 +1320,37 @@ $$) AS (eid agtype, props agtype, sid agtype, eid2 agtype);
 --
 -- This avoids expensive vertex reconstruction in join conditions.
 --
+-- Helper function to check if join condition optimization is applied.
+-- Returns true if the plan uses direct column references (e.g., u.id)
+-- and NOT _agtype_build_vertex
+CREATE OR REPLACE FUNCTION plan_has_join_optimization(sql text)
+RETURNS boolean
+LANGUAGE plpgsql AS
+$$
+DECLARE
+    plan_row RECORD;
+    full_plan text := '';
+    has_direct_id boolean;
+    has_build_vertex boolean;
+BEGIN
+    -- Concatenate all rows of the EXPLAIN output
+    FOR plan_row IN EXECUTE format('EXPLAIN (FORMAT TEXT) %s', sql)
+    LOOP
+        full_plan := full_plan || plan_row."QUERY PLAN" || ' ';
+    END LOOP;
+    
+    -- Check for direct id references in join conditions (e.g., u.id, e.start_id)
+    has_direct_id := position('.id' in full_plan) > 0 OR
+                     position('start_id' in full_plan) > 0 OR
+                     position('end_id' in full_plan) > 0;
+    
+    -- Check for unoptimized pattern
+    has_build_vertex := position('_agtype_build_vertex' in full_plan) > 0;
+    
+    -- Optimization is applied if we see direct id references and no build_vertex
+    RETURN has_direct_id AND NOT has_build_vertex;
+END;
+$$;
 -- Create test data: Users following each other
 SELECT * FROM cypher('unified_test', $$
     CREATE (:JoinOptUser {name: 'Alice'}),
@@ -1346,28 +1377,14 @@ $$) AS (e agtype);
 ---
 (0 rows)
 
--- EXPLAIN showing join conditions use direct column access
--- Look for: graphid_to_agtype(id) instead of age_id(_agtype_build_vertex(...))
--- And: direct id comparisons instead of age_id(...)::graphid
-EXPLAIN (COSTS OFF)
-SELECT * FROM cypher('unified_test', $$
-    MATCH (u:JoinOptUser)-[e:JOPT_FOLLOWS]->(v:JoinOptUser)
-    RETURN u.name, v.name
-$$) AS (u_name agtype, v_name agtype);
-                         QUERY PLAN                         
-------------------------------------------------------------
- Nested Loop
-   Join Filter: (e.start_id = u.id)
-   ->  Nested Loop
-         ->  Seq Scan on _ag_label_vertex u
-               Filter: (labels = '23814'::oid)
-         ->  Seq Scan on _ag_label_vertex v
-               Filter: (labels = '23814'::oid)
-   ->  Bitmap Heap Scan on "JOPT_FOLLOWS" e
-         Recheck Cond: (end_id = v.id)
-         ->  Bitmap Index Scan on "JOPT_FOLLOWS_end_id_idx"
-               Index Cond: (end_id = v.id)
-(11 rows)
+-- Test 29a: Simple join - check for direct column access optimization
+SELECT plan_has_join_optimization(
+    'SELECT * FROM cypher(''unified_test'', $$ MATCH (u:JoinOptUser)-[e:JOPT_FOLLOWS]->(v:JoinOptUser) RETURN u.name, v.name $$) AS (u_name agtype, v_name agtype)'
+) AS simple_join_optimized;
+ simple_join_optimized 
+-----------------------
+ t
+(1 row)
 
 -- Verify the query still returns correct results
 SELECT * FROM cypher('unified_test', $$
@@ -1381,36 +1398,14 @@ $$) AS (u_name agtype, v_name agtype);
  "Bob"   | "Carol"
 (2 rows)
 
--- Multi-hop pattern showing optimization across multiple joins
-EXPLAIN (COSTS OFF)
-SELECT * FROM cypher('unified_test', $$
-    MATCH (a:JoinOptUser)-[e1:JOPT_FOLLOWS]->(b:JoinOptUser)-[e2:JOPT_FOLLOWS]->(c:JoinOptUser)
-    RETURN a.name, b.name, c.name
-$$) AS (a_name agtype, b_name agtype, c_name agtype);
-                               QUERY PLAN                               
-------------------------------------------------------------------------
- Nested Loop
-   Join Filter: (e1.start_id = a.id)
-   ->  Nested Loop
-         Join Filter: _ag_enforce_edge_uniqueness2(e1.id, e2.id)
-         ->  Nested Loop
-               Join Filter: (e2.start_id = b.id)
-               ->  Nested Loop
-                     ->  Seq Scan on _ag_label_vertex b
-                           Filter: (labels = '23814'::oid)
-                     ->  Seq Scan on _ag_label_vertex c
-                           Filter: (labels = '23814'::oid)
-               ->  Bitmap Heap Scan on "JOPT_FOLLOWS" e2
-                     Recheck Cond: (end_id = c.id)
-                     ->  Bitmap Index Scan on "JOPT_FOLLOWS_end_id_idx"
-                           Index Cond: (end_id = c.id)
-         ->  Bitmap Heap Scan on "JOPT_FOLLOWS" e1
-               Recheck Cond: (end_id = b.id)
-               ->  Bitmap Index Scan on "JOPT_FOLLOWS_end_id_idx"
-                     Index Cond: (end_id = b.id)
-   ->  Seq Scan on _ag_label_vertex a
-         Filter: (labels = '23814'::oid)
-(21 rows)
+-- Test 29b: Multi-hop pattern - check for optimization across multiple joins
+SELECT plan_has_join_optimization(
+    'SELECT * FROM cypher(''unified_test'', $$ MATCH (a:JoinOptUser)-[e1:JOPT_FOLLOWS]->(b:JoinOptUser)-[e2:JOPT_FOLLOWS]->(c:JoinOptUser) RETURN a.name, b.name, c.name $$) AS (a_name agtype, b_name agtype, c_name agtype)'
+) AS multihop_join_optimized;
+ multihop_join_optimized 
+-------------------------
+ t
+(1 row)
 
 -- Verify multi-hop query results
 SELECT * FROM cypher('unified_test', $$
@@ -1422,11 +1417,313 @@ $$) AS (a_name agtype, b_name agtype, c_name agtype);
  "Alice" | "Bob"  | "Carol"
 (1 row)
 
+-- Clean up Test 29 helper function
+DROP FUNCTION plan_has_join_optimization(text);
+--
+-- Test 30: Verify GROUP BY optimization with EXPLAIN
+--
+-- When using aggregation with id(vertex) or id(edge) in the GROUP BY key,
+-- the optimization should replace patterns like:
+--   age_id(_agtype_build_vertex(u.id, ...))
+-- with direct column access:
+--   graphid_to_agtype(u.id)
+--
+-- This avoids expensive vertex/edge reconstruction during grouping.
+--
+-- Helper function to check if GROUP BY optimization is applied.
+-- Returns true if the plan uses graphid_to_agtype (optimized)
+-- and NOT _agtype_build_vertex (unoptimized)
+CREATE OR REPLACE FUNCTION plan_has_groupby_optimization(sql text)
+RETURNS boolean
+LANGUAGE plpgsql AS
+$$
+DECLARE
+    plan_row RECORD;
+    full_plan text := '';
+    has_graphid_to_agtype boolean;
+    has_build_vertex boolean;
+    has_build_edge boolean;
+BEGIN
+    -- Concatenate all rows of the EXPLAIN output
+    FOR plan_row IN EXECUTE format('EXPLAIN (FORMAT TEXT) %s', sql)
+    LOOP
+        full_plan := full_plan || plan_row."QUERY PLAN" || ' ';
+    END LOOP;
+    
+    -- Check for optimized pattern
+    has_graphid_to_agtype := position('graphid_to_agtype' in full_plan) > 0;
+    
+    -- Check for unoptimized patterns
+    has_build_vertex := position('_agtype_build_vertex' in full_plan) > 0;
+    has_build_edge := position('_agtype_build_edge' in full_plan) > 0;
+    
+    -- Optimization is applied if we see graphid_to_agtype 
+    -- and don't see _agtype_build in the Group Key
+    RETURN has_graphid_to_agtype AND NOT has_build_vertex AND NOT has_build_edge;
+END;
+$$;
+-- Create test data: Users and Books with interactions
+SELECT * FROM cypher('unified_test', $$
+    CREATE (:GrpOptUser {name: 'Alice'}),
+           (:GrpOptUser {name: 'Bob'}),
+           (:GrpOptUser {name: 'Carol'}),
+           (:GrpOptBook {title: 'Book1'}),
+           (:GrpOptBook {title: 'Book2'})
+$$) AS (v agtype);
+ v 
+---
+(0 rows)
+
+SELECT * FROM cypher('unified_test', $$
+    MATCH (a:GrpOptUser {name: 'Alice'}), (b:GrpOptBook {title: 'Book1'})
+    CREATE (a)-[:GRPOPT_READ]->(b)
+$$) AS (e agtype);
+ e 
+---
+(0 rows)
+
+SELECT * FROM cypher('unified_test', $$
+    MATCH (a:GrpOptUser {name: 'Alice'}), (b:GrpOptBook {title: 'Book2'})
+    CREATE (a)-[:GRPOPT_READ]->(b)
+$$) AS (e agtype);
+ e 
+---
+(0 rows)
+
+SELECT * FROM cypher('unified_test', $$
+    MATCH (a:GrpOptUser {name: 'Bob'}), (b:GrpOptBook {title: 'Book1'})
+    CREATE (a)-[:GRPOPT_READ]->(b)
+$$) AS (e agtype);
+ e 
+---
+(0 rows)
+
+-- Test 30a: Simple vertex id() GROUP BY optimization
+-- Checks that plan uses graphid_to_agtype(u.id) instead of age_id(_agtype_build_vertex(...))
+SELECT plan_has_groupby_optimization(
+    'SELECT * FROM cypher(''unified_test'', $$ MATCH (u:GrpOptUser) RETURN id(u), count(*) $$) AS (user_id agtype, cnt agtype)'
+) AS vertex_id_optimized;
+ vertex_id_optimized 
+---------------------
+ t
+(1 row)
+
+-- Verify correct results
+SELECT * FROM cypher('unified_test', $$
+    MATCH (u:GrpOptUser)
+    RETURN id(u), count(*) AS cnt
+    ORDER BY cnt DESC
+$$) AS (user_id agtype, cnt agtype);
+      user_id      | cnt 
+-------------------+-----
+ 12666373951979521 | 1
+ 12666373951979522 | 1
+ 12666373951979523 | 1
+(3 rows)
+
+-- Test 30b: Multiple vertex id() GROUP BY keys optimization
+-- Checks that plan uses graphid_to_agtype for both u.id and b.id
+SELECT plan_has_groupby_optimization(
+    'SELECT * FROM cypher(''unified_test'', $$ MATCH (u:GrpOptUser)-[e:GRPOPT_READ]->(b:GrpOptBook) RETURN id(u), id(b), count(*) $$) AS (user_id agtype, book_id agtype, cnt agtype)'
+) AS multi_vertex_id_optimized;
+ multi_vertex_id_optimized 
+---------------------------
+ t
+(1 row)
+
+-- Verify correct results
+SELECT * FROM cypher('unified_test', $$
+    MATCH (u:GrpOptUser)-[e:GRPOPT_READ]->(b:GrpOptBook)
+    RETURN id(u), id(b), count(*) AS cnt
+    ORDER BY cnt DESC
+$$) AS (user_id agtype, book_id agtype, cnt agtype);
+      user_id      |      book_id      | cnt 
+-------------------+-------------------+-----
+ 12666373951979521 | 12947848928690177 | 1
+ 12666373951979521 | 12947848928690178 | 1
+ 12666373951979522 | 12947848928690177 | 1
+(3 rows)
+
+-- Test 30c: Edge id() GROUP BY optimization
+-- Checks that plan uses graphid_to_agtype(e.id)
+SELECT plan_has_groupby_optimization(
+    'SELECT * FROM cypher(''unified_test'', $$ MATCH (u:GrpOptUser)-[e:GRPOPT_READ]->(b:GrpOptBook) RETURN id(e), count(*) $$) AS (edge_id agtype, cnt agtype)'
+) AS edge_id_optimized;
+ edge_id_optimized 
+-------------------
+ t
+(1 row)
+
+-- Verify correct results
+SELECT * FROM cypher('unified_test', $$
+    MATCH (u:GrpOptUser)-[e:GRPOPT_READ]->(b:GrpOptBook)
+    RETURN id(e), count(*) AS cnt
+    ORDER BY cnt DESC
+$$) AS (edge_id agtype, cnt agtype);
+      edge_id      | cnt 
+-------------------+-----
+ 13229323905400833 | 1
+ 13229323905400834 | 1
+ 13229323905400835 | 1
+(3 rows)
+
+-- Test 30d: Edge start_id() and end_id() GROUP BY optimization
+-- Checks that plan uses graphid_to_agtype(e.start_id) and graphid_to_agtype(e.end_id)
+SELECT plan_has_groupby_optimization(
+    'SELECT * FROM cypher(''unified_test'', $$ MATCH (u:GrpOptUser)-[e:GRPOPT_READ]->(b:GrpOptBook) RETURN start_id(e), end_id(e), count(*) $$) AS (start_id agtype, end_id agtype, cnt agtype)'
+) AS edge_start_end_id_optimized;
+ edge_start_end_id_optimized 
+-----------------------------
+ t
+(1 row)
+
+-- Verify correct results
+SELECT * FROM cypher('unified_test', $$
+    MATCH (u:GrpOptUser)-[e:GRPOPT_READ]->(b:GrpOptBook)
+    RETURN start_id(e), end_id(e), count(*) AS cnt
+    ORDER BY cnt DESC
+$$) AS (start_id agtype, end_id agtype, cnt agtype);
+     start_id      |      end_id       | cnt 
+-------------------+-------------------+-----
+ 12666373951979521 | 12947848928690177 | 1
+ 12666373951979521 | 12947848928690178 | 1
+ 12666373951979522 | 12947848928690177 | 1
+(3 rows)
+
+-- Cleanup the GROUP BY helper function
+DROP FUNCTION plan_has_groupby_optimization(text);
+--
+-- Test 31: ORDER BY optimization tests
+-- Test that ORDER BY id(v) uses graphid_to_agtype instead of rebuilding vertex
+--
+-- Create a helper function to check for ORDER BY optimization
+CREATE OR REPLACE FUNCTION plan_has_orderby_optimization(query_text text)
+RETURNS boolean AS $$
+DECLARE
+    plan_row record;
+    full_plan text := '';
+    has_graphid_to_agtype boolean;
+    has_build_vertex boolean;
+    has_build_edge boolean;
+BEGIN
+    -- Load AGE extension and set search path for the session
+    EXECUTE 'LOAD ''age''';
+    EXECUTE 'SET search_path = ag_catalog, public';
+    
+    -- Get the query plan
+    FOR plan_row IN EXECUTE 'EXPLAIN (COSTS OFF) ' || query_text
+    LOOP
+        full_plan := full_plan || plan_row."QUERY PLAN" || ' ';
+    END LOOP;
+    
+    -- Check for optimized pattern
+    has_graphid_to_agtype := position('graphid_to_agtype' in full_plan) > 0;
+    
+    -- Check for unoptimized patterns
+    has_build_vertex := position('_agtype_build_vertex' in full_plan) > 0;
+    has_build_edge := position('_agtype_build_edge' in full_plan) > 0;
+    
+    -- Optimization is applied if we see graphid_to_agtype 
+    -- and don't see _agtype_build in the Sort Key
+    RETURN has_graphid_to_agtype AND NOT has_build_vertex AND NOT has_build_edge;
+END;
+$$
+LANGUAGE plpgsql;
+-- Test 31a: Simple vertex id() ORDER BY optimization
+-- Checks that Sort Key uses graphid_to_agtype(u.id) instead of age_id(_agtype_build_vertex(...))
+SELECT plan_has_orderby_optimization(
+    'SELECT * FROM cypher(''unified_test'', $$ MATCH (u:GrpOptUser) RETURN id(u) ORDER BY id(u) $$) AS (user_id agtype)'
+) AS vertex_id_orderby_optimized;
+ vertex_id_orderby_optimized 
+-----------------------------
+ t
+(1 row)
+
+-- Verify correct results
+SELECT * FROM cypher('unified_test', $$
+    MATCH (u:GrpOptUser)
+    RETURN id(u) ORDER BY id(u)
+$$) AS (user_id agtype);
+      user_id      
+-------------------
+ 12666373951979521
+ 12666373951979522
+ 12666373951979523
+(3 rows)
+
+-- Test 31b: ORDER BY with GROUP BY (both should be optimized)
+-- Checks that both Sort Key and Group Key use graphid_to_agtype
+SELECT plan_has_orderby_optimization(
+    'SELECT * FROM cypher(''unified_test'', $$ MATCH (u:GrpOptUser) RETURN id(u), count(*) ORDER BY id(u) $$) AS (user_id agtype, cnt agtype)'
+) AS orderby_with_groupby_optimized;
+ orderby_with_groupby_optimized 
+--------------------------------
+ t
+(1 row)
+
+-- Verify correct results
+SELECT * FROM cypher('unified_test', $$
+    MATCH (u:GrpOptUser)
+    RETURN id(u), count(*) AS cnt
+    ORDER BY id(u)
+$$) AS (user_id agtype, cnt agtype);
+      user_id      | cnt 
+-------------------+-----
+ 12666373951979521 | 1
+ 12666373951979522 | 1
+ 12666373951979523 | 1
+(3 rows)
+
+-- Test 31c: Edge id() ORDER BY optimization
+-- Checks that Sort Key uses graphid_to_agtype(e.id)
+SELECT plan_has_orderby_optimization(
+    'SELECT * FROM cypher(''unified_test'', $$ MATCH (u:GrpOptUser)-[e:GRPOPT_READ]->(b:GrpOptBook) RETURN id(e) ORDER BY id(e) $$) AS (edge_id agtype)'
+) AS edge_id_orderby_optimized;
+ edge_id_orderby_optimized 
+---------------------------
+ t
+(1 row)
+
+-- Verify correct results
+SELECT * FROM cypher('unified_test', $$
+    MATCH (u:GrpOptUser)-[e:GRPOPT_READ]->(b:GrpOptBook)
+    RETURN id(e) ORDER BY id(e)
+$$) AS (edge_id agtype);
+      edge_id      
+-------------------
+ 13229323905400833
+ 13229323905400834
+ 13229323905400835
+(3 rows)
+
+-- Test 31d: Edge start_id() ORDER BY optimization
+SELECT plan_has_orderby_optimization(
+    'SELECT * FROM cypher(''unified_test'', $$ MATCH (u:GrpOptUser)-[e:GRPOPT_READ]->(b:GrpOptBook) RETURN start_id(e) ORDER BY start_id(e) $$) AS (start_id agtype)'
+) AS edge_start_id_orderby_optimized;
+ edge_start_id_orderby_optimized 
+---------------------------------
+ t
+(1 row)
+
+-- Verify correct results
+SELECT * FROM cypher('unified_test', $$
+    MATCH (u:GrpOptUser)-[e:GRPOPT_READ]->(b:GrpOptBook)
+    RETURN start_id(e) ORDER BY start_id(e)
+$$) AS (start_id agtype);
+     start_id      
+-------------------
+ 12666373951979521
+ 12666373951979521
+ 12666373951979522
+(3 rows)
+
+-- Cleanup the ORDER BY helper function
+DROP FUNCTION plan_has_orderby_optimization(text);
 --
 -- Cleanup
 --
 SELECT drop_graph('unified_test', true);
-NOTICE:  drop cascades to 44 other objects
+NOTICE:  drop cascades to 47 other objects
 DETAIL:  drop cascades to table unified_test._ag_label_vertex
 drop cascades to table unified_test._ag_label_edge
 drop cascades to table unified_test."Person"
@@ -1471,6 +1768,9 @@ drop cascades to table unified_test."OPT_EDGE"
 drop cascades to table unified_test."OptEnd"
 drop cascades to table unified_test."JoinOptUser"
 drop cascades to table unified_test."JOPT_FOLLOWS"
+drop cascades to table unified_test."GrpOptUser"
+drop cascades to table unified_test."GrpOptBook"
+drop cascades to table unified_test."GRPOPT_READ"
 NOTICE:  graph "unified_test" has been dropped
  drop_graph 
 ------------


### PR DESCRIPTION
NOTE: This PR was created with AI tools and a human.

Add GROUP BY and ORDER BY optimization for vertex/edge field access.

Transform expressions like age_id(_agtype_build_vertex(id, label, props)) into graphid_to_agtype(id) in GROUP BY and ORDER BY clauses, avoiding unnecessary vertex/edge reconstruction when only the ID is needed.

Implementation:
- Add optimize_sortgroupby_vertex_access() in cypher_clause.c
- Walk target entries with non-zero ressortgroupref (GROUP BY/ORDER BY refs)
- Detect outer accessor functions: age_id, age_start_id, age_end_id, age_properties
- Match inner build functions: _agtype_build_vertex, _agtype_build_edge
- Extract the relevant field directly and wrap with graphid_to_agtype()
- Add resjunk target entries to subquery for direct field access

Supported patterns:
- GROUP BY id(v)        -> Group Key: graphid_to_agtype(v.id)
- GROUP BY start_id(e)  -> Group Key: graphid_to_agtype(e.start_id)
- GROUP BY end_id(e)    -> Group Key: graphid_to_agtype(e.end_id)
- ORDER BY id(v)        -> Sort Key: graphid_to_agtype(v.id)
- ORDER BY start_id(e)  -> Sort Key: graphid_to_agtype(e.start_id)
- ORDER BY end_id(e)    -> Sort Key: graphid_to_agtype(e.end_id)
- Combined ORDER BY + GROUP BY

This complements existing optimizations:
- cypher_expr.c: optimize_vertex_field_access() for direct FuncExpr patterns
- cypher_clause.c: optimize_qual_expr_mutator() for WHERE/join conditions

Existing regression tests were not affected.
Added additional regression tests.

modified:   regress/expected/unified_vertex_table.out
modified:   regress/sql/unified_vertex_table.sql
modified:   src/backend/parser/cypher_clause.c