### PR TITLE
[PG17] Backport: Add 32-bit platform support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,10 @@ PG_CONFIG ?= pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 
+# 32-bit platform support: pass SIZEOF_DATUM=4 to enable (e.g., make SIZEOF_DATUM=4)
+# When SIZEOF_DATUM=4, PASSEDBYVALUE is stripped from graphid type for pass-by-reference.
+# If not specified, normal 64-bit behavior is used (PASSEDBYVALUE preserved).
+
 src/backend/parser/cypher_keywords.o: src/include/parser/cypher_kwlist_d.h
 
 src/include/parser/cypher_kwlist_d.h: src/include/parser/cypher_kwlist.h $(GEN_KEYWORDLIST_DEPS)
@@ -150,8 +154,14 @@ src/backend/parser/cypher_gram.c: BISONFLAGS += --defines=src/include/parser/cyp
 src/backend/parser/cypher_parser.o: src/backend/parser/cypher_gram.c
 src/backend/parser/cypher_keywords.o: src/backend/parser/cypher_gram.c
 
-$(age_sql):
+# Strip PASSEDBYVALUE on 32-bit (SIZEOF_DATUM=4) for graphid pass-by-reference
+$(age_sql): $(SQLS)
 	@cat $(SQLS) > $@
+ifeq ($(SIZEOF_DATUM),4)
+	@echo "32-bit build: removing PASSEDBYVALUE from graphid type"
+	@sed 's/^  PASSEDBYVALUE,$$/  -- PASSEDBYVALUE removed for 32-bit (see Makefile)/' $@ > $@.tmp && mv $@.tmp $@
+	@grep -q 'PASSEDBYVALUE removed for 32-bit' $@ || { echo "Error: PASSEDBYVALUE replacement failed in $@"; exit 1; }
+endif
 
 src/backend/parser/ag_scanner.c: FLEX_NO_BACKUP=yes
 


### PR DESCRIPTION
Backport of #2286 from master/PG18 to PG17.

Enables AGE to work on 32-bit platforms including WebAssembly (WASM).

**Use case:** PGlite (PostgreSQL compiled to WebAssembly) uses PG17.5 and requires this patch.

**Change:** Makefile-only — when `SIZEOF_DATUM=4` is passed, strips `PASSEDBYVALUE` from the graphid type.

Already merged to master (#2286) and PG18 (#2311).