### PR TITLE
Fix crash in PREPARE with property parameter when enable_containment is off

### DIFF
--- a/regress/expected/cypher_match.out
+++ b/regress/expected/cypher_match.out
@@ -3534,6 +3534,79 @@ SELECT * FROM cypher('test_enable_containment', $$ EXPLAIN (costs off) MATCH (x:
 (2 rows)
 
 --
+-- Issue 1964
+--
+-- PREPARE with property parameter ($props) crashed the server when
+-- age.enable_containment was set to off. The crash was in
+-- transform_map_to_ind_recursive which blindly cast cypher_param
+-- nodes to cypher_map, accessing invalid memory.
+--
+SELECT create_graph('issue_1964');
+NOTICE:  graph "issue_1964" has been created
+ create_graph 
+--------------
+ 
+(1 row)
+
+SELECT * FROM cypher('issue_1964', $$
+    CREATE (:Person {name: 'Alice', age: 30}),
+           (:Person {name: 'Bob', age: 25})
+$$) AS (result agtype);
+ result 
+--------
+(0 rows)
+
+SELECT * FROM cypher('issue_1964', $$
+    CREATE (:Person {name: 'Alice'})-[:KNOWS {since: 2020}]->(:Person {name: 'Bob'})
+$$) AS (result agtype);
+ result 
+--------
+(0 rows)
+
+-- Test PREPARE with enable_containment off (was crashing)
+SET age.enable_containment = off;
+PREPARE issue_1964_vertex(agtype) AS
+    SELECT * FROM cypher('issue_1964',
+        $$MATCH (n $props) RETURN n $$, $1) AS (p agtype);
+EXECUTE issue_1964_vertex('{"props": {"name": "Alice"}}');
+                                               p                                                
+------------------------------------------------------------------------------------------------
+ {"id": 844424930131969, "label": "Person", "properties": {"age": 30, "name": "Alice"}}::vertex
+ {"id": 844424930131971, "label": "Person", "properties": {"name": "Alice"}}::vertex
+(2 rows)
+
+EXECUTE issue_1964_vertex('{"props": {"age": 25}}');
+                                              p                                               
+----------------------------------------------------------------------------------------------
+ {"id": 844424930131970, "label": "Person", "properties": {"age": 25, "name": "Bob"}}::vertex
+(1 row)
+
+DEALLOCATE issue_1964_vertex;
+-- Test edge property parameter with enable_containment off
+PREPARE issue_1964_edge(agtype) AS
+    SELECT * FROM cypher('issue_1964',
+        $$MATCH ()-[r $props]->() RETURN r $$, $1) AS (p agtype);
+EXECUTE issue_1964_edge('{"props": {"since": 2020}}');
+                                                                    p                                                                    
+-----------------------------------------------------------------------------------------------------------------------------------------
+ {"id": 1125899906842625, "label": "KNOWS", "end_id": 844424930131972, "start_id": 844424930131971, "properties": {"since": 2020}}::edge
+(1 row)
+
+DEALLOCATE issue_1964_edge;
+-- Verify enable_containment on still works with PREPARE
+SET age.enable_containment = on;
+PREPARE issue_1964_vertex_on(agtype) AS
+    SELECT * FROM cypher('issue_1964',
+        $$MATCH (n $props) RETURN n $$, $1) AS (p agtype);
+EXECUTE issue_1964_vertex_on('{"props": {"name": "Alice"}}');
+                                               p                                                
+------------------------------------------------------------------------------------------------
+ {"id": 844424930131969, "label": "Person", "properties": {"age": 30, "name": "Alice"}}::vertex
+ {"id": 844424930131971, "label": "Person", "properties": {"name": "Alice"}}::vertex
+(2 rows)
+
+DEALLOCATE issue_1964_vertex_on;
+--
 -- Clean up
 --
 SELECT drop_graph('cypher_match', true);
@@ -3616,6 +3689,18 @@ drop cascades to table issue_1393._ag_label_edge
 drop cascades to table issue_1393."Object"
 drop cascades to table issue_1393.knows
 NOTICE:  graph "issue_1393" has been dropped
+ drop_graph 
+------------
+ 
+(1 row)
+
+SELECT drop_graph('issue_1964', true);
+NOTICE:  drop cascades to 4 other objects
+DETAIL:  drop cascades to table issue_1964._ag_label_vertex
+drop cascades to table issue_1964._ag_label_edge
+drop cascades to table issue_1964."Person"
+drop cascades to table issue_1964."KNOWS"
+NOTICE:  graph "issue_1964" has been dropped
  drop_graph 
 ------------
  

--- a/src/backend/parser/cypher_clause.c
+++ b/src/backend/parser/cypher_clause.c
@@ -4245,6 +4245,17 @@ static Node *create_property_constraints(cypher_parsestate *cpstate,
     }
     else
     {
+        /*
+         * Map decomposition into individual index lookups requires known
+         * keys at parse time. When the property constraint is a parameter
+         * (cypher_param), the keys are not available until execution, so
+         * fall back to the containment operator.
+         */
+        if (is_ag_node(property_constraints, cypher_param))
+        {
+            return (Node *)make_op(pstate, list_make1(makeString("@>")),
+                                   prop_expr, const_expr, last_srf, -1);
+        }
         return (Node *)transform_map_to_ind(
             cpstate, entity, (cypher_map *)property_constraints);
     }
@@ -4674,7 +4685,10 @@ static List *transform_match_entities(cypher_parsestate *cpstate, Query *query,
                                                   -1);
                 }
 
-                ((cypher_map*)node->props)->keep_null = true;
+                if (is_ag_node(node->props, cypher_map))
+                {
+                    ((cypher_map*)node->props)->keep_null = true;
+                }
                 n = create_property_constraints(cpstate, entity, node->props,
                                                 prop_expr);
 
@@ -4803,7 +4817,10 @@ static List *transform_match_entities(cypher_parsestate *cpstate, Query *query,
                                                       false, -1);
                     }
 
-                    ((cypher_map*)rel->props)->keep_null = true;
+                    if (is_ag_node(rel->props, cypher_map))
+                    {
+                        ((cypher_map*)rel->props)->keep_null = true;
+                    }
                     r = create_property_constraints(cpstate, entity, rel->props,
                                                     prop_expr);
 


### PR DESCRIPTION
## Summary

- Fixes server crash (segfault) when executing `PREPARE` with a property parameter (`$props`) while `age.enable_containment` is set to `off`
- Root cause: `create_property_constraints` blindly casts `cypher_param` nodes to `cypher_map*` in the non-containment code path, then dereferences the `keyvals` field which maps to the `name` char pointer of `cypher_param` — reading invalid memory
- Also fixes unsafe `keep_null` writes on `cypher_param` nodes in `transform_match_entities` for both vertex and edge property constraints

## Reproducer

```sql
LOAD 'age';
SET search_path TO ag_catalog;
SET age.enable_containment = off;

PREPARE ptest(agtype) AS
  SELECT * FROM cypher('graph', $$MATCH (n $props) RETURN n $$, $1) AS (p agtype);
-- Server crashes with SIGSEGV
```

## GDB backtrace

```
Program received signal SIGSEGV, Segmentation fault.
transform_map_to_ind_recursive (cpstate=0x5e73d71659e0, entity=0x5e73d7166878,
    map=0x5e73d7073b58, parent_fields=0x0) at src/backend/parser/cypher_clause.c:4055
4055        key = (Node *)map->keyvals->elements[i].ptr_value;

#0  transform_map_to_ind_recursive at src/backend/parser/cypher_clause.c:4055
#1  transform_map_to_ind at src/backend/parser/cypher_clause.c:4006
#2  create_property_constraints at src/backend/parser/cypher_clause.c:4248
#3  transform_match_entities at src/backend/parser/cypher_clause.c:4678
#4  transform_match_path at src/backend/parser/cypher_clause.c:4268
#5  transform_match_pattern at src/backend/parser/cypher_clause.c:3349
...
```

The crash occurs because `map` is actually a `cypher_param` node (`{extensible, name, location}`), not a `cypher_map` (`{extensible, keyvals, location, keep_null}`). The `name` char pointer is reinterpreted as the `keyvals` List pointer, and dereferencing it as `keyvals->elements[i].ptr_value` accesses invalid memory.

## Root cause analysis

When `age.enable_containment = on` (the default), `create_property_constraints` handles property parameters correctly:

1. `transform_cypher_expr()` dispatches `cypher_param` to `transform_cypher_param()`, producing a `FuncExpr` that resolves the parameter at execution time
2. The result is used with the `@>` containment operator: `properties @> $props`

When `age.enable_containment = off`, the code takes the `else` branch (line 4246) which calls `transform_map_to_ind()`. This function is designed to decompose a known `cypher_map` (`{key1: val1, key2: val2}`) into individual index-based equality expressions (`properties->"key1" = val1 AND properties->"key2" = val2`). It cannot work with a `cypher_param` because the map keys are not known until execution time.

Additionally, `transform_match_entities` writes `keep_null = true` by casting `node->props` / `rel->props` to `cypher_map*` (lines 4677 and 4806 on master) without checking the actual node type, corrupting the `cypher_param` struct.

## Fix

Three changes in `cypher_clause.c`:

1. **`create_property_constraints`**: Before the `cypher_map` cast, check `is_ag_node(property_constraints, cypher_param)`. For parameters, fall back to the containment operator (`@>`), which correctly resolves at execution time. This matches the behavior of the `enable_containment = on` path.

2. **`transform_match_entities` (vertex)**: Guard the `keep_null` assignment with `is_ag_node(node->props, cypher_map)` to prevent writing to wrong struct memory.

3. **`transform_match_entities` (edge)**: Same guard for `is_ag_node(rel->props, cypher_map)`.

## Test plan

- [x] Regression test added: `PREPARE`/`EXECUTE` with vertex and edge property parameters, both `enable_containment = on` and `off`
- [x] All 31 existing regression tests pass
- [x] Verified correct query results (not just no-crash) for parameterized property matching
- [x] Code style matches surrounding codebase (ISO C90 declarations, brace placement, argument alignment)

Fixes #1964

🤖 Generated with [Claude Code](https://claude.com/claude-code)