### PR TITLE
Fix JDBC driver CI test failures: encoding and Testcontainers

### DIFF
--- a/drivers/jdbc/lib/build.gradle.kts
+++ b/drivers/jdbc/lib/build.gradle.kts
@@ -38,11 +38,15 @@ dependencies {
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
-    testImplementation("org.testcontainers:testcontainers:1.18.0")
+    testImplementation("org.testcontainers:testcontainers:1.21.4")
     testImplementation("org.postgresql:postgresql:42.6.0")
 
     testImplementation("org.slf4j:slf4j-api:2.0.7")
     testImplementation("org.slf4j:slf4j-simple:2.0.7")
+}
+
+tasks.withType<JavaCompile> {
+    options.encoding = "UTF-8"
 }
 
 tasks.generateGrammarSource {


### PR DESCRIPTION
Note: This PR was created with the help of AI tools and a human.

Fix JDBC driver CI test failures: encoding, Testcontainers, and
Docker compatibility.

- Set JavaCompile encoding to UTF-8 to fix unicode test failures in
      CI environments that default to US-ASCII.

- Add Testcontainers wait strategy (Wait.forLogMessage) to wait for
      PostgreSQL to be fully ready before connecting.

- Use agensGraphContainer.getHost() instead of hardcoded localhost
      for Docker-in-Docker compatibility.

- Add sslmode=disable to JDBC URL since PostgreSQL driver 42.6.0+
      attempts SSL by default.

- Remove silent exception swallowing around connection setup to fail
      fast with meaningful errors instead of NullPointerException.

- Upgrade Testcontainers from 1.18.0 to 1.21.4 to fix Docker 29.x
      detection failure on ubuntu-24.04 runners (docker-java 3.3.x in
      1.18.0 cannot negotiate with Docker Engine 29.1.5 API).

modified:   drivers/jdbc/lib/build.gradle.kts
modified:   drivers/jdbc/lib/src/test/java/org/apache/age/jdbc/BaseDockerizedTest.java