### PR TITLE
Fix entity_exists() CID visibility for CREATE + WITH + MERGE

### DIFF
--- a/regress/expected/cypher_merge.out
+++ b/regress/expected/cypher_merge.out
@@ -1728,9 +1728,9 @@ SELECT * FROM cypher('issue_1907', $$ MATCH ()-[r]->() RETURN r $$) AS (r agtype
 --
 SELECT * FROM create_graph('issue_1446');
 NOTICE:  graph "issue_1446" has been created
- create_graph 
+ create_graph
 --------------
- 
+
 (1 row)
 
 -- Reporter's exact setup: two initial nodes
@@ -1864,6 +1864,113 @@ $$) AS (edge_count agtype);
 ------------
  0
 (1 row)
+-- Issue 1954: CREATE + WITH + MERGE causes "vertex was deleted" error
+-- when the number of input rows exceeds the snapshot's command ID window.
+-- entity_exists() used a stale curcid, making recently-created vertices
+-- invisible on later iterations.
+--
+SELECT * FROM create_graph('issue_1954');
+NOTICE:  graph "issue_1954" has been created
+ create_graph 
+--------------
+ 
+(1 row)
+
+-- Setup: create source nodes and relationships (3 rows to trigger the bug)
+SELECT * FROM cypher('issue_1954', $$
+    CREATE (:A {name: 'a1'})-[:R]->(:B {name: 'b1'}),
+           (:A {name: 'a2'})-[:R]->(:B {name: 'b2'}),
+           (:A {name: 'a3'})-[:R]->(:B {name: 'b3'})
+$$) AS (result agtype);
+ result 
+--------
+(0 rows)
+
+-- This query would fail with "vertex assigned to variable c was deleted"
+-- on the 3rd row before the fix.
+SELECT * FROM cypher('issue_1954', $$
+    MATCH (a:A)-[:R]->(b:B)
+    CREATE (c:C {name: a.name + '|' + b.name})
+    WITH a, b, c
+    MERGE (a)-[:LINK]->(c)
+    RETURN a.name, b.name, c.name
+    ORDER BY a.name
+$$) AS (a agtype, b agtype, c agtype);
+  a   |  b   |    c    
+------+------+---------
+ "a1" | "b1" | "a1|b1"
+ "a2" | "b2" | "a2|b2"
+ "a3" | "b3" | "a3|b3"
+(3 rows)
+
+-- Verify edges were created
+SELECT * FROM cypher('issue_1954', $$
+    MATCH (a:A)-[:LINK]->(c:C)
+    RETURN a.name, c.name
+    ORDER BY a.name
+$$) AS (a agtype, c agtype);
+  a   |    c    
+------+---------
+ "a1" | "a1|b1"
+ "a2" | "a2|b2"
+ "a3" | "a3|b3"
+(3 rows)
+
+-- Test with two MERGEs (more complex case from the original report)
+SELECT * FROM cypher('issue_1954', $$
+    MATCH ()-[e:LINK]->() DELETE e
+$$) AS (result agtype);
+ result 
+--------
+(0 rows)
+
+SELECT * FROM cypher('issue_1954', $$
+    MATCH (c:C) DELETE c
+$$) AS (result agtype);
+ result 
+--------
+(0 rows)
+
+SELECT * FROM cypher('issue_1954', $$
+    MATCH (a:A)-[:R]->(b:B)
+    CREATE (c:C {name: a.name + '|' + b.name})
+    WITH a, b, c
+    MERGE (a)-[:LINK1]->(c)
+    MERGE (b)-[:LINK2]->(c)
+    RETURN a.name, b.name, c.name
+    ORDER BY a.name
+$$) AS (a agtype, b agtype, c agtype);
+  a   |  b   |    c    
+------+------+---------
+ "a1" | "b1" | "a1|b1"
+ "a2" | "b2" | "a2|b2"
+ "a3" | "b3" | "a3|b3"
+(3 rows)
+
+-- Verify both sets of edges
+SELECT * FROM cypher('issue_1954', $$
+    MATCH (a:A)-[:LINK1]->(c:C)
+    RETURN a.name, c.name
+    ORDER BY a.name
+$$) AS (a agtype, c agtype);
+  a   |    c    
+------+---------
+ "a1" | "a1|b1"
+ "a2" | "a2|b2"
+ "a3" | "a3|b3"
+(3 rows)
+
+SELECT * FROM cypher('issue_1954', $$
+    MATCH (b:B)-[:LINK2]->(c:C)
+    RETURN b.name, c.name
+    ORDER BY b.name
+$$) AS (b agtype, c agtype);
+  b   |    c    
+------+---------
+ "b1" | "a1|b1"
+ "b2" | "a2|b2"
+ "b3" | "a3|b3"
+(3 rows)
 
 --
 -- clean up graphs
@@ -1884,6 +1991,11 @@ SELECT * FROM cypher('issue_1709', $$ MATCH (n) DETACH DELETE n $$) AS (a agtype
 (0 rows)
 
 SELECT * FROM cypher('issue_1446', $$ MATCH (n) DETACH DELETE n $$) AS (a agtype);
+ a 
+---
+(0 rows)
+
+SELECT * FROM cypher('issue_1954', $$ MATCH (n) DETACH DELETE n $$) AS (a agtype);
  a 
 ---
 (0 rows)
@@ -1980,6 +2092,23 @@ drop cascades to table issue_1446.link
 drop cascades to table issue_1446.shared
 drop cascades to table issue_1446.hub
 NOTICE:  graph "issue_1446" has been dropped
+ drop_graph 
+------------
+ 
+(1 row)
+
+SELECT drop_graph('issue_1954', true);
+NOTICE:  drop cascades to 9 other objects
+DETAIL:  drop cascades to table issue_1954._ag_label_vertex
+drop cascades to table issue_1954._ag_label_edge
+drop cascades to table issue_1954."A"
+drop cascades to table issue_1954."R"
+drop cascades to table issue_1954."B"
+drop cascades to table issue_1954."C"
+drop cascades to table issue_1954."LINK"
+drop cascades to table issue_1954."LINK1"
+drop cascades to table issue_1954."LINK2"
+NOTICE:  graph "issue_1954" has been dropped
  drop_graph 
 ------------
  

--- a/regress/expected/cypher_merge.out
+++ b/regress/expected/cypher_merge.out
@@ -1728,9 +1728,9 @@ SELECT * FROM cypher('issue_1907', $$ MATCH ()-[r]->() RETURN r $$) AS (r agtype
 --
 SELECT * FROM create_graph('issue_1446');
 NOTICE:  graph "issue_1446" has been created
- create_graph
+ create_graph 
 --------------
-
+ 
 (1 row)
 
 -- Reporter's exact setup: two initial nodes
@@ -1864,6 +1864,7 @@ $$) AS (edge_count agtype);
 ------------
  0
 (1 row)
+
 -- Issue 1954: CREATE + WITH + MERGE causes "vertex was deleted" error
 -- when the number of input rows exceeds the snapshot's command ID window.
 -- entity_exists() used a stale curcid, making recently-created vertices

--- a/src/backend/executor/cypher_utils.c
+++ b/src/backend/executor/cypher_utils.c
@@ -208,6 +208,7 @@ bool entity_exists(EState *estate, Oid graph_oid, graphid id)
     HeapTuple tuple;
     Relation rel;
     bool result = true;
+    CommandId saved_curcid;
 
     /*
      * Extract the label id from the graph id and get the table name
@@ -218,6 +219,18 @@ bool entity_exists(EState *estate, Oid graph_oid, graphid id)
     /* Setup the scan key to be the graphid */
     ScanKeyInit(&scan_keys[0], 1, BTEqualStrategyNumber,
                 F_GRAPHIDEQ, GRAPHID_GET_DATUM(id));
+
+    /*
+     * Temporarily advance the snapshot's curcid to the current global
+     * command ID so that entities inserted by preceding clauses (e.g.,
+     * CREATE) in the same query are visible. CREATE calls
+     * CommandCounterIncrement() which advances the global CID, but does
+     * not update es_snapshot->curcid. The Decrement/Increment CID
+     * macros used by the executors can leave curcid behind the global
+     * CID, making recently created entities invisible to this scan.
+     */
+    saved_curcid = estate->es_snapshot->curcid;
+    estate->es_snapshot->curcid = GetCurrentCommandId(false);
 
     rel = table_open(label->relation, RowExclusiveLock);
     scan_desc = table_beginscan(rel, estate->es_snapshot, 1, scan_keys);
@@ -235,6 +248,9 @@ bool entity_exists(EState *estate, Oid graph_oid, graphid id)
 
     table_endscan(scan_desc);
     table_close(rel, RowExclusiveLock);
+
+    /* Restore the original curcid */
+    estate->es_snapshot->curcid = saved_curcid;
 
     return result;
 }


### PR DESCRIPTION
## Summary

Fixes #1954.

When a Cypher query chains `CREATE ... WITH ... MERGE`, vertices created by `CREATE` become invisible to `entity_exists()` after a threshold number of input rows, causing MERGE to throw **"vertex assigned to variable was deleted"**.

**Root cause:** `CREATE` calls `CommandCounterIncrement()` which advances the global command ID, but does **not** update `es_snapshot->curcid`. The `Decrement_Estate_CommandId` / `Increment_Estate_CommandId` macros used by the executors bring `curcid` back to the same value on each iteration. After enough rows, newly inserted vertices have a `Cmin >= curcid` and `HeapTupleSatisfiesMVCC` rejects them (it requires `Cmin < curcid`).

**Example:** With 3 input rows, the global CID advances to 3 after three CREATEs, but `curcid` stays at 2 (due to Decrement/Increment pairs). The third vertex (Cmin=2) is invisible because `2 < 2` is false.

**Fix:** In `entity_exists()`, temporarily set `es_snapshot->curcid` to the current global command ID (via `GetCurrentCommandId(false)`) for the duration of the heap scan, then restore it. This makes all entities inserted by preceding clauses in the same query visible to the existence check without affecting the broader CID management.

## Changes

- `src/backend/executor/cypher_utils.c`: Save/restore `curcid` around the `entity_exists()` scan
- `regress/sql/cypher_merge.sql`: Regression tests for CREATE + WITH + MERGE with 3 rows (1 and 2 MERGEs)
- `regress/expected/cypher_merge.out`: Expected output

## Test plan

- [x] Reproduced the bug: 3+ input rows with CREATE + WITH + MERGE triggers "vertex was deleted"
- [x] Verified the fix: all rows return correct values and edges are created
- [x] Tested with 2 MERGEs (reporter's full pattern): works correctly
- [x] All 31 regression tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)