### PR TITLE
Add agtype <-> jsonb bidirectional casts (#350)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,8 @@ REGRESS = scan \
           map_projection \
           direct_field_access \
           security \
-          reserved_keyword_alias
+          reserved_keyword_alias \
+          agtype_jsonb_cast
 
 ifneq ($(EXTRA_TESTS),)
   REGRESS += $(EXTRA_TESTS)

--- a/age--1.7.0--y.y.y.sql
+++ b/age--1.7.0--y.y.y.sql
@@ -459,3 +459,34 @@ BEGIN
     END LOOP;
 END;
 $$;
+
+--
+-- agtype <-> jsonb bidirectional casts
+--
+
+-- agtype -> jsonb (explicit)
+-- Uses json intermediate (agtype_to_json -> json::jsonb) because agtype
+-- extends jsonb's binary format with types (AGTV_INTEGER, AGTV_FLOAT,
+-- AGTV_VERTEX, AGTV_EDGE, AGTV_PATH) that jsonb does not recognize.
+CREATE FUNCTION ag_catalog.agtype_to_jsonb(agtype)
+    RETURNS jsonb
+    LANGUAGE sql
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'SELECT ag_catalog.agtype_to_json($1)::jsonb';
+
+CREATE CAST (agtype AS jsonb)
+    WITH FUNCTION ag_catalog.agtype_to_jsonb(agtype);
+
+-- jsonb -> agtype (explicit)
+CREATE FUNCTION ag_catalog.jsonb_to_agtype(jsonb)
+    RETURNS agtype
+    LANGUAGE sql
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'SELECT $1::text::agtype';
+
+CREATE CAST (jsonb AS agtype)
+    WITH FUNCTION ag_catalog.jsonb_to_agtype(jsonb);

--- a/regress/expected/agtype_jsonb_cast.out
+++ b/regress/expected/agtype_jsonb_cast.out
@@ -1,0 +1,261 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+LOAD 'age';
+SET search_path TO ag_catalog;
+--
+-- agtype -> jsonb casts
+--
+-- String scalar
+SELECT '"hello"'::agtype::jsonb;
+  jsonb  
+---------
+ "hello"
+(1 row)
+
+-- Null
+SELECT 'null'::agtype::jsonb;
+ jsonb 
+-------
+ null
+(1 row)
+
+-- Array
+SELECT '[1, "two", null]'::agtype::jsonb;
+      jsonb       
+------------------
+ [1, "two", null]
+(1 row)
+
+-- Nested array
+SELECT '[[1, 2], [3, 4]]'::agtype::jsonb;
+      jsonb       
+------------------
+ [[1, 2], [3, 4]]
+(1 row)
+
+-- Empty array
+SELECT '[]'::agtype::jsonb;
+ jsonb 
+-------
+ []
+(1 row)
+
+-- Object
+SELECT '{"name": "Alice", "age": 30}'::agtype::jsonb;
+            jsonb             
+------------------------------
+ {"age": 30, "name": "Alice"}
+(1 row)
+
+-- Nested object
+SELECT '{"a": {"b": {"c": 1}}}'::agtype::jsonb;
+         jsonb          
+------------------------
+ {"a": {"b": {"c": 1}}}
+(1 row)
+
+-- Object with array values
+SELECT '{"tags": ["a", "b"], "count": 2}'::agtype::jsonb;
+              jsonb               
+----------------------------------
+ {"tags": ["a", "b"], "count": 2}
+(1 row)
+
+-- Empty object
+SELECT '{}'::agtype::jsonb;
+ jsonb 
+-------
+ {}
+(1 row)
+
+--
+-- jsonb -> agtype casts
+--
+-- String scalar
+SELECT '"hello"'::jsonb::agtype;
+ agtype  
+---------
+ "hello"
+(1 row)
+
+-- Numeric scalar
+SELECT '42'::jsonb::agtype;
+ agtype 
+--------
+ 42
+(1 row)
+
+-- Float scalar
+SELECT '3.14'::jsonb::agtype;
+ agtype 
+--------
+ 3.14
+(1 row)
+
+-- Boolean
+SELECT 'true'::jsonb::agtype;
+ agtype 
+--------
+ true
+(1 row)
+
+-- Null
+SELECT 'null'::jsonb::agtype;
+ agtype 
+--------
+ null
+(1 row)
+
+-- Array
+SELECT '[1, "two", null]'::jsonb::agtype;
+      agtype      
+------------------
+ [1, "two", null]
+(1 row)
+
+-- Nested array
+SELECT '[[1, 2], [3, 4]]'::jsonb::agtype;
+      agtype      
+------------------
+ [[1, 2], [3, 4]]
+(1 row)
+
+-- Empty array
+SELECT '[]'::jsonb::agtype;
+ agtype 
+--------
+ []
+(1 row)
+
+-- Object
+SELECT '{"name": "Alice", "age": 30}'::jsonb::agtype;
+            agtype            
+------------------------------
+ {"age": 30, "name": "Alice"}
+(1 row)
+
+-- Nested object
+SELECT '{"a": {"b": {"c": 1}}}'::jsonb::agtype;
+         agtype         
+------------------------
+ {"a": {"b": {"c": 1}}}
+(1 row)
+
+-- Empty object
+SELECT '{}'::jsonb::agtype;
+ agtype 
+--------
+ {}
+(1 row)
+
+--
+-- Roundtrip: jsonb -> agtype -> jsonb
+--
+SELECT ('{"key": "value"}'::jsonb::agtype)::jsonb;
+      jsonb       
+------------------
+ {"key": "value"}
+(1 row)
+
+SELECT ('[1, 2, 3]'::jsonb::agtype)::jsonb;
+   jsonb   
+-----------
+ [1, 2, 3]
+(1 row)
+
+SELECT ('null'::jsonb::agtype)::jsonb;
+ jsonb 
+-------
+ null
+(1 row)
+
+--
+-- Graph data -> jsonb (vertex and edge)
+--
+SELECT create_graph('agtype_jsonb_test');
+NOTICE:  graph "agtype_jsonb_test" has been created
+ create_graph 
+--------------
+ 
+(1 row)
+
+SELECT * FROM cypher('agtype_jsonb_test', $$
+    CREATE (a:Person {name: 'Alice', age: 30})-[:KNOWS {since: 2020}]->(b:Person {name: 'Bob', age: 25})
+    RETURN a, b
+$$) AS (a agtype, b agtype);
+                                               a                                                |                                              b                                               
+------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------
+ {"id": 844424930131969, "label": "Person", "properties": {"age": 30, "name": "Alice"}}::vertex | {"id": 844424930131970, "label": "Person", "properties": {"age": 25, "name": "Bob"}}::vertex
+(1 row)
+
+-- Vertex to jsonb: check structure
+SELECT v::jsonb ? 'label' AS has_label,
+       v::jsonb ? 'properties' AS has_properties,
+       (v::jsonb -> 'properties' ->> 'name') AS name
+FROM cypher('agtype_jsonb_test', $$
+    MATCH (n:Person) RETURN n ORDER BY n.name
+$$) AS (v agtype);
+ has_label | has_properties | name  
+-----------+----------------+-------
+ t         | t              | Alice
+ t         | t              | Bob
+(2 rows)
+
+-- Edge to jsonb: check structure
+SELECT e::jsonb ? 'label' AS has_label,
+       (e::jsonb ->> 'label') AS label,
+       (e::jsonb -> 'properties' ->> 'since') AS since
+FROM cypher('agtype_jsonb_test', $$
+    MATCH ()-[r:KNOWS]->() RETURN r
+$$) AS (e agtype);
+ has_label | label | since 
+-----------+-------+-------
+ t         | KNOWS | 2020
+(1 row)
+
+--
+-- NULL handling
+--
+SELECT NULL::agtype::jsonb;
+ jsonb 
+-------
+ 
+(1 row)
+
+SELECT NULL::jsonb::agtype;
+ agtype 
+--------
+ 
+(1 row)
+
+--
+-- Cleanup
+--
+SELECT drop_graph('agtype_jsonb_test', true);
+NOTICE:  drop cascades to 4 other objects
+DETAIL:  drop cascades to table agtype_jsonb_test._ag_label_vertex
+drop cascades to table agtype_jsonb_test._ag_label_edge
+drop cascades to table agtype_jsonb_test."Person"
+drop cascades to table agtype_jsonb_test."KNOWS"
+NOTICE:  graph "agtype_jsonb_test" has been dropped
+ drop_graph 
+------------
+ 
+(1 row)
+

--- a/regress/sql/agtype_jsonb_cast.sql
+++ b/regress/sql/agtype_jsonb_cast.sql
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+LOAD 'age';
+SET search_path TO ag_catalog;
+
+--
+-- agtype -> jsonb casts
+--
+
+-- String scalar
+SELECT '"hello"'::agtype::jsonb;
+
+-- Null
+SELECT 'null'::agtype::jsonb;
+
+-- Array
+SELECT '[1, "two", null]'::agtype::jsonb;
+
+-- Nested array
+SELECT '[[1, 2], [3, 4]]'::agtype::jsonb;
+
+-- Empty array
+SELECT '[]'::agtype::jsonb;
+
+-- Object
+SELECT '{"name": "Alice", "age": 30}'::agtype::jsonb;
+
+-- Nested object
+SELECT '{"a": {"b": {"c": 1}}}'::agtype::jsonb;
+
+-- Object with array values
+SELECT '{"tags": ["a", "b"], "count": 2}'::agtype::jsonb;
+
+-- Empty object
+SELECT '{}'::agtype::jsonb;
+
+--
+-- jsonb -> agtype casts
+--
+
+-- String scalar
+SELECT '"hello"'::jsonb::agtype;
+
+-- Numeric scalar
+SELECT '42'::jsonb::agtype;
+
+-- Float scalar
+SELECT '3.14'::jsonb::agtype;
+
+-- Boolean
+SELECT 'true'::jsonb::agtype;
+
+-- Null
+SELECT 'null'::jsonb::agtype;
+
+-- Array
+SELECT '[1, "two", null]'::jsonb::agtype;
+
+-- Nested array
+SELECT '[[1, 2], [3, 4]]'::jsonb::agtype;
+
+-- Empty array
+SELECT '[]'::jsonb::agtype;
+
+-- Object
+SELECT '{"name": "Alice", "age": 30}'::jsonb::agtype;
+
+-- Nested object
+SELECT '{"a": {"b": {"c": 1}}}'::jsonb::agtype;
+
+-- Empty object
+SELECT '{}'::jsonb::agtype;
+
+--
+-- Roundtrip: jsonb -> agtype -> jsonb
+--
+
+SELECT ('{"key": "value"}'::jsonb::agtype)::jsonb;
+SELECT ('[1, 2, 3]'::jsonb::agtype)::jsonb;
+SELECT ('null'::jsonb::agtype)::jsonb;
+
+--
+-- Graph data -> jsonb (vertex and edge)
+--
+
+SELECT create_graph('agtype_jsonb_test');
+
+SELECT * FROM cypher('agtype_jsonb_test', $$
+    CREATE (a:Person {name: 'Alice', age: 30})-[:KNOWS {since: 2020}]->(b:Person {name: 'Bob', age: 25})
+    RETURN a, b
+$$) AS (a agtype, b agtype);
+
+-- Vertex to jsonb: check structure
+SELECT v::jsonb ? 'label' AS has_label,
+       v::jsonb ? 'properties' AS has_properties,
+       (v::jsonb -> 'properties' ->> 'name') AS name
+FROM cypher('agtype_jsonb_test', $$
+    MATCH (n:Person) RETURN n ORDER BY n.name
+$$) AS (v agtype);
+
+-- Edge to jsonb: check structure
+SELECT e::jsonb ? 'label' AS has_label,
+       (e::jsonb ->> 'label') AS label,
+       (e::jsonb -> 'properties' ->> 'since') AS since
+FROM cypher('agtype_jsonb_test', $$
+    MATCH ()-[r:KNOWS]->() RETURN r
+$$) AS (e agtype);
+
+--
+-- NULL handling
+--
+
+SELECT NULL::agtype::jsonb;
+SELECT NULL::jsonb::agtype;
+
+--
+-- Cleanup
+--
+
+SELECT drop_graph('agtype_jsonb_test', true);

--- a/sql/agtype_coercions.sql
+++ b/sql/agtype_coercions.sql
@@ -175,9 +175,9 @@ CREATE CAST (agtype AS json)
     WITH FUNCTION ag_catalog.agtype_to_json(agtype);
 
 -- agtype -> jsonb (explicit)
--- Uses text intermediate because agtype extends jsonb's binary format
--- with types (AGTV_INTEGER, AGTV_FLOAT, AGTV_VERTEX, AGTV_EDGE, AGTV_PATH)
--- that jsonb does not recognize.
+-- Uses json intermediate (agtype_to_json -> json::jsonb) because agtype
+-- extends jsonb's binary format with types (AGTV_INTEGER, AGTV_FLOAT,
+-- AGTV_VERTEX, AGTV_EDGE, AGTV_PATH) that jsonb does not recognize.
 CREATE FUNCTION ag_catalog.agtype_to_jsonb(agtype)
     RETURNS jsonb
     LANGUAGE sql

--- a/sql/agtype_coercions.sql
+++ b/sql/agtype_coercions.sql
@@ -174,6 +174,33 @@ AS 'MODULE_PATHNAME';
 CREATE CAST (agtype AS json)
     WITH FUNCTION ag_catalog.agtype_to_json(agtype);
 
+-- agtype -> jsonb (explicit)
+-- Uses text intermediate because agtype extends jsonb's binary format
+-- with types (AGTV_INTEGER, AGTV_FLOAT, AGTV_VERTEX, AGTV_EDGE, AGTV_PATH)
+-- that jsonb does not recognize.
+CREATE FUNCTION ag_catalog.agtype_to_jsonb(agtype)
+    RETURNS jsonb
+    LANGUAGE sql
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'SELECT ag_catalog.agtype_to_json($1)::jsonb';
+
+CREATE CAST (agtype AS jsonb)
+    WITH FUNCTION ag_catalog.agtype_to_jsonb(agtype);
+
+-- jsonb -> agtype (explicit)
+CREATE FUNCTION ag_catalog.jsonb_to_agtype(jsonb)
+    RETURNS agtype
+    LANGUAGE sql
+    IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'SELECT $1::text::agtype';
+
+CREATE CAST (jsonb AS agtype)
+    WITH FUNCTION ag_catalog.jsonb_to_agtype(jsonb);
+
 CREATE FUNCTION ag_catalog.agtype_array_to_agtype(agtype[])
     RETURNS agtype
     LANGUAGE c


### PR DESCRIPTION
## Summary

Adds explicit casts between `agtype` and `jsonb` (issue #350, open since 2022):

```sql
-- agtype -> jsonb: use jsonb operators on graph data
SELECT properties(n)::jsonb FROM cypher('g', $$ MATCH (n) RETURN n $$) AS (n agtype);
SELECT (props::jsonb)->>'name' FROM cypher('g', $$ MATCH (n) RETURN properties(n) $$) AS (props agtype);

-- jsonb -> agtype: pass jsonb data into Cypher context
SELECT '{"key": "value"}'::jsonb::agtype;

-- Roundtrip
SELECT ('{"x": 1}'::agtype::jsonb)::agtype;

-- Vertex/edge → jsonb (properties extracted as JSON object)
SELECT n::jsonb FROM cypher('g', $$ MATCH (n:Person) RETURN n $$) AS (n agtype);
```

## Implementation

SQL language functions using json-intermediate paths:
- `agtype → jsonb`: `ag_catalog.agtype_to_json($1)::jsonb`
- `jsonb → agtype`: `$1::text::agtype`

**Why json intermediate?** agtype extends jsonb's binary format with types (`AGTV_INTEGER`, `AGTV_FLOAT`, `AGTV_VERTEX`, `AGTV_EDGE`, `AGTV_PATH`) that jsonb does not recognize. Direct binary cast causes `"unknown type of jsonb container"` errors. The json roundtrip correctly handles all value types — graph types are serialized as JSON objects with their properties.

## Files changed

- `sql/agtype_coercions.sql` — adds the two cast functions and `CREATE CAST` statements (27 lines).
- `regress/sql/agtype_jsonb_cast.sql` + `regress/expected/agtype_jsonb_cast.out` — new regression suite covering scalar/array/object roundtrips, all jsonb scalar types → agtype, vertex/edge → jsonb with structural key checks, and NULL handling (137 + 261 lines).
- `Makefile` — registers `agtype_jsonb_cast` in the `REGRESS` list so the new suite runs as part of `make installcheck`.

No C code changes.

## Test plan
- [x] Object with integers: `'{"name": "Alice", "age": 30}'::agtype::jsonb`
- [x] Arrays: `'[1, 2, 3]'::agtype::jsonb`
- [x] Strings: `'"hello"'::agtype::jsonb`
- [x] Nested objects: `'{"a": {"b": [1, true, null]}}'::agtype::jsonb`
- [x] jsonb → agtype: `'{"key": "value"}'::jsonb::agtype`
- [x] Roundtrip: `('{"x": 1}'::agtype::jsonb)::agtype`
- [x] Vertex → jsonb: graph type converted to JSON object
- [x] properties() → jsonb: direct property extraction
- [x] JSONB operators on agtype data: `(props::jsonb)->>'name'`
- [x] All existing regression tests pass
- [x] New `agtype_jsonb_cast` regression suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)