### PR TITLE
Fix MATCH on brand-new label after CREATE returning 0 rows

### DIFF
--- a/regress/expected/cypher_match.out
+++ b/regress/expected/cypher_match.out
@@ -3634,6 +3634,79 @@ NOTICE:  graph "issue_2308" has been dropped
 (1 row)
 
 --
+-- Issue 2193: CREATE ... WITH ... MATCH on brand-new label returns 0 rows
+-- on first execution because match_check_valid_label() runs before
+-- transform_prev_cypher_clause() creates the label table.
+--
+SELECT create_graph('issue_2193');
+NOTICE:  graph "issue_2193" has been created
+ create_graph 
+--------------
+ 
+(1 row)
+
+-- Reporter's exact case: CREATE two Person nodes, then MATCH on Person
+-- Should return 2 rows on the very first execution
+SELECT * FROM cypher('issue_2193', $$
+    CREATE (a:Person {name: 'Jane', livesIn: 'London'}),
+           (b:Person {name: 'Tom', livesIn: 'Copenhagen'})
+    WITH a, b
+    MATCH (p:Person)
+    RETURN p.name
+$$) AS (result agtype);
+ result 
+--------
+ "Jane"
+ "Tom"
+(2 rows)
+
+-- Single CREATE + MATCH on brand-new label
+SELECT * FROM cypher('issue_2193', $$
+    CREATE (a:City {name: 'Berlin'})
+    WITH a
+    MATCH (c:City)
+    RETURN c.name
+$$) AS (result agtype);
+  result  
+----------
+ "Berlin"
+(1 row)
+
+-- MATCH on a label that now exists (second execution) still works
+SELECT * FROM cypher('issue_2193', $$
+    CREATE (a:City {name: 'Paris'})
+    WITH a
+    MATCH (c:City)
+    RETURN c.name
+$$) AS (result agtype);
+  result  
+----------
+ "Berlin"
+ "Paris"
+(2 rows)
+
+-- MATCH on non-existent label without DML predecessor still returns 0 rows
+SELECT * FROM cypher('issue_2193', $$
+    MATCH (x:NonExistentLabel)
+    RETURN x
+$$) AS (result agtype);
+ result 
+--------
+(0 rows)
+
+SELECT drop_graph('issue_2193', true);
+NOTICE:  drop cascades to 4 other objects
+DETAIL:  drop cascades to table issue_2193._ag_label_vertex
+drop cascades to table issue_2193._ag_label_edge
+drop cascades to table issue_2193."Person"
+drop cascades to table issue_2193."City"
+NOTICE:  graph "issue_2193" has been dropped
+ drop_graph 
+------------
+ 
+(1 row)
+
+--
 -- Clean up
 --
 SELECT drop_graph('cypher_match', true);

--- a/regress/expected/cypher_match.out
+++ b/regress/expected/cypher_match.out
@@ -3652,7 +3652,7 @@ SELECT * FROM cypher('issue_2193', $$
            (b:Person {name: 'Tom', livesIn: 'Copenhagen'})
     WITH a, b
     MATCH (p:Person)
-    RETURN p.name
+    RETURN p.name ORDER BY p.name
 $$) AS (result agtype);
  result 
 --------
@@ -3677,7 +3677,7 @@ SELECT * FROM cypher('issue_2193', $$
     CREATE (a:City {name: 'Paris'})
     WITH a
     MATCH (c:City)
-    RETURN c.name
+    RETURN c.name ORDER BY c.name
 $$) AS (result agtype);
   result  
 ----------
@@ -3689,6 +3689,18 @@ $$) AS (result agtype);
 SELECT * FROM cypher('issue_2193', $$
     MATCH (x:NonExistentLabel)
     RETURN x
+$$) AS (result agtype);
+ result 
+--------
+(0 rows)
+
+-- MATCH on non-existent label after DML predecessor still returns 0 rows
+-- and MATCH-introduced variable (p) is properly registered
+SELECT * FROM cypher('issue_2193', $$
+    CREATE (a:Person {name: 'Alice'})
+    WITH a
+    MATCH (p:NonExistentLabel)
+    RETURN p
 $$) AS (result agtype);
  result 
 --------

--- a/regress/expected/cypher_match.out
+++ b/regress/expected/cypher_match.out
@@ -3665,7 +3665,7 @@ SELECT * FROM cypher('issue_2193', $$
     CREATE (a:City {name: 'Berlin'})
     WITH a
     MATCH (c:City)
-    RETURN c.name
+    RETURN c.name ORDER BY c.name
 $$) AS (result agtype);
   result  
 ----------

--- a/regress/expected/cypher_match.out
+++ b/regress/expected/cypher_match.out
@@ -3706,6 +3706,18 @@ $$) AS (result agtype);
 --------
 (0 rows)
 
+-- Verify that the CREATE side effect was preserved even though MATCH
+-- returned 0 rows (guards against plan-elimination regressions where
+-- a constant-false predicate causes PG to skip the DML predecessor)
+SELECT * FROM cypher('issue_2193', $$
+    MATCH (a:Person {name: 'Alice'})
+    RETURN a.name
+$$) AS (result agtype);
+ result  
+---------
+ "Alice"
+(1 row)
+
 SELECT drop_graph('issue_2193', true);
 NOTICE:  drop cascades to 4 other objects
 DETAIL:  drop cascades to table issue_2193._ag_label_vertex

--- a/regress/sql/cypher_match.sql
+++ b/regress/sql/cypher_match.sql
@@ -1506,7 +1506,7 @@ SELECT * FROM cypher('issue_2193', $$
            (b:Person {name: 'Tom', livesIn: 'Copenhagen'})
     WITH a, b
     MATCH (p:Person)
-    RETURN p.name
+    RETURN p.name ORDER BY p.name
 $$) AS (result agtype);
 
 -- Single CREATE + MATCH on brand-new label
@@ -1522,13 +1522,22 @@ SELECT * FROM cypher('issue_2193', $$
     CREATE (a:City {name: 'Paris'})
     WITH a
     MATCH (c:City)
-    RETURN c.name
+    RETURN c.name ORDER BY c.name
 $$) AS (result agtype);
 
 -- MATCH on non-existent label without DML predecessor still returns 0 rows
 SELECT * FROM cypher('issue_2193', $$
     MATCH (x:NonExistentLabel)
     RETURN x
+$$) AS (result agtype);
+
+-- MATCH on non-existent label after DML predecessor still returns 0 rows
+-- and MATCH-introduced variable (p) is properly registered
+SELECT * FROM cypher('issue_2193', $$
+    CREATE (a:Person {name: 'Alice'})
+    WITH a
+    MATCH (p:NonExistentLabel)
+    RETURN p
 $$) AS (result agtype);
 
 SELECT drop_graph('issue_2193', true);

--- a/regress/sql/cypher_match.sql
+++ b/regress/sql/cypher_match.sql
@@ -1493,6 +1493,47 @@ $$) AS (val agtype);
 SELECT drop_graph('issue_2308', true);
 
 --
+-- Issue 2193: CREATE ... WITH ... MATCH on brand-new label returns 0 rows
+-- on first execution because match_check_valid_label() runs before
+-- transform_prev_cypher_clause() creates the label table.
+--
+SELECT create_graph('issue_2193');
+
+-- Reporter's exact case: CREATE two Person nodes, then MATCH on Person
+-- Should return 2 rows on the very first execution
+SELECT * FROM cypher('issue_2193', $$
+    CREATE (a:Person {name: 'Jane', livesIn: 'London'}),
+           (b:Person {name: 'Tom', livesIn: 'Copenhagen'})
+    WITH a, b
+    MATCH (p:Person)
+    RETURN p.name
+$$) AS (result agtype);
+
+-- Single CREATE + MATCH on brand-new label
+SELECT * FROM cypher('issue_2193', $$
+    CREATE (a:City {name: 'Berlin'})
+    WITH a
+    MATCH (c:City)
+    RETURN c.name
+$$) AS (result agtype);
+
+-- MATCH on a label that now exists (second execution) still works
+SELECT * FROM cypher('issue_2193', $$
+    CREATE (a:City {name: 'Paris'})
+    WITH a
+    MATCH (c:City)
+    RETURN c.name
+$$) AS (result agtype);
+
+-- MATCH on non-existent label without DML predecessor still returns 0 rows
+SELECT * FROM cypher('issue_2193', $$
+    MATCH (x:NonExistentLabel)
+    RETURN x
+$$) AS (result agtype);
+
+SELECT drop_graph('issue_2193', true);
+
+--
 -- Clean up
 --
 SELECT drop_graph('cypher_match', true);

--- a/regress/sql/cypher_match.sql
+++ b/regress/sql/cypher_match.sql
@@ -1514,7 +1514,7 @@ SELECT * FROM cypher('issue_2193', $$
     CREATE (a:City {name: 'Berlin'})
     WITH a
     MATCH (c:City)
-    RETURN c.name
+    RETURN c.name ORDER BY c.name
 $$) AS (result agtype);
 
 -- MATCH on a label that now exists (second execution) still works

--- a/regress/sql/cypher_match.sql
+++ b/regress/sql/cypher_match.sql
@@ -1540,6 +1540,14 @@ SELECT * FROM cypher('issue_2193', $$
     RETURN p
 $$) AS (result agtype);
 
+-- Verify that the CREATE side effect was preserved even though MATCH
+-- returned 0 rows (guards against plan-elimination regressions where
+-- a constant-false predicate causes PG to skip the DML predecessor)
+SELECT * FROM cypher('issue_2193', $$
+    MATCH (a:Person {name: 'Alice'})
+    RETURN a.name
+$$) AS (result agtype);
+
 SELECT drop_graph('issue_2193', true);
 
 --

--- a/src/backend/parser/cypher_clause.c
+++ b/src/backend/parser/cypher_clause.c
@@ -346,7 +346,7 @@ static bool isa_special_VLE_case(cypher_path *path);
 static ParseNamespaceItem *find_pnsi(cypher_parsestate *cpstate, char *varname);
 static bool has_list_comp_or_subquery(Node *expr, void *context);
 static bool clause_chain_has_dml(cypher_clause *clause);
-static Node *make_false_where_clause(void);
+static Node *make_false_where_clause(bool volatile_needed);
 
 /*
  * Add required permissions to the RTEPermissionInfo for a relation.
@@ -2650,9 +2650,9 @@ static Query *transform_cypher_match(cypher_parsestate *cpstate,
     if (!clause_chain_has_dml(clause->prev) &&
         !match_check_valid_label(match_self, cpstate))
     {
-        /* Label is invalid — inject a paradoxical WHERE true = false
-         * so the MATCH returns zero rows. */
-        match_self->where = make_false_where_clause();
+        /* Label is invalid — inject a false WHERE so the MATCH returns
+         * zero rows. No DML predecessor here, so constant-foldable is fine. */
+        match_self->where = make_false_where_clause(false);
     }
 
     if (has_list_comp_or_subquery((Node *)match_self->where, NULL))
@@ -2960,10 +2960,16 @@ static Query *transform_cypher_match_pattern(cypher_parsestate *cpstate,
              * deferred check is only needed when the chain has DML,
              * since labels created by CREATE are not in the cache at
              * the time of the early check in transform_cypher_match().
+             *
+             * We use a volatile false predicate (random() IS NULL)
+             * instead of a constant one (true = false) because PG's
+             * planner can constant-fold the latter into a One-Time
+             * Filter: false, eliminating the entire plan subtree —
+             * including the DML predecessor scan — without executing it.
              */
             if (has_dml && !match_check_valid_label(self, cpstate))
             {
-                where = make_false_where_clause();
+                where = make_false_where_clause(true);
             }
         }
 
@@ -6600,22 +6606,56 @@ static bool clause_chain_has_dml(cypher_clause *clause)
 }
 
 /*
- * Build a paradoxical WHERE clause (true = false) that forces a MATCH
- * to return zero rows. Used when the MATCH pattern references a label
- * that does not exist.
+ * Build a false WHERE clause that forces a MATCH to return zero rows.
+ * Used when the MATCH pattern references a label that does not exist.
+ *
+ * When volatile_needed is false, returns a constant (true = false) that
+ * PG's planner may constant-fold — this is fine when there is no DML
+ * predecessor whose execution must be preserved.
+ *
+ * When volatile_needed is true, returns (random() IS NULL) instead.
+ * random() is VOLATILE, so eval_const_expressions() cannot fold this,
+ * preventing PG from creating a One-Time Filter: false that would
+ * eliminate the DML predecessor scan without executing it.
+ *
+ * Note: AGE's add_volatile_wrapper() serves a similar anti-fold purpose
+ * but operates at the Expr level (post-transform) and returns agtype,
+ * so it cannot be used here in the parse-tree WHERE clause context.
  */
-static Node *make_false_where_clause(void)
+static Node *make_false_where_clause(bool volatile_needed)
 {
-    cypher_bool_const *l = make_ag_node(cypher_bool_const);
-    cypher_bool_const *r = make_ag_node(cypher_bool_const);
+    if (volatile_needed)
+    {
+        FuncCall *random_fn;
+        NullTest *nt;
 
-    l->boolean = true;
-    l->location = -1;
-    r->boolean = false;
-    r->location = -1;
+        random_fn = makeFuncCall(
+            list_make2(makeString("pg_catalog"), makeString("random")),
+            NIL,
+            COERCE_EXPLICIT_CALL,
+            -1);
 
-    return (Node *)makeSimpleA_Expr(AEXPR_OP, "=",
-                                    (Node *)l, (Node *)r, -1);
+        nt = makeNode(NullTest);
+        nt->arg = (Expr *)random_fn;
+        nt->nulltesttype = IS_NULL;
+        nt->argisrow = false;
+        nt->location = -1;
+
+        return (Node *)nt;
+    }
+    else
+    {
+        cypher_bool_const *l = make_ag_node(cypher_bool_const);
+        cypher_bool_const *r = make_ag_node(cypher_bool_const);
+
+        l->boolean = true;
+        l->location = -1;
+        r->boolean = false;
+        r->location = -1;
+
+        return (Node *)makeSimpleA_Expr(AEXPR_OP, "=",
+                                        (Node *)l, (Node *)r, -1);
+    }
 }
 
 static Query *analyze_cypher_clause(transform_method transform,

--- a/src/backend/parser/cypher_clause.c
+++ b/src/backend/parser/cypher_clause.c
@@ -2650,7 +2650,7 @@ static Query *transform_cypher_match(cypher_parsestate *cpstate,
     if (!clause_chain_has_dml(clause->prev) &&
         !match_check_valid_label(match_self, cpstate))
     {
-        /* Label is invalid — inject a false WHERE so the MATCH returns
+        /* Label is invalid -- inject a false WHERE so the MATCH returns
          * zero rows. No DML predecessor here, so constant-foldable is fine. */
         match_self->where = make_false_where_clause(false);
     }
@@ -2964,8 +2964,8 @@ static Query *transform_cypher_match_pattern(cypher_parsestate *cpstate,
              * We use a volatile false predicate (random() IS NULL)
              * instead of a constant one (true = false) because PG's
              * planner can constant-fold the latter into a One-Time
-             * Filter: false, eliminating the entire plan subtree —
-             * including the DML predecessor scan — without executing it.
+             * Filter: false, eliminating the entire plan subtree --
+             * including the DML predecessor scan -- without executing it.
              */
             if (has_dml && !match_check_valid_label(self, cpstate))
             {
@@ -6610,7 +6610,7 @@ static bool clause_chain_has_dml(cypher_clause *clause)
  * Used when the MATCH pattern references a label that does not exist.
  *
  * When volatile_needed is false, returns a constant (true = false) that
- * PG's planner may constant-fold — this is fine when there is no DML
+ * PG's planner may constant-fold -- this is fine when there is no DML
  * predecessor whose execution must be preserved.
  *
  * When volatile_needed is true, returns (random() IS NULL) instead.

--- a/src/backend/parser/cypher_clause.c
+++ b/src/backend/parser/cypher_clause.c
@@ -346,6 +346,7 @@ static bool isa_special_VLE_case(cypher_path *path);
 static ParseNamespaceItem *find_pnsi(cypher_parsestate *cpstate, char *varname);
 static bool has_list_comp_or_subquery(Node *expr, void *context);
 static bool clause_chain_has_dml(cypher_clause *clause);
+static Node *make_false_where_clause(void);
 
 /*
  * Add required permissions to the RTEPermissionInfo for a relation.
@@ -2649,18 +2650,9 @@ static Query *transform_cypher_match(cypher_parsestate *cpstate,
     if (!clause_chain_has_dml(clause->prev) &&
         !match_check_valid_label(match_self, cpstate))
     {
-        cypher_bool_const *l = make_ag_node(cypher_bool_const);
-        cypher_bool_const *r = make_ag_node(cypher_bool_const);
-
-        l->boolean = true;
-        l->location = -1;
-        r->boolean = false;
-        r->location = -1;
-
-        /*if the label is invalid, create a paradoxical where to get null*/
-        match_self->where = (Node *)makeSimpleA_Expr(AEXPR_OP, "=",
-                                                     (Node *)l,
-                                                     (Node *)r, -1);
+        /* Label is invalid — inject a paradoxical WHERE true = false
+         * so the MATCH returns zero rows. */
+        match_self->where = make_false_where_clause();
     }
 
     if (has_list_comp_or_subquery((Node *)match_self->where, NULL))
@@ -2923,6 +2915,7 @@ static Query *transform_cypher_match_pattern(cypher_parsestate *cpstate,
             RangeTblEntry *rte;
             int rtindex;
             ParseNamespaceItem *pnsi;
+            bool has_dml;
 
             pnsi = transform_prev_cypher_clause(cpstate, clause->prev, true);
             rte = pnsi->p_rte;
@@ -2936,7 +2929,9 @@ static Query *transform_cypher_match_pattern(cypher_parsestate *cpstate,
              * DML executes -- resulting in quals checking NULL values
              * and filtering out all rows.
              */
-            if (clause_chain_has_dml(clause->prev))
+            has_dml = clause_chain_has_dml(clause->prev);
+
+            if (has_dml)
             {
                 rte->security_barrier = true;
             }
@@ -2966,20 +2961,9 @@ static Query *transform_cypher_match_pattern(cypher_parsestate *cpstate,
              * since labels created by CREATE are not in the cache at
              * the time of the early check in transform_cypher_match().
              */
-            if (clause_chain_has_dml(clause->prev) &&
-                !match_check_valid_label(self, cpstate))
+            if (has_dml && !match_check_valid_label(self, cpstate))
             {
-                cypher_bool_const *l = make_ag_node(cypher_bool_const);
-                cypher_bool_const *r = make_ag_node(cypher_bool_const);
-
-                l->boolean = true;
-                l->location = -1;
-                r->boolean = false;
-                r->location = -1;
-
-                where = (Node *)makeSimpleA_Expr(AEXPR_OP, "=",
-                                                 (Node *)l,
-                                                 (Node *)r, -1);
+                where = make_false_where_clause();
             }
         }
 
@@ -6613,6 +6597,25 @@ static bool clause_chain_has_dml(cypher_clause *clause)
     }
 
     return false;
+}
+
+/*
+ * Build a paradoxical WHERE clause (true = false) that forces a MATCH
+ * to return zero rows. Used when the MATCH pattern references a label
+ * that does not exist.
+ */
+static Node *make_false_where_clause(void)
+{
+    cypher_bool_const *l = make_ag_node(cypher_bool_const);
+    cypher_bool_const *r = make_ag_node(cypher_bool_const);
+
+    l->boolean = true;
+    l->location = -1;
+    r->boolean = false;
+    r->location = -1;
+
+    return (Node *)makeSimpleA_Expr(AEXPR_OP, "=",
+                                    (Node *)l, (Node *)r, -1);
 }
 
 static Query *analyze_cypher_clause(transform_method transform,


### PR DESCRIPTION
## Issue

Fixes #2193

## Problem

When `CREATE` introduces a new label and a subsequent `MATCH` references it via `WITH`, the query returns **0 rows on first execution** but works correctly on the second:

```sql
SELECT * FROM cypher('test_graph', $$
   CREATE (a:Person {name: 'Jane'}), (b:Person {name: 'Tom'})
   WITH a, b
   MATCH (p:Person)
   RETURN p.name
$$) AS (result agtype);
```

**First execution:** 0 rows, `EXPLAIN` shows `One-Time Filter: false`
**Second execution:** 2 rows, `EXPLAIN` shows `Seq Scan on "Person"`

## Root Cause

`match_check_valid_label()` in `transform_cypher_match()` runs **before** `transform_prev_cypher_clause()` processes the predecessor chain. Since CREATE's transform has not yet executed (which creates the label table as a side effect), the `Person` label is not in the label cache. The check concludes the label is invalid and generates a paradoxical `WHERE true = false` clause, producing a `One-Time Filter: false` plan that returns no rows.

On the second execution the label table already exists from the first run, so the check passes.

## Fix

**Defer the label check when the predecessor chain contains DML:**

1. In `transform_cypher_match()`: skip the early `match_check_valid_label()` when `clause_chain_has_dml(clause->prev)` is true (CREATE, SET, DELETE, or MERGE in the predecessor chain). When not deferred, a constant false predicate (`true = false`) is injected -- safe since no DML predecessor needs to execute.

2. In `transform_cypher_match_pattern()`: after `transform_prev_cypher_clause()` completes and any new labels exist in the cache, run a deferred label check. If labels are still invalid, inject a volatile false predicate (`random() IS NULL`) instead of a constant one. The volatile function prevents PG's `eval_const_expressions()` from folding the predicate into a `One-Time Filter: false` that would eliminate the DML predecessor scan without executing it.

This preserves existing behavior for MATCH without DML predecessors -- e.g., `MATCH (a) MATCH (a:invalid_label)` still produces the proper "multiple labels" error.

## EXPLAIN after fix (first execution)

```
 Nested Loop
   ->  Result
         ->  Custom Scan (Cypher Create)
               ->  Subquery Scan on _age_default_alias_previous_cypher_clause
                     ->  Result
   ->  Seq Scan on "Person" p
```

## Dependencies

This PR is based on PR #2340 (`clause_chain_has_dml` helper and `security_barrier` fix for issue #2308).

## Regression tests added

- Reporter's exact case (CREATE two nodes, WITH, MATCH -- expects 2 rows)
- Single CREATE + MATCH on brand-new label
- CREATE + MATCH when label already exists (second execution)
- MATCH on non-existent label without DML predecessor (still returns 0 rows)
- DML side-effect verification: confirms CREATE actually executed even when deferred MATCH returns 0 rows

All 31 regression tests pass.