### PR TITLE
Fix ISO C90 forbids mixed declarations and code warning

### DIFF
--- a/src/backend/utils/adt/agtype.c
+++ b/src/backend/utils/adt/agtype.c
@@ -7498,9 +7498,11 @@ Datum age_tostringlist(PG_FUNCTION_ARGS)
     for (i = 0; i < count; i++)
     {
         /* TODO: check element's type, it's value, and convert it to string if possible. */
+        enum agtype_value_type elem_type;
+
         elem = get_ith_agtype_value_from_container(&agt_arg->root, i);
         string_elem.type = AGTV_STRING;
-        enum agtype_value_type elem_type = elem ? elem->type : AGTV_NULL;
+        elem_type = elem ? elem->type : AGTV_NULL;
 
         switch (elem_type)
         {


### PR DESCRIPTION
Fixed the following ISO C90 warning -

src/backend/utils/adt/agtype.c:7503:9: warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]
 7503 |         enum agtype_value_type elem_type = elem ? elem->type : AGTV_NULL;
      |         ^~~~

No regression tests impacted.

modified:   src/backend/utils/adt/agtype.c