### PR TITLE
Fix MATCH after CREATE returning 0 rows (issue #2308)

### DIFF
--- a/regress/expected/cypher_match.out
+++ b/regress/expected/cypher_match.out
@@ -3534,6 +3534,106 @@ SELECT * FROM cypher('test_enable_containment', $$ EXPLAIN (costs off) MATCH (x:
 (2 rows)
 
 --
+-- issue 2308: MATCH after CREATE returns 0 rows
+--
+-- When all MATCH variables are already bound from a preceding CREATE + WITH,
+-- the MATCH filter quals must evaluate after CREATE, not before.
+--
+SELECT create_graph('issue_2308');
+NOTICE:  graph "issue_2308" has been created
+ create_graph 
+--------------
+ 
+(1 row)
+
+-- Reporter's exact case: CREATE + WITH + MATCH + SET + RETURN
+SELECT * FROM cypher('issue_2308', $$
+    CREATE (a:TestB3)-[e:B3REL]->(b:TestB3)
+    WITH a, e, b
+    MATCH p = (a)-[e]->(b)
+    SET a.something = 'something'
+    RETURN a
+$$) AS (a agtype);
+                                              a                                               
+----------------------------------------------------------------------------------------------
+ {"id": 844424930131969, "label": "TestB3", "properties": {"something": "something"}}::vertex
+(1 row)
+
+-- Bound variables, no SET
+SELECT * FROM cypher('issue_2308', $$
+    CREATE (a:T2)-[e:R2]->(b:T2)
+    WITH a, e, b
+    MATCH (a)-[e]->(b)
+    RETURN a, e, b
+$$) AS (a agtype, e agtype, b agtype);
+                                 a                                 |                                                             e                                                             |                                 b                                 
+-------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------
+ {"id": 1407374883553281, "label": "T2", "properties": {}}::vertex | {"id": 1688849860263937, "label": "R2", "end_id": 1407374883553282, "start_id": 1407374883553281, "properties": {}}::edge | {"id": 1407374883553282, "label": "T2", "properties": {}}::vertex
+(1 row)
+
+-- Reversed direction: filter should reject (0 rows expected)
+SELECT * FROM cypher('issue_2308', $$
+    CREATE (a:T3)-[e:R3]->(b:T3)
+    WITH a, e, b
+    MATCH (b)-[e]->(a)
+    RETURN a
+$$) AS (a agtype);
+ a 
+---
+(0 rows)
+
+-- Node-only MATCH with bound variable
+SELECT * FROM cypher('issue_2308', $$
+    CREATE (a:T4 {name: 'test'})
+    WITH a
+    MATCH (a)
+    RETURN a
+$$) AS (a agtype);
+                                        a                                        
+---------------------------------------------------------------------------------
+ {"id": 2533274790395905, "label": "T4", "properties": {"name": "test"}}::vertex
+(1 row)
+
+-- MATCH after SET (SET is also DML, chain must be protected)
+SELECT * FROM cypher('issue_2308', $$
+    CREATE (a:T5 {val: 1})-[e:R5]->(b:T5 {val: 2})
+$$) AS (r agtype);
+ r 
+---
+(0 rows)
+
+SELECT * FROM cypher('issue_2308', $$
+    MATCH (a:T5)-[e:R5]->(b:T5)
+    SET a.val = 10
+    WITH a, e, b
+    MATCH (a)-[e]->(b)
+    RETURN a.val
+$$) AS (val agtype);
+ val 
+-----
+ 10
+(1 row)
+
+SELECT drop_graph('issue_2308', true);
+NOTICE:  drop cascades to 11 other objects
+DETAIL:  drop cascades to table issue_2308._ag_label_vertex
+drop cascades to table issue_2308._ag_label_edge
+drop cascades to table issue_2308."TestB3"
+drop cascades to table issue_2308."B3REL"
+drop cascades to table issue_2308."T2"
+drop cascades to table issue_2308."R2"
+drop cascades to table issue_2308."T3"
+drop cascades to table issue_2308."R3"
+drop cascades to table issue_2308."T4"
+drop cascades to table issue_2308."T5"
+drop cascades to table issue_2308."R5"
+NOTICE:  graph "issue_2308" has been dropped
+ drop_graph 
+------------
+ 
+(1 row)
+
+--
 -- Clean up
 --
 SELECT drop_graph('cypher_match', true);


### PR DESCRIPTION
## Problem

`CREATE (a)-[e]->(b) WITH a,e,b MATCH p=(a)-[e]->(b) SET a.something = 'something' RETURN a` returns 0 rows instead of the created vertex.

Reported in #2308.

## Root Cause

When MATCH follows CREATE + WITH and re-uses all bound variables, the MATCH generates filter quals (`age_start_id(e) = age_id(a) AND age_end_id(e) = age_id(b)`) that reference only columns from the predecessor subquery. Since the MATCH adds no new table scans (all entities are bound), PostgreSQL's optimizer treats the subquery as transparent and pushes these filter quals down through the subquery layers into the CREATE's child plan.

**Before fix — EXPLAIN plan showing the bug:**
```
Custom Scan (Cypher Set)
  ->  Subquery Scan on _age_default_alias_previous_cypher_clause
        ->  Result
              ->  Custom Scan (Cypher Create)
                    ->  Subquery Scan on _age_default_alias_previous_cypher_clause_1
                          Filter: (age_start_id(e) = age_id(a) AND age_end_id(e) = age_id(b))
                          ->  Result
```

The filter is placed **below** the CREATE custom scan, on its child subquery. At execution time:

1. The innermost `Result` produces a dummy row with NULL values
2. The pushed-down filter evaluates `age_start_id(NULL) = age_id(NULL)` → fails
3. The filter produces 0 rows → CREATE never receives input → nothing is created
4. The entire query returns 0 rows

The filter should evaluate **after** CREATE produces its output (where `a`, `e`, `b` have actual values), not before.

## Fix

In `transform_cypher_match_pattern()`, after transforming the predecessor clause chain into a subquery RTE, check if the chain contains any data-modifying operation (CREATE, SET, DELETE, or MERGE). If it does, set `rte->security_barrier = true` on the subquery RTE. This is PostgreSQL's standard mechanism to prevent qual pushdown through subqueries — the optimizer will not flatten a security-barrier subquery or push filter conditions into it.

A helper function `clause_chain_has_dml()` walks the clause chain to detect DML operations.

**After fix — EXPLAIN plan showing correct structure:**
```
Custom Scan (Cypher Set)
  ->  Subquery Scan on _age_default_alias_previous_cypher_clause
        ->  Subquery Scan on _age_default_alias_previous_cypher_clause_1
              Filter: (age_start_id(e) = age_id(a) AND age_end_id(e) = age_id(b))
              ->  Custom Scan (Cypher Create)
                    ->  Subquery Scan on _age_default_alias_previous_cypher_clause_2
                          ->  Result
```

Now the filter is placed **above** the CREATE custom scan. CREATE runs first (inserting entities), then the filter evaluates on the output values and correctly passes.

## Files Changed

- `src/backend/parser/cypher_clause.c` — Added `clause_chain_has_dml()` helper function and `security_barrier` logic in `transform_cypher_match_pattern()`
- `regress/sql/cypher_match.sql` — Regression tests for issue #2308
- `regress/expected/cypher_match.out` — Expected test output

## Regression Tests

Added tests covering:
- Reporter's exact case: `CREATE + WITH + MATCH + SET + RETURN` (1 row expected)
- Bound variables without SET (1 row expected)
- Reversed direction filter — confirms the filter still works correctly (0 rows expected)
- Node-only MATCH with bound variable (1 row expected)
- MATCH after SET (DML chain detection) (1 row expected)

All 31 existing regression tests pass with this change.

Closes #2308.

## AI Disclosure

AI tools (Claude by Anthropic) were used to assist in developing this fix, including root cause analysis, code changes, and regression tests.