### PR TITLE
Fix VLE queries failing on read-only replicas (#2160)

### DIFF
--- a/src/backend/utils/adt/age_global_graph.c
+++ b/src/backend/utils/adt/age_global_graph.c
@@ -215,7 +215,7 @@ static List *get_ag_labels_names(Snapshot snapshot, Oid graph_oid,
                 F_CHAREQ, CharGetDatum(label_type));
 
     /* setup the table to be scanned, ag_label in this case */
-    ag_label = table_open(ag_label_relation_id(), ShareLock);
+    ag_label = table_open(ag_label_relation_id(), AccessShareLock);
     scan_desc = table_beginscan(ag_label, snapshot, 2, scan_keys);
 
     /* get the tupdesc - we don't need to release this one */
@@ -241,7 +241,7 @@ static List *get_ag_labels_names(Snapshot snapshot, Oid graph_oid,
 
     /* close up scan */
     table_endscan(scan_desc);
-    table_close(ag_label, ShareLock);
+    table_close(ag_label, AccessShareLock);
 
     return labels;
 }
@@ -493,7 +493,7 @@ static void load_vertex_hashtable(GRAPH_global_context *ggctx)
         vertex_label_table_oid = get_relname_relid(vertex_label_name,
                                                    graph_namespace_oid);
         /* open the relation (table) and begin the scan */
-        graph_vertex_label = table_open(vertex_label_table_oid, ShareLock);
+        graph_vertex_label = table_open(vertex_label_table_oid, AccessShareLock);
         scan_desc = table_beginscan(graph_vertex_label, snapshot, 0, NULL);
         /* get the tupdesc - we don't need to release this one */
         tupdesc = RelationGetDescr(graph_vertex_label);
@@ -544,7 +544,7 @@ static void load_vertex_hashtable(GRAPH_global_context *ggctx)
 
         /* end the scan and close the relation */
         table_endscan(scan_desc);
-        table_close(graph_vertex_label, ShareLock);
+        table_close(graph_vertex_label, AccessShareLock);
     }
 }
 
@@ -601,7 +601,7 @@ static void load_edge_hashtable(GRAPH_global_context *ggctx)
         edge_label_table_oid = get_relname_relid(edge_label_name,
                                                  graph_namespace_oid);
         /* open the relation (table) and begin the scan */
-        graph_edge_label = table_open(edge_label_table_oid, ShareLock);
+        graph_edge_label = table_open(edge_label_table_oid, AccessShareLock);
         scan_desc = table_beginscan(graph_edge_label, snapshot, 0, NULL);
         /* get the tupdesc - we don't need to release this one */
         tupdesc = RelationGetDescr(graph_edge_label);
@@ -678,7 +678,7 @@ static void load_edge_hashtable(GRAPH_global_context *ggctx)
 
         /* end the scan and close the relation */
         table_endscan(scan_desc);
-        table_close(graph_edge_label, ShareLock);
+        table_close(graph_edge_label, AccessShareLock);
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #2160.

VLE queries fail on read-only replicas (standby servers) with:

```
ERROR: cannot acquire lock mode ShareLock on database objects while recovery is in progress
HINT: Only RowExclusiveLock or less can be acquired on database objects during recovery.
```

### Root Cause

The VLE global graph cache (`age_global_graph.c`) acquires `ShareLock` when scanning vertex and edge label tables to populate in-memory hashtables. On standby servers in recovery mode, PostgreSQL restricts locks to `RowExclusiveLock` or lower. `ShareLock` exceeds this threshold.

The three affected functions are:
- `get_ag_labels_names()` — scans `ag_label` catalog table
- `load_vertex_hashtable()` — scans vertex label tables
- `load_edge_hashtable()` — scans edge label tables

All three perform read-only sequential scans to populate caches — no writes.

### Fix

Change `ShareLock` to `AccessShareLock` in all three functions (6 call sites: 3 `table_open` + 3 `table_close`).

`AccessShareLock` is:
- Sufficient for read-only table scans (blocks DDL, allows concurrent reads and DML)
- Allowed on read-only replicas
- Consistent with the existing `ag_cache.c` code, which performs identical catalog scan operations using `AccessShareLock` (18 call sites)

### Test Plan

- [x] All 31 regression tests pass
- [x] Manual VLE test: multi-hop path traversal works correctly
- [x] Lock change is minimal (6 substitutions in 1 file) with no logic changes