### PR TITLE
Upgrade Jest to v29 for node: protocol compatibility

### DIFF
--- a/drivers/nodejs/package.json
+++ b/drivers/nodejs/package.json
@@ -33,7 +33,7 @@
     "pg": ">=6.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^26.0.20",
+    "@types/jest": "^29.5.14",
     "@types/pg": "^7.14.10",
     "@typescript-eslint/eslint-plugin": "^4.22.1",
     "@typescript-eslint/parser": "^4.22.1",
@@ -44,8 +44,8 @@
     "eslint-plugin-jest": "^24.3.6",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.3.1",
-    "jest": "^26.6.3",
-    "ts-jest": "^26.5.1",
-    "typescript": "^4.1.5"
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.6",
+    "typescript": "^4.9.5"
   }
 }


### PR DESCRIPTION
Note: This PR was created with AI tools and a human.

The pg-connection-string module (dependency of pg) now uses the node: protocol prefix for built-in modules (e.g., require('node:process')). Jest 26 does not support this syntax, causing test failures.

Changes:
- Upgrade jest from ^26.6.3 to ^29.7.0
- Upgrade ts-jest from ^26.5.1 to ^29.4.6
- Upgrade @types/jest from ^26.0.20 to ^29.5.14
- Update typescript to ^4.9.5

This also resolves 19 npm audit vulnerabilities (17 moderate, 2 high) that existed in the older Jest 26 dependency tree.

modified:   drivers/nodejs/package.json