### PR TITLE
Fix null pointer handling in array iteration

### DIFF
--- a/src/backend/utils/adt/agtype.c
+++ b/src/backend/utils/adt/agtype.c
@@ -7500,18 +7500,11 @@ Datum age_tostringlist(PG_FUNCTION_ARGS)
         /* TODO: check element's type, it's value, and convert it to string if possible. */
         elem = get_ith_agtype_value_from_container(&agt_arg->root, i);
         string_elem.type = AGTV_STRING;
+        enum agtype_value_type elem_type = elem ? elem->type : AGTV_NULL;
 
-        switch (elem->type)
+        switch (elem_type)
         {
         case AGTV_STRING:
-
-            if(!elem)
-            {
-                string_elem.type = AGTV_NULL;
-
-                agis_result.res = push_agtype_value(&agis_result.parse_state,
-                                                    WAGT_ELEM, &string_elem);
-            }
 
             string_elem.val.string.val = elem->val.string.val;
             string_elem.val.string.len = elem->val.string.len;


### PR DESCRIPTION
Previously, when iterating through an agtype container, the code would access `elem->val` even when `elem` was null.
This adds a null check to set the result type to AGTV_NULL when the element is null, preventing a potential segmentation fault.

Fixes: 4274f10 ("Added the toStringList() function (#1084)") 
Found by PostgresPro.