### PR TITLE
Optimize id()/start_id()/end_id() with direct column access

### DIFF
--- a/age--1.6.0--y.y.y.sql
+++ b/age--1.6.0--y.y.y.sql
@@ -51,3 +51,274 @@ CREATE FUNCTION ag_catalog._ag_enforce_edge_uniqueness4(graphid, graphid, graphi
     STABLE
 PARALLEL SAFE
 as 'MODULE_PATHNAME';
+
+--
+-- graphid - int8 cross-type comparison operators
+--
+-- These allow efficient comparison of graphid with integer literals,
+-- avoiding the need to convert to agtype for comparisons like id(v) > 0.
+--
+
+-- graphid vs int8 comparison functions
+CREATE FUNCTION ag_catalog.graphid_eq_int8(graphid, int8)
+    RETURNS boolean
+    LANGUAGE c
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
+CREATE FUNCTION ag_catalog.graphid_ne_int8(graphid, int8)
+    RETURNS boolean
+    LANGUAGE c
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
+CREATE FUNCTION ag_catalog.graphid_lt_int8(graphid, int8)
+    RETURNS boolean
+    LANGUAGE c
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
+CREATE FUNCTION ag_catalog.graphid_gt_int8(graphid, int8)
+    RETURNS boolean
+    LANGUAGE c
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
+CREATE FUNCTION ag_catalog.graphid_le_int8(graphid, int8)
+    RETURNS boolean
+    LANGUAGE c
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
+CREATE FUNCTION ag_catalog.graphid_ge_int8(graphid, int8)
+    RETURNS boolean
+    LANGUAGE c
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
+-- int8 vs graphid comparison functions
+CREATE FUNCTION ag_catalog.int8_eq_graphid(int8, graphid)
+    RETURNS boolean
+    LANGUAGE c
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
+CREATE FUNCTION ag_catalog.int8_ne_graphid(int8, graphid)
+    RETURNS boolean
+    LANGUAGE c
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
+CREATE FUNCTION ag_catalog.int8_lt_graphid(int8, graphid)
+    RETURNS boolean
+    LANGUAGE c
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
+CREATE FUNCTION ag_catalog.int8_gt_graphid(int8, graphid)
+    RETURNS boolean
+    LANGUAGE c
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
+CREATE FUNCTION ag_catalog.int8_le_graphid(int8, graphid)
+    RETURNS boolean
+    LANGUAGE c
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
+CREATE FUNCTION ag_catalog.int8_ge_graphid(int8, graphid)
+    RETURNS boolean
+    LANGUAGE c
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
+-- Cross-type operators: graphid vs int8
+CREATE OPERATOR = (
+  FUNCTION = ag_catalog.graphid_eq_int8,
+  LEFTARG = graphid,
+  RIGHTARG = int8,
+  COMMUTATOR = =,
+  NEGATOR = <>,
+  RESTRICT = eqsel,
+  JOIN = eqjoinsel,
+  HASHES,
+  MERGES
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = ag_catalog.graphid_ne_int8,
+  LEFTARG = graphid,
+  RIGHTARG = int8,
+  COMMUTATOR = <>,
+  NEGATOR = =,
+  RESTRICT = neqsel,
+  JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = ag_catalog.graphid_lt_int8,
+  LEFTARG = graphid,
+  RIGHTARG = int8,
+  COMMUTATOR = >,
+  NEGATOR = >=,
+  RESTRICT = scalarltsel,
+  JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = ag_catalog.graphid_gt_int8,
+  LEFTARG = graphid,
+  RIGHTARG = int8,
+  COMMUTATOR = <,
+  NEGATOR = <=,
+  RESTRICT = scalargtsel,
+  JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = ag_catalog.graphid_le_int8,
+  LEFTARG = graphid,
+  RIGHTARG = int8,
+  COMMUTATOR = >=,
+  NEGATOR = >,
+  RESTRICT = scalarlesel,
+  JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = ag_catalog.graphid_ge_int8,
+  LEFTARG = graphid,
+  RIGHTARG = int8,
+  COMMUTATOR = <=,
+  NEGATOR = <,
+  RESTRICT = scalargesel,
+  JOIN = scalargejoinsel
+);
+
+-- Cross-type operators: int8 vs graphid
+CREATE OPERATOR = (
+  FUNCTION = ag_catalog.int8_eq_graphid,
+  LEFTARG = int8,
+  RIGHTARG = graphid,
+  COMMUTATOR = =,
+  NEGATOR = <>,
+  RESTRICT = eqsel,
+  JOIN = eqjoinsel,
+  HASHES,
+  MERGES
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = ag_catalog.int8_ne_graphid,
+  LEFTARG = int8,
+  RIGHTARG = graphid,
+  COMMUTATOR = <>,
+  NEGATOR = =,
+  RESTRICT = neqsel,
+  JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = ag_catalog.int8_lt_graphid,
+  LEFTARG = int8,
+  RIGHTARG = graphid,
+  COMMUTATOR = >,
+  NEGATOR = >=,
+  RESTRICT = scalarltsel,
+  JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = ag_catalog.int8_gt_graphid,
+  LEFTARG = int8,
+  RIGHTARG = graphid,
+  COMMUTATOR = <,
+  NEGATOR = <=,
+  RESTRICT = scalargtsel,
+  JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = ag_catalog.int8_le_graphid,
+  LEFTARG = int8,
+  RIGHTARG = graphid,
+  COMMUTATOR = >=,
+  NEGATOR = >,
+  RESTRICT = scalarlesel,
+  JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = ag_catalog.int8_ge_graphid,
+  LEFTARG = int8,
+  RIGHTARG = graphid,
+  COMMUTATOR = <=,
+  NEGATOR = <,
+  RESTRICT = scalargesel,
+  JOIN = scalargejoinsel
+);
+
+-- Cross-type btree comparison support functions
+CREATE FUNCTION ag_catalog.graphid_btree_cmp_int8(graphid, int8)
+    RETURNS int
+    LANGUAGE c
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
+CREATE FUNCTION ag_catalog.int8_btree_cmp_graphid(int8, graphid)
+    RETURNS int
+    LANGUAGE c
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
+-- Update operator class to include cross-type operators for index scans
+-- We need to drop and recreate the operator class
+DROP OPERATOR CLASS IF EXISTS ag_catalog.graphid_ops USING btree CASCADE;
+
+CREATE OPERATOR CLASS ag_catalog.graphid_ops DEFAULT FOR TYPE graphid USING btree AS
+  -- same-type operators (graphid vs graphid)
+  OPERATOR 1 < (graphid, graphid),
+  OPERATOR 2 <= (graphid, graphid),
+  OPERATOR 3 = (graphid, graphid),
+  OPERATOR 4 >= (graphid, graphid),
+  OPERATOR 5 > (graphid, graphid),
+  -- cross-type operators (graphid vs int8)
+  OPERATOR 1 < (graphid, int8),
+  OPERATOR 2 <= (graphid, int8),
+  OPERATOR 3 = (graphid, int8),
+  OPERATOR 4 >= (graphid, int8),
+  OPERATOR 5 > (graphid, int8),
+  -- same-type support functions
+  FUNCTION 1 ag_catalog.graphid_btree_cmp (graphid, graphid),
+  FUNCTION 2 ag_catalog.graphid_btree_sort (internal),
+  -- cross-type support function (graphid vs int8)
+  FUNCTION 1 (graphid, int8) ag_catalog.graphid_btree_cmp_int8 (graphid, int8);

--- a/regress/expected/cypher_match.out
+++ b/regress/expected/cypher_match.out
@@ -3534,6 +3534,259 @@ SELECT * FROM cypher('test_enable_containment', $$ EXPLAIN (costs off) MATCH (x:
 (2 rows)
 
 --
+-- Test: WHERE clause id(), start_id(), end_id() optimizations in current clause
+-- These tests verify that id/start_id/end_id calls in WHERE clauses use direct
+-- column access (raw graphid) instead of rebuilding the full vertex/edge.
+-- This allows PostgreSQL to use indexes on graphid columns.
+--
+SELECT create_graph('test_where_opt');
+NOTICE:  graph "test_where_opt" has been created
+ create_graph 
+--------------
+ 
+(1 row)
+
+-- Create test data
+SELECT * FROM cypher('test_where_opt', $$
+    CREATE (:Person {name: 'Alice'})-[:KNOWS {since: 2020}]->(:Person {name: 'Bob'})
+$$) as (a agtype);
+ a 
+---
+(0 rows)
+
+-- Test 1: WHERE with id(vertex) in current clause - uses raw graphid column
+SELECT * FROM cypher('test_where_opt', $$
+    MATCH (p:Person)
+    WHERE id(p) > 0
+    RETURN p.name
+$$) as (name agtype);
+  name   
+---------
+ "Alice"
+ "Bob"
+(2 rows)
+
+-- Test 2: EXPLAIN to verify optimization (raw graphid instead of age_id)
+SELECT * FROM cypher('test_where_opt', $$
+    EXPLAIN (VERBOSE, COSTS OFF)
+    MATCH (p:Person)
+    WHERE id(p) > 0
+    RETURN p.name
+$$) as (plan agtype);
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Bitmap Heap Scan on test_where_opt."Person" p
+   Output: agtype_access_operator(VARIADIC ARRAY[_agtype_build_vertex(p.id, _label_name('20398'::oid, p.id), p.properties), '"name"'::agtype])
+   Recheck Cond: (p.id > '0'::graphid)
+   ->  Bitmap Index Scan on "Person_pkey"
+         Index Cond: (p.id > '0'::graphid)
+(5 rows)
+
+-- Test 3: WHERE with id(edge) in current clause
+SELECT * FROM cypher('test_where_opt', $$
+    MATCH (p:Person)-[e:KNOWS]->(q:Person)
+    WHERE id(e) > 0
+    RETURN p.name, q.name
+$$) as (name1 agtype, name2 agtype);
+  name1  | name2 
+---------+-------
+ "Alice" | "Bob"
+(1 row)
+
+-- Test 4: WHERE with start_id(edge) in current clause
+SELECT * FROM cypher('test_where_opt', $$
+    MATCH (p:Person)-[e:KNOWS]->(q:Person)
+    WHERE start_id(e) > 0
+    RETURN p.name, q.name
+$$) as (name1 agtype, name2 agtype);
+  name1  | name2 
+---------+-------
+ "Alice" | "Bob"
+(1 row)
+
+-- Test 5: WHERE with end_id(edge) in current clause
+SELECT * FROM cypher('test_where_opt', $$
+    MATCH (p:Person)-[e:KNOWS]->(q:Person)
+    WHERE end_id(e) > 0
+    RETURN p.name, q.name
+$$) as (name1 agtype, name2 agtype);
+  name1  | name2 
+---------+-------
+ "Alice" | "Bob"
+(1 row)
+
+-- Test 6: EXPLAIN to verify edge optimization (all three: id, start_id, end_id)
+SELECT * FROM cypher('test_where_opt', $$
+    EXPLAIN (VERBOSE, COSTS OFF)
+    MATCH (p:Person)-[e:KNOWS]->(q:Person)
+    WHERE id(e) > 0 AND start_id(e) > 0 AND end_id(e) > 0
+    RETURN p.name
+$$) as (plan agtype);
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Join
+   Output: agtype_access_operator(VARIADIC ARRAY[_agtype_build_vertex(p.id, _label_name('20398'::oid, p.id), p.properties), '"name"'::agtype])
+   Hash Cond: (q.id = e.end_id)
+   ->  Seq Scan on test_where_opt."Person" q
+         Output: q.id, q.properties
+   ->  Hash
+         Output: p.id, p.properties, e.end_id
+         ->  Hash Join
+               Output: p.id, p.properties, e.end_id
+               Hash Cond: (p.id = e.start_id)
+               ->  Seq Scan on test_where_opt."Person" p
+                     Output: p.id, p.properties
+               ->  Hash
+                     Output: e.start_id, e.end_id
+                     ->  Bitmap Heap Scan on test_where_opt."KNOWS" e
+                           Output: e.start_id, e.end_id
+                           Recheck Cond: (e.end_id > '0'::graphid)
+                           Filter: ((e.id > '0'::graphid) AND (e.start_id > '0'::graphid))
+                           ->  Bitmap Index Scan on "KNOWS_end_id_idx"
+                                 Index Cond: (e.end_id > '0'::graphid)
+(20 rows)
+
+-- Test 7: Combined WHERE with multiple id() calls on different entities
+SELECT * FROM cypher('test_where_opt', $$
+    MATCH (p:Person)-[e:KNOWS]->(q:Person)
+    WHERE id(p) > 0 AND id(q) > 0 AND id(e) > 0
+    RETURN p.name, q.name
+$$) as (name1 agtype, name2 agtype);
+  name1  | name2 
+---------+-------
+ "Alice" | "Bob"
+(1 row)
+
+-- Test 8: WHERE with id() comparison between entities
+SELECT * FROM cypher('test_where_opt', $$
+    MATCH (p:Person)-[e:KNOWS]->(q:Person)
+    WHERE start_id(e) = id(p) AND end_id(e) = id(q)
+    RETURN p.name, q.name
+$$) as (name1 agtype, name2 agtype);
+  name1  | name2 
+---------+-------
+ "Alice" | "Bob"
+(1 row)
+
+-- Test 9: WHERE with id() in complex expression
+SELECT * FROM cypher('test_where_opt', $$
+    MATCH (p:Person)
+    WHERE id(p) > 0 AND id(p) < 9223372036854775807
+    RETURN p.name
+$$) as (name agtype);
+  name   
+---------
+ "Alice"
+ "Bob"
+(2 rows)
+
+-- Test 10: Cross-clause WHERE still works (entity from previous MATCH)
+SELECT * FROM cypher('test_where_opt', $$
+    MATCH (p:Person)
+    MATCH (q:Person)
+    WHERE id(p) > 0
+    RETURN p.name, q.name
+$$) as (name1 agtype, name2 agtype);
+  name1  |  name2  
+---------+---------
+ "Alice" | "Alice"
+ "Bob"   | "Alice"
+ "Alice" | "Bob"
+ "Bob"   | "Bob"
+(4 rows)
+
+-- Test 11: EXPLAIN cross-clause to verify optimization
+SELECT * FROM cypher('test_where_opt', $$
+    EXPLAIN (VERBOSE, COSTS OFF)
+    MATCH (p:Person)
+    MATCH (q:Person)
+    WHERE id(p) > 0
+    RETURN p.name
+$$) as (plan agtype);
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop
+   Output: agtype_access_operator(VARIADIC ARRAY[_agtype_build_vertex(p.id, _label_name('20398'::oid, p.id), p.properties), '"name"'::agtype])
+   ->  Seq Scan on test_where_opt."Person" q
+         Output: q.id, q.properties
+   ->  Materialize
+         Output: p.id, p.properties
+         ->  Bitmap Heap Scan on test_where_opt."Person" p
+               Output: p.id, p.properties
+               Recheck Cond: (p.id > '0'::graphid)
+               ->  Bitmap Index Scan on "Person_pkey"
+                     Index Cond: (p.id > '0'::graphid)
+(11 rows)
+
+-- Test 12: Combined cross-clause and current-clause WHERE optimization
+-- p is from previous clause (cross-clause), q and e are from current clause (intra-clause)
+SELECT * FROM cypher('test_where_opt', $$
+    MATCH (p:Person)
+    MATCH (q:Person)-[e:KNOWS]->(r:Person)
+    WHERE id(p) > 0 AND id(q) > 0 AND id(e) > 0 AND start_id(e) > 0
+    RETURN p.name, q.name, r.name
+$$) as (name1 agtype, name2 agtype, name3 agtype);
+  name1  |  name2  | name3 
+---------+---------+-------
+ "Alice" | "Alice" | "Bob"
+ "Bob"   | "Alice" | "Bob"
+(2 rows)
+
+-- Test 13: EXPLAIN combined cross-clause and current-clause WHERE
+SELECT * FROM cypher('test_where_opt', $$
+    EXPLAIN (VERBOSE, COSTS OFF)
+    MATCH (p:Person)
+    MATCH (q:Person)-[e:KNOWS]->(r:Person)
+    WHERE id(p) > 0 AND id(q) > 0 AND id(e) > 0 AND start_id(e) > 0
+    RETURN p.name
+$$) as (plan agtype);
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop
+   Output: agtype_access_operator(VARIADIC ARRAY[_agtype_build_vertex(p.id, _label_name('20398'::oid, p.id), p.properties), '"name"'::agtype])
+   ->  Bitmap Heap Scan on test_where_opt."Person" p
+         Output: p.id, p.properties
+         Recheck Cond: (p.id > '0'::graphid)
+         ->  Bitmap Index Scan on "Person_pkey"
+               Index Cond: (p.id > '0'::graphid)
+   ->  Materialize
+         ->  Nested Loop
+               Inner Unique: true
+               ->  Hash Join
+                     Output: e.end_id
+                     Inner Unique: true
+                     Hash Cond: (e.start_id = q.id)
+                     ->  Bitmap Heap Scan on test_where_opt."KNOWS" e
+                           Output: e.id, e.start_id, e.end_id, e.properties
+                           Recheck Cond: (e.start_id > '0'::graphid)
+                           Filter: (e.id > '0'::graphid)
+                           ->  Bitmap Index Scan on "KNOWS_start_id_idx"
+                                 Index Cond: (e.start_id > '0'::graphid)
+                     ->  Hash
+                           Output: q.id
+                           ->  Bitmap Heap Scan on test_where_opt."Person" q
+                                 Output: q.id
+                                 Recheck Cond: (q.id > '0'::graphid)
+                                 ->  Bitmap Index Scan on "Person_pkey"
+                                       Index Cond: (q.id > '0'::graphid)
+               ->  Index Only Scan using "Person_pkey" on test_where_opt."Person" r
+                     Output: r.id
+                     Index Cond: (r.id = e.end_id)
+(30 rows)
+
+SELECT drop_graph('test_where_opt', true);
+NOTICE:  drop cascades to 4 other objects
+DETAIL:  drop cascades to table test_where_opt._ag_label_vertex
+drop cascades to table test_where_opt._ag_label_edge
+drop cascades to table test_where_opt."Person"
+drop cascades to table test_where_opt."KNOWS"
+NOTICE:  graph "test_where_opt" has been dropped
+ drop_graph 
+------------
+ 
+(1 row)
+
+--
 -- Clean up
 --
 SELECT drop_graph('cypher_match', true);

--- a/regress/expected/cypher_with.out
+++ b/regress/expected/cypher_with.out
@@ -280,6 +280,214 @@ ERROR:  could not find rte for end_node
 LINE 7:     RETURN id(start_node),end_node.name
                                   ^
 HINT:  variable end_node does not exist within scope of usage
+--
+-- WITH clause with id(), start_id(), end_id() functions
+-- These tests verify that graph entity id functions work correctly
+-- when the entity is passed through WITH clauses
+--
+-- Simple WITH vertex RETURN id(vertex)
+SELECT * FROM cypher('cypher_with', $$
+    MATCH (n)
+    WITH n
+    RETURN id(n), n.name
+    ORDER BY id(n)
+$$) AS (id agtype, name agtype);
+       id        |   name    
+-----------------+-----------
+ 281474976710657 | "Andres"
+ 281474976710658 | "Caesar"
+ 281474976710659 | "Bossman"
+ 281474976710660 | "David"
+ 281474976710661 | "George"
+(5 rows)
+
+-- WITH vertex RETURN id(vertex) with WHERE clause
+SELECT * FROM cypher('cypher_with', $$
+    MATCH (n)
+    WITH n
+    WHERE n.age > 30
+    RETURN id(n), n.name
+    ORDER BY id(n)
+$$) AS (id agtype, name agtype);
+       id        |   name    
+-----------------+-----------
+ 281474976710657 | "Andres"
+ 281474976710659 | "Bossman"
+ 281474976710660 | "David"
+ 281474976710661 | "George"
+(4 rows)
+
+-- Simple WITH edge RETURN id(edge), start_id(edge), end_id(edge)
+SELECT * FROM cypher('cypher_with', $$
+    MATCH ()-[e]->()
+    WITH e
+    RETURN id(e), start_id(e), end_id(e)
+    ORDER BY id(e)
+$$) AS (id agtype, start_id agtype, end_id agtype);
+        id        |    start_id     |     end_id      
+------------------+-----------------+-----------------
+ 844424930131969  | 281474976710657 | 281474976710658
+ 844424930131970  | 281474976710659 | 281474976710660
+ 1125899906842625 | 281474976710657 | 281474976710659
+ 1125899906842626 | 281474976710658 | 281474976710661
+ 1125899906842627 | 281474976710659 | 281474976710661
+ 1125899906842628 | 281474976710660 | 281474976710657
+(6 rows)
+
+-- WITH edge with label filter
+SELECT * FROM cypher('cypher_with', $$
+    MATCH ()-[e:KNOWS]->()
+    WITH e
+    RETURN id(e), start_id(e), end_id(e)
+    ORDER BY id(e)
+$$) AS (id agtype, start_id agtype, end_id agtype);
+        id        |    start_id     |     end_id      
+------------------+-----------------+-----------------
+ 1125899906842625 | 281474976710657 | 281474976710659
+ 1125899906842626 | 281474976710658 | 281474976710661
+ 1125899906842627 | 281474976710659 | 281474976710661
+ 1125899906842628 | 281474976710660 | 281474976710657
+(4 rows)
+
+-- WITH both vertex and edge, return all id functions
+SELECT * FROM cypher('cypher_with', $$
+    MATCH (a)-[e]->(b)
+    WITH a, e, b
+    RETURN id(a), id(e), start_id(e), end_id(e), id(b)
+    ORDER BY id(a), id(e)
+$$) AS (id_a agtype, id_e agtype, start_e agtype, end_e agtype, id_b agtype);
+      id_a       |       id_e       |     start_e     |      end_e      |      id_b       
+-----------------+------------------+-----------------+-----------------+-----------------
+ 281474976710657 | 844424930131969  | 281474976710657 | 281474976710658 | 281474976710658
+ 281474976710657 | 1125899906842625 | 281474976710657 | 281474976710659 | 281474976710659
+ 281474976710658 | 1125899906842626 | 281474976710658 | 281474976710661 | 281474976710661
+ 281474976710659 | 844424930131970  | 281474976710659 | 281474976710660 | 281474976710660
+ 281474976710659 | 1125899906842627 | 281474976710659 | 281474976710661 | 281474976710661
+ 281474976710660 | 1125899906842628 | 281474976710660 | 281474976710657 | 281474976710657
+(6 rows)
+
+-- Chained WITH clauses with id functions
+SELECT * FROM cypher('cypher_with', $$
+    MATCH (a)-[e]->(b)
+    WITH a, e, b
+    WHERE label(e) = 'KNOWS'
+    WITH a, e, b
+    RETURN id(a), id(e), id(b), a.name, b.name
+    ORDER BY id(a)
+$$) AS (id_a agtype, id_e agtype, id_b agtype, name_a agtype, name_b agtype);
+      id_a       |       id_e       |      id_b       |  name_a   |  name_b   
+-----------------+------------------+-----------------+-----------+-----------
+ 281474976710657 | 1125899906842625 | 281474976710659 | "Andres"  | "Bossman"
+ 281474976710658 | 1125899906842626 | 281474976710661 | "Caesar"  | "George"
+ 281474976710659 | 1125899906842627 | 281474976710661 | "Bossman" | "George"
+ 281474976710660 | 1125899906842628 | 281474976710657 | "David"   | "Andres"
+(4 rows)
+
+-- Triple WITH chain with id functions
+SELECT * FROM cypher('cypher_with', $$
+    MATCH (a)-[e]->(b)
+    WITH a, e, b
+    WITH a, e, b
+    WITH a, e, b
+    RETURN id(a), id(e), id(b)
+    ORDER BY id(a), id(e)
+$$) AS (id_a agtype, id_e agtype, id_b agtype);
+      id_a       |       id_e       |      id_b       
+-----------------+------------------+-----------------
+ 281474976710657 | 844424930131969  | 281474976710658
+ 281474976710657 | 1125899906842625 | 281474976710659
+ 281474976710658 | 1125899906842626 | 281474976710661
+ 281474976710659 | 844424930131970  | 281474976710660
+ 281474976710659 | 1125899906842627 | 281474976710661
+ 281474976710660 | 1125899906842628 | 281474976710657
+(6 rows)
+
+-- WITH ... AS alias, then id() on alias
+SELECT * FROM cypher('cypher_with', $$
+    MATCH (n)
+    WITH n AS person
+    RETURN id(person), person.name
+    ORDER BY id(person)
+$$) AS (id agtype, name agtype);
+       id        |   name    
+-----------------+-----------
+ 281474976710657 | "Andres"
+ 281474976710658 | "Caesar"
+ 281474976710659 | "Bossman"
+ 281474976710660 | "David"
+ 281474976710661 | "George"
+(5 rows)
+
+-- WITH edge AS alias, then edge id functions on alias
+SELECT * FROM cypher('cypher_with', $$
+    MATCH ()-[e]->()
+    WITH e AS rel
+    RETURN id(rel), start_id(rel), end_id(rel)
+    ORDER BY id(rel)
+$$) AS (id agtype, start_id agtype, end_id agtype);
+        id        |    start_id     |     end_id      
+------------------+-----------------+-----------------
+ 844424930131969  | 281474976710657 | 281474976710658
+ 844424930131970  | 281474976710659 | 281474976710660
+ 1125899906842625 | 281474976710657 | 281474976710659
+ 1125899906842626 | 281474976710658 | 281474976710661
+ 1125899906842627 | 281474976710659 | 281474976710661
+ 1125899906842628 | 281474976710660 | 281474976710657
+(6 rows)
+
+-- Mix of id functions and property access after WITH
+SELECT * FROM cypher('cypher_with', $$
+    MATCH (a)-[e]->(b)
+    WITH a, e, b
+    WHERE a.age > 30
+    RETURN id(a), a.name, id(e), id(b), b.name
+    ORDER BY id(a)
+$$) AS (id_a agtype, name_a agtype, id_e agtype, id_b agtype, name_b agtype);
+      id_a       |  name_a   |       id_e       |      id_b       |  name_b   
+-----------------+-----------+------------------+-----------------+-----------
+ 281474976710657 | "Andres"  | 844424930131969  | 281474976710658 | "Caesar"
+ 281474976710657 | "Andres"  | 1125899906842625 | 281474976710659 | "Bossman"
+ 281474976710659 | "Bossman" | 844424930131970  | 281474976710660 | "David"
+ 281474976710659 | "Bossman" | 1125899906842627 | 281474976710661 | "George"
+ 281474976710660 | "David"   | 1125899906842628 | 281474976710657 | "Andres"
+(5 rows)
+
+-- WITH in subquery pattern - vertex ids
+SELECT * FROM cypher('cypher_with', $$
+    MATCH (a)-[]->(b)
+    WITH a, b
+    MATCH (b)-[]->(c)
+    RETURN id(a), id(b), id(c), a.name, b.name, c.name
+    ORDER BY id(a), id(b), id(c)
+$$) AS (id_a agtype, id_b agtype, id_c agtype, name_a agtype, name_b agtype, name_c agtype);
+      id_a       |      id_b       |      id_c       |  name_a   |  name_b   |  name_c   
+-----------------+-----------------+-----------------+-----------+-----------+-----------
+ 281474976710657 | 281474976710658 | 281474976710661 | "Andres"  | "Caesar"  | "George"
+ 281474976710657 | 281474976710659 | 281474976710660 | "Andres"  | "Bossman" | "David"
+ 281474976710657 | 281474976710659 | 281474976710661 | "Andres"  | "Bossman" | "George"
+ 281474976710659 | 281474976710660 | 281474976710657 | "Bossman" | "David"   | "Andres"
+ 281474976710660 | 281474976710657 | 281474976710658 | "David"   | "Andres"  | "Caesar"
+ 281474976710660 | 281474976710657 | 281474976710659 | "David"   | "Andres"  | "Bossman"
+(6 rows)
+
+-- WITH in subquery pattern - edge ids
+SELECT * FROM cypher('cypher_with', $$
+    MATCH (a)-[e1]->(b)
+    WITH a, e1, b
+    MATCH (b)-[e2]->(c)
+    RETURN id(e1), start_id(e1), end_id(e1), id(e2), start_id(e2), end_id(e2)
+    ORDER BY id(e1), id(e2)
+$$) AS (id_e1 agtype, start_e1 agtype, end_e1 agtype, id_e2 agtype, start_e2 agtype, end_e2 agtype);
+      id_e1       |    start_e1     |     end_e1      |      id_e2       |    start_e2     |     end_e2      
+------------------+-----------------+-----------------+------------------+-----------------+-----------------
+ 844424930131969  | 281474976710657 | 281474976710658 | 1125899906842626 | 281474976710658 | 281474976710661
+ 844424930131970  | 281474976710659 | 281474976710660 | 1125899906842628 | 281474976710660 | 281474976710657
+ 1125899906842625 | 281474976710657 | 281474976710659 | 844424930131970  | 281474976710659 | 281474976710660
+ 1125899906842625 | 281474976710657 | 281474976710659 | 1125899906842627 | 281474976710659 | 281474976710661
+ 1125899906842628 | 281474976710660 | 281474976710657 | 844424930131969  | 281474976710657 | 281474976710658
+ 1125899906842628 | 281474976710660 | 281474976710657 | 1125899906842625 | 281474976710657 | 281474976710659
+(6 rows)
+
 -- Clean up
 SELECT drop_graph('cypher_with', true);
 NOTICE:  drop cascades to 4 other objects

--- a/regress/expected/graphid.out
+++ b/regress/expected/graphid.out
@@ -63,6 +63,96 @@ SELECT '0'::graphid >= '1'::graphid,
  f        | t        | t
 (1 row)
 
+-- graphid vs int8 cross-type comparisons
+SELECT '0'::graphid = 0::int8, '0'::graphid = 1::int8;
+ ?column? | ?column? 
+----------+----------
+ t        | f
+(1 row)
+
+SELECT '0'::graphid <> 0::int8, '0'::graphid <> 1::int8;
+ ?column? | ?column? 
+----------+----------
+ f        | t
+(1 row)
+
+SELECT '0'::graphid < 1::int8,
+       '0'::graphid < 0::int8,
+       '1'::graphid < 0::int8;
+ ?column? | ?column? | ?column? 
+----------+----------+----------
+ t        | f        | f
+(1 row)
+
+SELECT '0'::graphid > 1::int8,
+       '0'::graphid > 0::int8,
+       '1'::graphid > 0::int8;
+ ?column? | ?column? | ?column? 
+----------+----------+----------
+ f        | f        | t
+(1 row)
+
+SELECT '0'::graphid <= 1::int8,
+       '0'::graphid <= 0::int8,
+       '1'::graphid <= 0::int8;
+ ?column? | ?column? | ?column? 
+----------+----------+----------
+ t        | t        | f
+(1 row)
+
+SELECT '0'::graphid >= 1::int8,
+       '0'::graphid >= 0::int8,
+       '1'::graphid >= 0::int8;
+ ?column? | ?column? | ?column? 
+----------+----------+----------
+ f        | t        | t
+(1 row)
+
+-- int8 vs graphid cross-type comparisons
+SELECT 0::int8 = '0'::graphid, 0::int8 = '1'::graphid;
+ ?column? | ?column? 
+----------+----------
+ t        | f
+(1 row)
+
+SELECT 0::int8 <> '0'::graphid, 0::int8 <> '1'::graphid;
+ ?column? | ?column? 
+----------+----------
+ f        | t
+(1 row)
+
+SELECT 0::int8 < '1'::graphid,
+       0::int8 < '0'::graphid,
+       1::int8 < '0'::graphid;
+ ?column? | ?column? | ?column? 
+----------+----------+----------
+ t        | f        | f
+(1 row)
+
+SELECT 0::int8 > '1'::graphid,
+       0::int8 > '0'::graphid,
+       1::int8 > '0'::graphid;
+ ?column? | ?column? | ?column? 
+----------+----------+----------
+ f        | f        | t
+(1 row)
+
+SELECT 0::int8 <= '1'::graphid,
+       0::int8 <= '0'::graphid,
+       1::int8 <= '0'::graphid;
+ ?column? | ?column? | ?column? 
+----------+----------+----------
+ t        | t        | f
+(1 row)
+
+SELECT 0::int8 >= '1'::graphid,
+       0::int8 >= '0'::graphid,
+       1::int8 >= '0'::graphid;
+ ?column? | ?column? | ?column? 
+----------+----------+----------
+ f        | t        | t
+(1 row)
+
 -- b-tree index
 CREATE TABLE graphid_table (gid graphid);
 INSERT INTO graphid_table VALUES ('0'), ('1'), ('2');
@@ -80,6 +170,21 @@ EXPLAIN (COSTS FALSE) SELECT * FROM graphid_table WHERE gid > '0';
 --------------------------------------------------------------
  Index Only Scan using graphid_table_gid_idx on graphid_table
    Index Cond: (gid > '0'::graphid)
+(2 rows)
+
+-- verify index usage with int8 cross-type comparison
+EXPLAIN (COSTS FALSE) SELECT * FROM graphid_table WHERE gid = 1::int8;
+                          QUERY PLAN                          
+--------------------------------------------------------------
+ Index Only Scan using graphid_table_gid_idx on graphid_table
+   Index Cond: (gid = '1'::bigint)
+(2 rows)
+
+EXPLAIN (COSTS FALSE) SELECT * FROM graphid_table WHERE gid > 0::int8;
+                          QUERY PLAN                          
+--------------------------------------------------------------
+ Index Only Scan using graphid_table_gid_idx on graphid_table
+   Index Cond: (gid > '0'::bigint)
 (2 rows)
 
 SET enable_seqscan = ON;

--- a/regress/sql/graphid.sql
+++ b/regress/sql/graphid.sql
@@ -36,6 +36,38 @@ SELECT '0'::graphid >= '1'::graphid,
        '0'::graphid >= '0'::graphid,
        '1'::graphid >= '0'::graphid;
 
+-- graphid vs int8 cross-type comparisons
+SELECT '0'::graphid = 0::int8, '0'::graphid = 1::int8;
+SELECT '0'::graphid <> 0::int8, '0'::graphid <> 1::int8;
+SELECT '0'::graphid < 1::int8,
+       '0'::graphid < 0::int8,
+       '1'::graphid < 0::int8;
+SELECT '0'::graphid > 1::int8,
+       '0'::graphid > 0::int8,
+       '1'::graphid > 0::int8;
+SELECT '0'::graphid <= 1::int8,
+       '0'::graphid <= 0::int8,
+       '1'::graphid <= 0::int8;
+SELECT '0'::graphid >= 1::int8,
+       '0'::graphid >= 0::int8,
+       '1'::graphid >= 0::int8;
+
+-- int8 vs graphid cross-type comparisons
+SELECT 0::int8 = '0'::graphid, 0::int8 = '1'::graphid;
+SELECT 0::int8 <> '0'::graphid, 0::int8 <> '1'::graphid;
+SELECT 0::int8 < '1'::graphid,
+       0::int8 < '0'::graphid,
+       1::int8 < '0'::graphid;
+SELECT 0::int8 > '1'::graphid,
+       0::int8 > '0'::graphid,
+       1::int8 > '0'::graphid;
+SELECT 0::int8 <= '1'::graphid,
+       0::int8 <= '0'::graphid,
+       1::int8 <= '0'::graphid;
+SELECT 0::int8 >= '1'::graphid,
+       0::int8 >= '0'::graphid,
+       1::int8 >= '0'::graphid;
+
 -- b-tree index
 CREATE TABLE graphid_table (gid graphid);
 INSERT INTO graphid_table VALUES ('0'), ('1'), ('2');
@@ -43,5 +75,8 @@ CREATE INDEX ON graphid_table (gid);
 SET enable_seqscan = OFF;
 EXPLAIN (COSTS FALSE) SELECT * FROM graphid_table WHERE gid = '1';
 EXPLAIN (COSTS FALSE) SELECT * FROM graphid_table WHERE gid > '0';
+-- verify index usage with int8 cross-type comparison
+EXPLAIN (COSTS FALSE) SELECT * FROM graphid_table WHERE gid = 1::int8;
+EXPLAIN (COSTS FALSE) SELECT * FROM graphid_table WHERE gid > 0::int8;
 SET enable_seqscan = ON;
 DROP TABLE graphid_table;

--- a/sql/age_main.sql
+++ b/sql/age_main.sql
@@ -309,6 +309,237 @@ CREATE OPERATOR >= (
 );
 
 --
+-- graphid - int8 cross-type comparison operators
+--
+-- These allow efficient comparison of graphid with integer literals,
+-- avoiding the need to convert to agtype for comparisons like id(v) > 0.
+--
+
+-- graphid vs int8 comparison functions
+CREATE FUNCTION ag_catalog.graphid_eq_int8(graphid, int8)
+    RETURNS boolean
+    LANGUAGE c
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
+CREATE FUNCTION ag_catalog.graphid_ne_int8(graphid, int8)
+    RETURNS boolean
+    LANGUAGE c
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
+CREATE FUNCTION ag_catalog.graphid_lt_int8(graphid, int8)
+    RETURNS boolean
+    LANGUAGE c
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
+CREATE FUNCTION ag_catalog.graphid_gt_int8(graphid, int8)
+    RETURNS boolean
+    LANGUAGE c
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
+CREATE FUNCTION ag_catalog.graphid_le_int8(graphid, int8)
+    RETURNS boolean
+    LANGUAGE c
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
+CREATE FUNCTION ag_catalog.graphid_ge_int8(graphid, int8)
+    RETURNS boolean
+    LANGUAGE c
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
+-- int8 vs graphid comparison functions
+CREATE FUNCTION ag_catalog.int8_eq_graphid(int8, graphid)
+    RETURNS boolean
+    LANGUAGE c
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
+CREATE FUNCTION ag_catalog.int8_ne_graphid(int8, graphid)
+    RETURNS boolean
+    LANGUAGE c
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
+CREATE FUNCTION ag_catalog.int8_lt_graphid(int8, graphid)
+    RETURNS boolean
+    LANGUAGE c
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
+CREATE FUNCTION ag_catalog.int8_gt_graphid(int8, graphid)
+    RETURNS boolean
+    LANGUAGE c
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
+CREATE FUNCTION ag_catalog.int8_le_graphid(int8, graphid)
+    RETURNS boolean
+    LANGUAGE c
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
+CREATE FUNCTION ag_catalog.int8_ge_graphid(int8, graphid)
+    RETURNS boolean
+    LANGUAGE c
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
+-- Cross-type operators: graphid vs int8
+CREATE OPERATOR = (
+  FUNCTION = ag_catalog.graphid_eq_int8,
+  LEFTARG = graphid,
+  RIGHTARG = int8,
+  COMMUTATOR = =,
+  NEGATOR = <>,
+  RESTRICT = eqsel,
+  JOIN = eqjoinsel,
+  HASHES,
+  MERGES
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = ag_catalog.graphid_ne_int8,
+  LEFTARG = graphid,
+  RIGHTARG = int8,
+  COMMUTATOR = <>,
+  NEGATOR = =,
+  RESTRICT = neqsel,
+  JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = ag_catalog.graphid_lt_int8,
+  LEFTARG = graphid,
+  RIGHTARG = int8,
+  COMMUTATOR = >,
+  NEGATOR = >=,
+  RESTRICT = scalarltsel,
+  JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = ag_catalog.graphid_gt_int8,
+  LEFTARG = graphid,
+  RIGHTARG = int8,
+  COMMUTATOR = <,
+  NEGATOR = <=,
+  RESTRICT = scalargtsel,
+  JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = ag_catalog.graphid_le_int8,
+  LEFTARG = graphid,
+  RIGHTARG = int8,
+  COMMUTATOR = >=,
+  NEGATOR = >,
+  RESTRICT = scalarlesel,
+  JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = ag_catalog.graphid_ge_int8,
+  LEFTARG = graphid,
+  RIGHTARG = int8,
+  COMMUTATOR = <=,
+  NEGATOR = <,
+  RESTRICT = scalargesel,
+  JOIN = scalargejoinsel
+);
+
+-- Cross-type operators: int8 vs graphid
+CREATE OPERATOR = (
+  FUNCTION = ag_catalog.int8_eq_graphid,
+  LEFTARG = int8,
+  RIGHTARG = graphid,
+  COMMUTATOR = =,
+  NEGATOR = <>,
+  RESTRICT = eqsel,
+  JOIN = eqjoinsel,
+  HASHES,
+  MERGES
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = ag_catalog.int8_ne_graphid,
+  LEFTARG = int8,
+  RIGHTARG = graphid,
+  COMMUTATOR = <>,
+  NEGATOR = =,
+  RESTRICT = neqsel,
+  JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = ag_catalog.int8_lt_graphid,
+  LEFTARG = int8,
+  RIGHTARG = graphid,
+  COMMUTATOR = >,
+  NEGATOR = >=,
+  RESTRICT = scalarltsel,
+  JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = ag_catalog.int8_gt_graphid,
+  LEFTARG = int8,
+  RIGHTARG = graphid,
+  COMMUTATOR = <,
+  NEGATOR = <=,
+  RESTRICT = scalargtsel,
+  JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = ag_catalog.int8_le_graphid,
+  LEFTARG = int8,
+  RIGHTARG = graphid,
+  COMMUTATOR = >=,
+  NEGATOR = >,
+  RESTRICT = scalarlesel,
+  JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = ag_catalog.int8_ge_graphid,
+  LEFTARG = int8,
+  RIGHTARG = graphid,
+  COMMUTATOR = <=,
+  NEGATOR = <,
+  RESTRICT = scalargesel,
+  JOIN = scalargejoinsel
+);
+
+--
 -- graphid - B-tree support functions
 --
 
@@ -324,6 +555,24 @@ AS 'MODULE_PATHNAME';
 -- sort support
 CREATE FUNCTION ag_catalog.graphid_btree_sort(internal)
     RETURNS void
+    LANGUAGE c
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
+-- cross-type btree comparison support: graphid vs int8
+CREATE FUNCTION ag_catalog.graphid_btree_cmp_int8(graphid, int8)
+    RETURNS int
+    LANGUAGE c
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
+-- cross-type btree comparison support: int8 vs graphid
+CREATE FUNCTION ag_catalog.int8_btree_cmp_graphid(int8, graphid)
+    RETURNS int
     LANGUAGE c
     IMMUTABLE
 RETURNS NULL ON NULL INPUT
@@ -349,13 +598,23 @@ AS 'MODULE_PATHNAME';
 --   3: compare a test value to a base value plus/minus an offset, and return
 --      true or false according to the comparison result (optional)
 CREATE OPERATOR CLASS graphid_ops DEFAULT FOR TYPE graphid USING btree AS
-  OPERATOR 1 <,
-  OPERATOR 2 <=,
-  OPERATOR 3 =,
-  OPERATOR 4 >=,
-  OPERATOR 5 >,
+  -- same-type operators (graphid vs graphid)
+  OPERATOR 1 < (graphid, graphid),
+  OPERATOR 2 <= (graphid, graphid),
+  OPERATOR 3 = (graphid, graphid),
+  OPERATOR 4 >= (graphid, graphid),
+  OPERATOR 5 > (graphid, graphid),
+  -- cross-type operators (graphid vs int8)
+  OPERATOR 1 < (graphid, int8),
+  OPERATOR 2 <= (graphid, int8),
+  OPERATOR 3 = (graphid, int8),
+  OPERATOR 4 >= (graphid, int8),
+  OPERATOR 5 > (graphid, int8),
+  -- same-type support functions
   FUNCTION 1 ag_catalog.graphid_btree_cmp (graphid, graphid),
-  FUNCTION 2 ag_catalog.graphid_btree_sort (internal);
+  FUNCTION 2 ag_catalog.graphid_btree_sort (internal),
+  -- cross-type support function (graphid vs int8)
+  FUNCTION 1 (graphid, int8) ag_catalog.graphid_btree_cmp_int8 (graphid, int8);
 
 --
 -- graphid functions

--- a/src/backend/parser/cypher_transform_entity.c
+++ b/src/backend/parser/cypher_transform_entity.c
@@ -53,6 +53,12 @@ transform_entity *make_transform_entity(cypher_parsestate *cpstate,
     entity->expr = expr;
     entity->in_join_tree = expr != NULL;
 
+    /* Initialize exposed column Vars to NULL */
+    entity->id_var = NULL;
+    entity->start_id_var = NULL;
+    entity->end_id_var = NULL;
+    entity->props_var = NULL;
+
     return entity;
 }
 

--- a/src/backend/utils/adt/agtype.c
+++ b/src/backend/utils/adt/agtype.c
@@ -12185,6 +12185,12 @@ Datum agtype_volatile_wrapper(PG_FUNCTION_ARGS)
             agtv_result.val.string.val = text_to_cstring(DatumGetTextPP(arg));
             agtv_result.val.string.len = strlen(agtv_result.val.string.val);
         }
+        else if (type == GRAPHIDOID)
+        {
+            /* graphid is internally int64 */
+            agtv_result.type = AGTV_INTEGER;
+            agtv_result.val.int_value = DatumGetInt64(arg);
+        }
         else
         {
             ereport(ERROR,

--- a/src/backend/utils/adt/graphid.c
+++ b/src/backend/utils/adt/graphid.c
@@ -262,3 +262,167 @@ Datum graphid_hash_cmp(PG_FUNCTION_ARGS)
 
     PG_RETURN_INT32(hash);
 }
+
+/*
+ * Cross-type comparison functions: graphid vs int8
+ *
+ * Since graphid is internally an int64, we can compare directly with int8.
+ * These allow expressions like `id(v) > 0` to use native integer comparison
+ * instead of converting everything to agtype.
+ */
+PG_FUNCTION_INFO_V1(graphid_eq_int8);
+
+Datum graphid_eq_int8(PG_FUNCTION_ARGS)
+{
+    graphid lgid = AG_GETARG_GRAPHID(0);
+    int64 ri8 = PG_GETARG_INT64(1);
+
+    PG_RETURN_BOOL(lgid == ri8);
+}
+
+PG_FUNCTION_INFO_V1(graphid_ne_int8);
+
+Datum graphid_ne_int8(PG_FUNCTION_ARGS)
+{
+    graphid lgid = AG_GETARG_GRAPHID(0);
+    int64 ri8 = PG_GETARG_INT64(1);
+
+    PG_RETURN_BOOL(lgid != ri8);
+}
+
+PG_FUNCTION_INFO_V1(graphid_lt_int8);
+
+Datum graphid_lt_int8(PG_FUNCTION_ARGS)
+{
+    graphid lgid = AG_GETARG_GRAPHID(0);
+    int64 ri8 = PG_GETARG_INT64(1);
+
+    PG_RETURN_BOOL(lgid < ri8);
+}
+
+PG_FUNCTION_INFO_V1(graphid_gt_int8);
+
+Datum graphid_gt_int8(PG_FUNCTION_ARGS)
+{
+    graphid lgid = AG_GETARG_GRAPHID(0);
+    int64 ri8 = PG_GETARG_INT64(1);
+
+    PG_RETURN_BOOL(lgid > ri8);
+}
+
+PG_FUNCTION_INFO_V1(graphid_le_int8);
+
+Datum graphid_le_int8(PG_FUNCTION_ARGS)
+{
+    graphid lgid = AG_GETARG_GRAPHID(0);
+    int64 ri8 = PG_GETARG_INT64(1);
+
+    PG_RETURN_BOOL(lgid <= ri8);
+}
+
+PG_FUNCTION_INFO_V1(graphid_ge_int8);
+
+Datum graphid_ge_int8(PG_FUNCTION_ARGS)
+{
+    graphid lgid = AG_GETARG_GRAPHID(0);
+    int64 ri8 = PG_GETARG_INT64(1);
+
+    PG_RETURN_BOOL(lgid >= ri8);
+}
+
+/* Reverse versions: int8 vs graphid */
+PG_FUNCTION_INFO_V1(int8_eq_graphid);
+
+Datum int8_eq_graphid(PG_FUNCTION_ARGS)
+{
+    int64 li8 = PG_GETARG_INT64(0);
+    graphid rgid = AG_GETARG_GRAPHID(1);
+
+    PG_RETURN_BOOL(li8 == rgid);
+}
+
+PG_FUNCTION_INFO_V1(int8_ne_graphid);
+
+Datum int8_ne_graphid(PG_FUNCTION_ARGS)
+{
+    int64 li8 = PG_GETARG_INT64(0);
+    graphid rgid = AG_GETARG_GRAPHID(1);
+
+    PG_RETURN_BOOL(li8 != rgid);
+}
+
+PG_FUNCTION_INFO_V1(int8_lt_graphid);
+
+Datum int8_lt_graphid(PG_FUNCTION_ARGS)
+{
+    int64 li8 = PG_GETARG_INT64(0);
+    graphid rgid = AG_GETARG_GRAPHID(1);
+
+    PG_RETURN_BOOL(li8 < rgid);
+}
+
+PG_FUNCTION_INFO_V1(int8_gt_graphid);
+
+Datum int8_gt_graphid(PG_FUNCTION_ARGS)
+{
+    int64 li8 = PG_GETARG_INT64(0);
+    graphid rgid = AG_GETARG_GRAPHID(1);
+
+    PG_RETURN_BOOL(li8 > rgid);
+}
+
+PG_FUNCTION_INFO_V1(int8_le_graphid);
+
+Datum int8_le_graphid(PG_FUNCTION_ARGS)
+{
+    int64 li8 = PG_GETARG_INT64(0);
+    graphid rgid = AG_GETARG_GRAPHID(1);
+
+    PG_RETURN_BOOL(li8 <= rgid);
+}
+
+PG_FUNCTION_INFO_V1(int8_ge_graphid);
+
+Datum int8_ge_graphid(PG_FUNCTION_ARGS)
+{
+    int64 li8 = PG_GETARG_INT64(0);
+    graphid rgid = AG_GETARG_GRAPHID(1);
+
+    PG_RETURN_BOOL(li8 >= rgid);
+}
+
+/*
+ * Cross-type B-tree comparison functions for graphid vs int8
+ *
+ * These are required for the btree operator class to use cross-type
+ * comparisons in index scans.
+ */
+PG_FUNCTION_INFO_V1(graphid_btree_cmp_int8);
+
+Datum graphid_btree_cmp_int8(PG_FUNCTION_ARGS)
+{
+    graphid lgid = AG_GETARG_GRAPHID(0);
+    int64 ri8 = PG_GETARG_INT64(1);
+
+    if (lgid > ri8)
+        PG_RETURN_INT32(1);
+    else if (lgid == ri8)
+        PG_RETURN_INT32(0);
+    else
+        PG_RETURN_INT32(-1);
+}
+
+PG_FUNCTION_INFO_V1(int8_btree_cmp_graphid);
+
+Datum int8_btree_cmp_graphid(PG_FUNCTION_ARGS)
+{
+    int64 li8 = PG_GETARG_INT64(0);
+    graphid rgid = AG_GETARG_GRAPHID(1);
+
+    if (li8 > rgid)
+        PG_RETURN_INT32(1);
+    else if (li8 == rgid)
+        PG_RETURN_INT32(0);
+    else
+        PG_RETURN_INT32(-1);
+}

--- a/src/include/parser/cypher_transform_entity.h
+++ b/src/include/parser/cypher_transform_entity.h
@@ -71,6 +71,18 @@ typedef struct
     Expr *expr;
 
     /*
+     * Exposed column Vars for cross-clause optimization.
+     * When an entity is exported to a subsequent clause, we also export its
+     * id, start_id (edges only), end_id (edges only), and properties as
+     * hidden columns. These Vars allow direct access to these values without
+     * rebuilding the full vertex/edge object.
+     */
+    Var *id_var;        /* Var for the exposed id column */
+    Var *start_id_var;  /* Var for the exposed start_id column (edges only) */
+    Var *end_id_var;    /* Var for the exposed end_id column (edges only) */
+    Var *props_var;     /* Var for the exposed properties column */
+
+    /*
      * tells each clause whether this variable was
      * declared by itself or a previous clause.
      */


### PR DESCRIPTION
NOTE: This PR was created with AI tools and a human

Optimize id()/start_id()/end_id() with direct graphid column access.

Add optimization to avoid rebuilding full vertex/edge objects when only
the id, start_id, or end_id is needed. Instead of calling age_id() on a
reconstructed _agtype_build_vertex/_agtype_build_edge, directly access
the underlying graphid column. This enables PostgreSQL to use B-tree
indexes on graphid columns for significantly improved query performance.

Implementation:
- Export hidden columns as raw graphid type (not agtype-wrapped) when
      entities pass between clauses via export_entity_hidden_columns()
- Store Var references (id_var, start_id_var, end_id_var) in
      transform_entity
- try_optimize_id_funcs() returns raw graphid Var for optimizable
      patterns
- Add cross-type comparison operators (graphid vs int8) with btree
      support
- Update graphid_ops operator class to include cross-type operators,
      enabling Index Cond scans instead of post-scan Filter evaluation
- Add graphid support to agtype_volatile_wrapper() for SET/MERGE
      contexts

Optimized patterns:
      MATCH (p) WHERE id(p) > 0 RETURN p
      MATCH ()-[e]->() WHERE id(e) > 0 RETURN e
      MATCH ()-[e]->() WHERE start_id(e) > 0 RETURN e
      MATCH ()-[e]->() WHERE end_id(e) > 0 RETURN e

All regression tests passed.
Added regression tests for the new graphid operators.

Files changed:
- src/include/parser/cypher_transform_entity.h: Add id_var, start_id_var,
      end_id_var fields to transform_entity struct
- src/backend/parser/cypher_clause.c: Export raw graphid columns
- src/backend/parser/cypher_expr.c: Add try_optimize_id_funcs(),
      extract_id_var_from_entity_expr(); return raw graphid Var
- src/backend/utils/adt/graphid.c: Add 12 cross-type comparison functions
      (graphid_eq_int8, etc.) and 2 btree comparison functions
      (graphid_btree_cmp_int8, int8_btree_cmp_graphid)
- src/backend/utils/adt/agtype.c: Add GRAPHIDOID to
      agtype_volatile_wrapper()
- sql/age_main.sql: Add cross-type operators, functions, and update
      graphid_ops operator class with cross-type btree support
- age--1.6.0--y.y.y.sql: Add upgrade definitions for new functions,
      operators, and operator class
- regress/sql/graphid.sql: Add cross-type operator and index tests
- regress/sql/cypher_match.sql: Add WHERE optimization tests
- regress/expected/*.out: Update expected output