### PR TITLE
Support doubled-quote escaping in Cypher string literals

### DIFF
--- a/regress/expected/scan.out
+++ b/regress/expected/scan.out
@@ -294,6 +294,47 @@ $$) AS t(a agtype, b agtype, c agtype);
  " \" \" ' ' " | " ' ' \" \" " | " / / \\ \b \f \n \r \t "
 (1 row)
 
+-- doubled-quote escape sequences for SQL driver compatibility (issue #2222)
+SELECT * FROM cypher('scan', $$
+RETURN 'isn''t'
+$$) AS t(a agtype);
+    a    
+---------
+ "isn't"
+(1 row)
+
+SELECT * FROM cypher('scan', $$
+RETURN '''hello'
+$$) AS t(a agtype);
+    a     
+----------
+ "'hello"
+(1 row)
+
+SELECT * FROM cypher('scan', $$
+RETURN 'hello'''
+$$) AS t(a agtype);
+    a     
+----------
+ "hello'"
+(1 row)
+
+SELECT * FROM cypher('scan', $$
+RETURN 'it''s a ''test'''
+$$) AS t(a agtype);
+        a        
+-----------------
+ "it's a 'test'"
+(1 row)
+
+SELECT * FROM cypher('scan', $$
+RETURN "she said ""hello"""
+$$) AS t(a agtype);
+          a           
+----------------------
+ "she said \"hello\""
+(1 row)
+
 -- invalid escape sequence
 SELECT * FROM cypher('scan', $$
 RETURN "\a"

--- a/regress/sql/scan.sql
+++ b/regress/sql/scan.sql
@@ -202,6 +202,27 @@ SELECT * FROM cypher('scan', $$
 RETURN " \" \" ' \' ", ' \' \' " \" ', " / \/ \\ \b \f \n \r \t "
 $$) AS t(a agtype, b agtype, c agtype);
 
+-- doubled-quote escape sequences for SQL driver compatibility (issue #2222)
+SELECT * FROM cypher('scan', $$
+RETURN 'isn''t'
+$$) AS t(a agtype);
+
+SELECT * FROM cypher('scan', $$
+RETURN '''hello'
+$$) AS t(a agtype);
+
+SELECT * FROM cypher('scan', $$
+RETURN 'hello'''
+$$) AS t(a agtype);
+
+SELECT * FROM cypher('scan', $$
+RETURN 'it''s a ''test'''
+$$) AS t(a agtype);
+
+SELECT * FROM cypher('scan', $$
+RETURN "she said ""hello"""
+$$) AS t(a agtype);
+
 -- invalid escape sequence
 SELECT * FROM cypher('scan', $$
 RETURN "\a"

--- a/src/backend/parser/ag_scanner.l
+++ b/src/backend/parser/ag_scanner.l
@@ -195,6 +195,8 @@ dquote        \"
 dqchars       [^"\\]+
 squote        '
 sqchars       [^'\\]+
+esdquote      {dquote}{dquote}
+essquote      {squote}{squote}
 esascii       \\["'/\\bfnrt]
 esasciifail   \\[^Uu]?
 esunicode     \\(U{hexdigit}{8}|u{hexdigit}{4})
@@ -418,6 +420,14 @@ ag_token token;
 <dqstr>{dqchars} |
 <sqstr>{sqchars} {
     strbuf_append_buf(&yyextra.literal_buf, yytext, yyleng);
+}
+
+<dqstr>{esdquote} {
+    strbuf_append_char(&yyextra.literal_buf, '"');
+}
+
+<sqstr>{essquote} {
+    strbuf_append_char(&yyextra.literal_buf, '\'');
 }
 
 <dqstr,sqstr>{esascii} {


### PR DESCRIPTION
## Issue

Fixes #2222

## Problem

SQL drivers (psycopg2, JDBC, Node.js `pg`, etc.) escape single quotes by doubling them when substituting parameters into queries. For example, psycopg2 turns `"isn't"` into `'isn''t'`. When these substitutions land inside Cypher's `$$` block, the Cypher scanner rejects them with a syntax error:

```python
cursor.execute("""
    SELECT * FROM cypher(%s, $$ CREATE (n {text: %s}) RETURN n $$) AS (r agtype);
""", ("graph", "isn't"))
```

```
ERROR: syntax error at or near "'t'"
```

The scanner only recognizes backslash escaping (`\'`), not SQL-style doubled-quote escaping (`''`).

## Fix

Add `''` and `""` as escape sequences in the Cypher scanner's `sqstr` and `dqstr` states respectively. This follows the same pattern already used for backtick-quoted identifiers, where ` `` ` is handled by the `esbquote` rule.

Flex's longest-match rule ensures the two-character `''` match takes priority over the one-character closing-quote match. The change is fully backwards-compatible since `''` inside a single-quoted string was previously a syntax error.

**Before:**
```sql
SELECT * FROM cypher('g', $$ RETURN 'isn''t' $$) AS (r agtype);
-- ERROR: syntax error at or near "'t'"
```

**After:**
```sql
SELECT * FROM cypher('g', $$ RETURN 'isn''t' $$) AS (r agtype);
--  r
-- ---------
--  "isn't"
```

## Changes

- `src/backend/parser/ag_scanner.l`: Added `esdquote` and `essquote` pattern definitions and corresponding rules in the `dqstr`/`sqstr` scanner states
- `regress/sql/scan.sql`: 5 regression tests covering single-quote, double-quote, leading/trailing, and multiple escaped quotes
- `regress/expected/scan.out`: Updated expected output

All 31 regression tests pass.

## Note

While this fix makes SQL driver parameter substitution work, the recommended approach for passing dynamic values to Cypher is through AGE's parameter mechanism using prepared statements, which avoids string escaping entirely:

```sql
PREPARE q(agtype) AS
SELECT * FROM cypher('g', $$ CREATE (n {text: $text}) RETURN n $$, $1) AS (r agtype);
EXECUTE q('{"text": "isn''t"}'::agtype);
```

## AI Disclosure

AI tools (Claude by Anthropic) were used to assist in developing this fix, including root cause analysis, code changes, and regression tests.