### PR TITLE
fix incorrect variable assignment

### DIFF
--- a/src/backend/commands/label_commands.c
+++ b/src/backend/commands/label_commands.c
@@ -448,7 +448,7 @@ static void create_index_on_column(char *schema_name,
     index_col->name = colname;
     index_col->expr = NULL;
     index_col->indexcolname = NULL;
-    index_col->collation = InvalidOid;
+    index_col->collation = NIL;
     index_col->opclass = list_make1(makeString("graphid_ops"));
     index_col->opclassopts = NIL;
     index_col->ordering = SORTBY_DEFAULT;


### PR DESCRIPTION
Fixed an incorrect variable assignment, that was causing a warning message during compilation, on some compilers.

The create_index_on_column function assigned InvalidOid, instead of NIL or NULL.

-    index_col->collation = InvalidOid;
+    index_col->collation = NIL;

No regression tests were impacted.

modified:   src/backend/commands/label_commands.c