### PR TITLE
Add extension upgrade template regression test

### DIFF
--- a/.github/workflows/installcheck.yaml
+++ b/.github/workflows/installcheck.yaml
@@ -42,6 +42,8 @@ jobs:
           make PG_CONFIG=$HOME/pg18/bin/pg_config install -j$(nproc) > /dev/null
 
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 75
 
       - name: Build AGE
         id: build

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,64 @@ MODULE_big = age
 
 age_sql = age--1.7.0.sql
 
+# --- Extension upgrade regression test support ---
+#
+# Validates the upgrade template (age--<VER>--y.y.y.sql) by simulating an
+# extension version upgrade entirely within "make installcheck". The test:
+#
+#   1. Builds the install SQL from the INITIAL version-bump commit (the "from"
+#      version). This is the age--<CURR>.sql used by CREATE EXTENSION age.
+#   2. Builds the install SQL from current HEAD as a synthetic "next" version
+#      (the "to" version). This is age--<NEXT>.sql where NEXT = CURR.minor+1.
+#   3. Stamps the upgrade template with the synthetic version, producing the
+#      upgrade script age--<CURR>--<NEXT>.sql.
+#   4. Temporarily installs both synthetic files into the PG extension directory
+#      so that ALTER EXTENSION age UPDATE TO '<NEXT>' can find them.
+#   5. The age_upgrade regression test exercises the full upgrade path: install
+#      at CURR, create data, ALTER EXTENSION UPDATE to NEXT, verify data.
+#   6. The test SQL cleans up the synthetic files via a generated shell script.
+#
+# This forces developers to keep the upgrade template in sync: any SQL object
+# added after the version-bump commit must also appear in the template, or the
+# upgrade test will fail (the object will be missing after ALTER EXTENSION UPDATE).
+#
+# The .so (shared library) is always built from current HEAD, so C-level changes
+# in the PR are tested by every regression test, not just the upgrade test.
+#
+# Graceful degradation — the upgrade test is silently skipped when:
+#   - No git history (tarball build): AGE_VER_COMMIT is empty.
+#   - No upgrade template: age--<CURR>--y.y.y.sql does not exist.
+#   - A real (git-tracked) upgrade script from <CURR> already exists
+#     (e.g., age--1.7.0--1.8.0.sql is committed): the synthetic test is
+#     redundant because the real script ships with the extension.
+# Current version from age.control (e.g., "1.7.0")
+AGE_CURR_VER := $(shell awk -F"'" '/default_version/ {print $$2}' age.control 2>/dev/null)
+# Git commit that last changed age.control — the "initial release" commit
+AGE_VER_COMMIT := $(shell git log -1 --format=%H -- age.control 2>/dev/null)
+# Synthetic next version: current minor + 1 (e.g., 1.7.0 -> 1.8.0)
+AGE_NEXT_VER := $(shell echo $(AGE_CURR_VER) | awk -F. '{printf "%s.%s.%s", $$1, $$2+1, $$3}')
+# The upgrade template file (e.g., age--1.7.0--y.y.y.sql); empty if not present
+AGE_UPGRADE_TEMPLATE := $(wildcard age--$(AGE_CURR_VER)--y.y.y.sql)
+
+# Synthetic filenames — these are NOT installed permanently; they are temporarily
+# placed in $(SHAREDIR)/extension/ during installcheck and removed after.
+age_next_sql = $(if $(AGE_NEXT_VER),age--$(AGE_NEXT_VER).sql)
+age_upgrade_test_sql = $(if $(AGE_NEXT_VER),age--$(AGE_CURR_VER)--$(AGE_NEXT_VER).sql)
+
+# Real (git-tracked, non-template) upgrade scripts FROM the current version.
+# If any exist (e.g., age--1.7.0--1.8.0.sql is committed), the synthetic
+# upgrade test is redundant because a real upgrade path already ships.
+# Uses git ls-files so untracked synthetic files are NOT matched.
+AGE_REAL_UPGRADE := $(shell git ls-files 'age--$(AGE_CURR_VER)--*.sql' 2>/dev/null | grep -v 'y\.y\.y')
+
+# Non-empty when ALL of these hold:
+#   1. Git history is available (AGE_VER_COMMIT non-empty)
+#   2. The upgrade template exists (AGE_UPGRADE_TEMPLATE non-empty)
+#   3. No real upgrade script from current version exists (AGE_REAL_UPGRADE empty)
+# When a real upgrade script ships, the test is skipped — the real script
+# supersedes the synthetic one and has its own validation path.
+AGE_HAS_UPGRADE_TEST = $(and $(AGE_VER_COMMIT),$(AGE_UPGRADE_TEMPLATE),$(if $(AGE_REAL_UPGRADE),,yes))
+
 OBJS = src/backend/age.o \
        src/backend/catalog/ag_catalog.o \
        src/backend/catalog/ag_graph.o \
@@ -83,6 +141,10 @@ SQLS := $(addsuffix .sql,$(SQLS))
 
 DATA_built = $(age_sql)
 
+# Git-tracked upgrade scripts shipped with the extension (e.g., age--1.6.0--1.7.0.sql).
+# Excludes the upgrade template (y.y.y) and the synthetic stamped test file.
+DATA = $(filter-out age--%-y.y.y.sql $(age_upgrade_test_sql),$(wildcard age--*--*.sql))
+
 # sorted in dependency order
 REGRESS = scan \
           graphid \
@@ -119,6 +181,13 @@ ifneq ($(EXTRA_TESTS),)
   REGRESS += $(EXTRA_TESTS)
 endif
 
+# Extension upgrade test — included when git history is available, the upgrade
+# template exists, and no real upgrade script from the current version is
+# committed. Runs between "security" and "drop" in test order.
+ifneq ($(AGE_HAS_UPGRADE_TEST),)
+  REGRESS += age_upgrade
+endif
+
 REGRESS += drop
 
 srcdir=`pwd`
@@ -127,7 +196,7 @@ ag_regress_dir = $(srcdir)/regress
 REGRESS_OPTS = --load-extension=age --inputdir=$(ag_regress_dir) --outputdir=$(ag_regress_dir) --temp-instance=$(ag_regress_dir)/instance --port=61958 --encoding=UTF-8 --temp-config $(ag_regress_dir)/age_regression.conf
 
 ag_regress_out = instance/ log/ results/ regression.*
-EXTRA_CLEAN = $(addprefix $(ag_regress_dir)/, $(ag_regress_out)) src/backend/parser/cypher_gram.c src/include/parser/cypher_gram_def.h src/include/parser/cypher_kwlist_d.h $(all_age_sql)
+EXTRA_CLEAN = $(addprefix $(ag_regress_dir)/, $(ag_regress_out)) src/backend/parser/cypher_gram.c src/include/parser/cypher_gram_def.h src/include/parser/cypher_kwlist_d.h $(all_age_sql) $(age_next_sql) $(age_upgrade_test_sql) $(ag_regress_dir)/age_upgrade_cleanup.sh
 
 GEN_KEYWORDLIST = $(PERL) -I ./tools/ ./tools/gen_keywordlist.pl
 GEN_KEYWORDLIST_DEPS = ./tools/gen_keywordlist.pl tools/PerfectHash.pm
@@ -157,7 +226,27 @@ src/backend/parser/cypher_parser.bc: src/backend/parser/cypher_gram.c src/includ
 src/backend/parser/cypher_keywords.o: src/backend/parser/cypher_gram.c src/include/parser/cypher_gram_def.h
 src/backend/parser/cypher_keywords.bc: src/backend/parser/cypher_gram.c src/include/parser/cypher_gram_def.h
 
-# Strip PASSEDBYVALUE on 32-bit (SIZEOF_DATUM=4) for graphid pass-by-reference
+# Build the default install SQL (age--<VER>.sql) from the INITIAL version-bump
+# commit in git history. This means CREATE EXTENSION age installs the "day-one
+# release" SQL — the state of sql/ at the moment the version was bumped in
+# age.control. All other regression tests run against this SQL + the current
+# HEAD .so, implicitly validating that the .so is backward-compatible with the
+# initial release SQL.
+#
+# The current HEAD SQL goes into the synthetic next version (age--<NEXT>.sql)
+# which is only reachable via ALTER EXTENSION UPDATE in the upgrade test.
+ifneq ($(AGE_VER_COMMIT),)
+$(age_sql): age.control
+	@echo "Building initial-release install SQL: $@ from commit $(AGE_VER_COMMIT)"
+	@for f in $$(git show $(AGE_VER_COMMIT):sql/sql_files 2>/dev/null); do \
+		git show $(AGE_VER_COMMIT):sql/$${f}.sql 2>/dev/null; \
+	done > $@
+ifeq ($(SIZEOF_DATUM),4)
+	@echo "32-bit build: removing PASSEDBYVALUE from graphid type"
+	@sed 's/^  PASSEDBYVALUE,$$/  -- PASSEDBYVALUE removed for 32-bit (see Makefile)/' $@ > $@.tmp && mv $@.tmp $@
+endif
+else
+# Fallback: no git history (tarball build) — use current HEAD SQL fragments
 $(age_sql): $(SQLS)
 	@cat $(SQLS) > $@
 ifeq ($(SIZEOF_DATUM),4)
@@ -165,7 +254,50 @@ ifeq ($(SIZEOF_DATUM),4)
 	@sed 's/^  PASSEDBYVALUE,$$/  -- PASSEDBYVALUE removed for 32-bit (see Makefile)/' $@ > $@.tmp && mv $@.tmp $@
 	@grep -q 'PASSEDBYVALUE removed for 32-bit' $@ || { echo "Error: PASSEDBYVALUE replacement failed in $@"; exit 1; }
 endif
+endif
+
+# Build synthetic "next" version install SQL from current HEAD's sql/sql_files.
+# This represents what the extension SQL looks like in the PR being tested.
+ifneq ($(AGE_HAS_UPGRADE_TEST),)
+$(age_next_sql): $(SQLS)
+	@echo "Building synthetic next version install SQL: $@ ($(AGE_NEXT_VER))"
+	@cat $(SQLS) > $@
+ifeq ($(SIZEOF_DATUM),4)
+	@sed 's/^  PASSEDBYVALUE,$$/  -- PASSEDBYVALUE removed for 32-bit (see Makefile)/' $@ > $@.tmp && mv $@.tmp $@
+endif
+
+# Stamp upgrade template as upgrade from current to synthetic next version
+$(age_upgrade_test_sql): $(AGE_UPGRADE_TEMPLATE)
+	@echo "Stamping upgrade template: $< -> $@"
+	@sed -e "s/1\.X\.0/$(AGE_NEXT_VER)/g" -e "s/y\.y\.y/$(AGE_NEXT_VER)/g" $< > $@
+endif
 
 src/backend/parser/ag_scanner.c: FLEX_NO_BACKUP=yes
 
+# --- Upgrade test file lifecycle during installcheck ---
+#
+# Problem: The upgrade test needs age--<NEXT>.sql and age--<CURR>--<NEXT>.sql
+# in the PG extension directory for ALTER EXTENSION UPDATE to find them, but
+# we must not leave them installed permanently (they would confuse users).
+#
+# Solution: A Make prerequisite installs them before pg_regress runs, and the
+# test SQL removes them at the end via \! (shell escape in psql). A generated
+# cleanup script (regress/age_upgrade_cleanup.sh) contains the exact absolute
+# paths so the removal works regardless of the working directory. EXTRA_CLEAN
+# also removes them on "make clean" as a safety net.
+#
+# This adds a prerequisite to "installcheck" but does NOT override the PGXS
+# recipe, so there are no Makefile warnings.
+SHAREDIR = $(shell $(PG_CONFIG) --sharedir)
+
 installcheck: export LC_COLLATE=C
+ifneq ($(AGE_HAS_UPGRADE_TEST),)
+.PHONY: _install_upgrade_test_files
+_install_upgrade_test_files: $(age_next_sql) $(age_upgrade_test_sql)  ## Build, install synthetic files, generate cleanup script
+	@echo "Installing upgrade test files to $(SHAREDIR)/extension/"
+	@$(INSTALL_DATA) $(age_next_sql) $(age_upgrade_test_sql) '$(SHAREDIR)/extension/'
+	@printf '#!/bin/sh\nrm -f "$(SHAREDIR)/extension/$(age_next_sql)" "$(SHAREDIR)/extension/$(age_upgrade_test_sql)"\n' > $(ag_regress_dir)/age_upgrade_cleanup.sh
+	@chmod +x $(ag_regress_dir)/age_upgrade_cleanup.sh
+
+installcheck: _install_upgrade_test_files
+endif

--- a/regress/expected/age_upgrade.out
+++ b/regress/expected/age_upgrade.out
@@ -1,0 +1,443 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+--
+-- Extension upgrade regression test
+--
+-- This test validates the upgrade template (age--<VER>--y.y.y.sql) by:
+--   1. Installing AGE at the current version (built from the initial
+--      version-bump commit's SQL — the "day-one release" state)
+--   2. Creating three graphs with multiple labels, edges, GIN indexes,
+--      and numeric properties that serve as integrity checksums
+--   3. Upgrading to a synthetic "next" version via the stamped template
+--   4. Verifying all data, structure, and checksums survived the upgrade
+--
+-- The Makefile builds:
+--   age--<CURR>.sql        from the initial version-bump commit (git history)
+--   age--<NEXT>.sql        from current HEAD's sql/sql_files
+--   age--<CURR>--<NEXT>.sql stamped from the upgrade template
+--
+-- All version discovery is dynamic — no hardcoded versions anywhere.
+-- This test is version-agnostic and works on any branch for any version.
+--
+LOAD 'age';
+SET search_path TO ag_catalog;
+-- Step 1: Clean up any state left by prior tests, then drop AGE entirely.
+-- The --load-extension=age flag installed AGE at the current (default) version.
+-- We need to remove it so we can cleanly re-create for this test.
+SELECT drop_graph(name, true) FROM ag_graph ORDER BY name;
+ drop_graph 
+------------
+(0 rows)
+
+DROP EXTENSION age;
+-- Step 2: Verify we have multiple installable versions.
+SELECT count(*) > 1 AS has_upgrade_path
+FROM pg_available_extension_versions WHERE name = 'age';
+ has_upgrade_path 
+------------------
+ t
+(1 row)
+
+-- Step 3: Install AGE at the default version (the initial release SQL).
+CREATE EXTENSION age;
+SELECT extversion IS NOT NULL AS version_installed FROM pg_extension WHERE extname = 'age';
+ version_installed 
+-------------------
+ t
+(1 row)
+
+-- Step 4: Create three test graphs with diverse labels, edges, and data.
+LOAD 'age';
+SET search_path TO ag_catalog, "$user", public;
+--
+-- Graph 1: "company" — organization hierarchy with numeric checksums.
+-- Labels: Employee, Department, Project
+-- Edges: WORKS_IN, MANAGES, ASSIGNED_TO
+-- Each vertex has a "val" property (float) for checksum validation.
+--
+SELECT create_graph('company');
+NOTICE:  graph "company" has been created
+ create_graph 
+--------------
+ 
+(1 row)
+
+SELECT * FROM cypher('company', $$
+    CREATE (e1:Employee {name: 'Alice',   role: 'VP',        val: 3.14159})
+    CREATE (e2:Employee {name: 'Bob',     role: 'Manager',   val: 2.71828})
+    CREATE (e3:Employee {name: 'Charlie', role: 'Engineer',  val: 1.41421})
+    CREATE (e4:Employee {name: 'Diana',   role: 'Engineer',  val: 1.73205})
+    CREATE (d1:Department {name: 'Engineering', budget: 500000, val: 42.0})
+    CREATE (d2:Department {name: 'Research',    budget: 300000, val: 17.5})
+    CREATE (p1:Project {name: 'Atlas',   priority: 1, val: 99.99})
+    CREATE (p2:Project {name: 'Beacon',  priority: 2, val: 88.88})
+    CREATE (p3:Project {name: 'Cipher',  priority: 3, val: 77.77})
+    CREATE (e1)-[:WORKS_IN {since: 2019}]->(d1)
+    CREATE (e2)-[:WORKS_IN {since: 2020}]->(d1)
+    CREATE (e3)-[:WORKS_IN {since: 2021}]->(d1)
+    CREATE (e4)-[:WORKS_IN {since: 2022}]->(d2)
+    CREATE (e1)-[:MANAGES {level: 1}]->(e2)
+    CREATE (e2)-[:MANAGES {level: 2}]->(e3)
+    CREATE (e3)-[:ASSIGNED_TO {hours: 40}]->(p1)
+    CREATE (e3)-[:ASSIGNED_TO {hours: 20}]->(p2)
+    CREATE (e4)-[:ASSIGNED_TO {hours: 30}]->(p2)
+    CREATE (e4)-[:ASSIGNED_TO {hours: 10}]->(p3)
+    RETURN 'company graph created'
+$$) AS (result agtype);
+         result          
+-------------------------
+ "company graph created"
+(1 row)
+
+-- GIN index on Employee properties in company graph
+CREATE INDEX company_employee_gin ON company."Employee" USING GIN (properties);
+--
+-- Graph 2: "network" — social network with weighted edges.
+-- Labels: User, Post
+-- Edges: FOLLOWS, AUTHORED, LIKES
+--
+SELECT create_graph('network');
+NOTICE:  graph "network" has been created
+ create_graph 
+--------------
+ 
+(1 row)
+
+SELECT * FROM cypher('network', $$
+    CREATE (u1:User {handle: '@alpha',   score: 1000.01})
+    CREATE (u2:User {handle: '@beta',    score: 2000.02})
+    CREATE (u3:User {handle: '@gamma',   score: 3000.03})
+    CREATE (u4:User {handle: '@delta',   score: 4000.04})
+    CREATE (u5:User {handle: '@epsilon', score: 5000.05})
+    CREATE (p1:Post {title: 'Hello World',        views: 150})
+    CREATE (p2:Post {title: 'Graph Databases 101', views: 890})
+    CREATE (p3:Post {title: 'AGE is awesome',      views: 2200})
+    CREATE (u1)-[:FOLLOWS {weight: 0.9}]->(u2)
+    CREATE (u2)-[:FOLLOWS {weight: 0.8}]->(u3)
+    CREATE (u3)-[:FOLLOWS {weight: 0.7}]->(u4)
+    CREATE (u4)-[:FOLLOWS {weight: 0.6}]->(u5)
+    CREATE (u5)-[:FOLLOWS {weight: 0.5}]->(u1)
+    CREATE (u1)-[:AUTHORED]->(p1)
+    CREATE (u2)-[:AUTHORED]->(p2)
+    CREATE (u3)-[:AUTHORED]->(p3)
+    CREATE (u4)-[:LIKES]->(p1)
+    CREATE (u5)-[:LIKES]->(p2)
+    CREATE (u1)-[:LIKES]->(p3)
+    CREATE (u2)-[:LIKES]->(p3)
+    RETURN 'network graph created'
+$$) AS (result agtype);
+         result          
+-------------------------
+ "network graph created"
+(1 row)
+
+-- GIN indexes on network graph
+CREATE INDEX network_user_gin ON network."User" USING GIN (properties);
+CREATE INDEX network_post_gin ON network."Post" USING GIN (properties);
+--
+-- Graph 3: "routes" — geographic routing with precise coordinates.
+-- Labels: City, Airport
+-- Edges: ROAD, FLIGHT
+-- Coordinates use precise decimals that are easy to checksum.
+--
+SELECT create_graph('routes');
+NOTICE:  graph "routes" has been created
+ create_graph 
+--------------
+ 
+(1 row)
+
+SELECT * FROM cypher('routes', $$
+    CREATE (c1:City    {name: 'Portland',   lat: 45.5152, lon: -122.6784, pop: 652503})
+    CREATE (c2:City    {name: 'Seattle',    lat: 47.6062, lon: -122.3321, pop: 749256})
+    CREATE (c3:City    {name: 'Vancouver',  lat: 49.2827, lon: -123.1207, pop: 631486})
+    CREATE (a1:Airport {code: 'PDX', elev: 30.5})
+    CREATE (a2:Airport {code: 'SEA', elev: 131.7})
+    CREATE (a3:Airport {code: 'YVR', elev: 4.3})
+    CREATE (c1)-[:ROAD    {distance_km: 279.5,  toll: 0.0}]->(c2)
+    CREATE (c2)-[:ROAD    {distance_km: 225.3,  toll: 5.0}]->(c3)
+    CREATE (c1)-[:ROAD    {distance_km: 502.1,  toll: 5.0}]->(c3)
+    CREATE (a1)-[:FLIGHT  {distance_km: 229.0, duration_min: 55}]->(a2)
+    CREATE (a2)-[:FLIGHT  {distance_km: 198.0, duration_min: 50}]->(a3)
+    CREATE (a1)-[:FLIGHT  {distance_km: 426.0, duration_min: 75}]->(a3)
+    RETURN 'routes graph created'
+$$) AS (result agtype);
+         result         
+------------------------
+ "routes graph created"
+(1 row)
+
+-- GIN index on routes graph
+CREATE INDEX routes_city_gin ON routes."City" USING GIN (properties);
+-- Step 5: Record pre-upgrade integrity checksums.
+-- These sums use the "val" / "score" / coordinate properties as fingerprints.
+-- company: sum of all val properties (should be a precise known value)
+SELECT * FROM cypher('company', $$
+    MATCH (n) WHERE n.val IS NOT NULL RETURN sum(n.val)
+$$) AS (company_val_sum_before agtype);
+ company_val_sum_before 
+------------------------
+ 335.14612999999997
+(1 row)
+
+-- network: sum of all score properties
+SELECT * FROM cypher('network', $$
+    MATCH (n:User) RETURN sum(n.score)
+$$) AS (network_score_sum_before agtype);
+ network_score_sum_before 
+--------------------------
+ 15000.149999999998
+(1 row)
+
+-- routes: sum of all latitude values
+SELECT * FROM cypher('routes', $$
+    MATCH (c:City) RETURN sum(c.lat)
+$$) AS (routes_lat_sum_before agtype);
+ routes_lat_sum_before 
+-----------------------
+ 142.4041
+(1 row)
+
+-- Total vertex and edge counts across all three graphs
+SELECT sum(cnt)::int AS total_vertices_before FROM (
+    SELECT count(*) AS cnt FROM cypher('company', $$ MATCH (n) RETURN n $$) AS (n agtype)
+    UNION ALL
+    SELECT count(*) FROM cypher('network', $$ MATCH (n) RETURN n $$) AS (n agtype)
+    UNION ALL
+    SELECT count(*) FROM cypher('routes', $$ MATCH (n) RETURN n $$) AS (n agtype)
+) sub;
+ total_vertices_before 
+-----------------------
+                    23
+(1 row)
+
+SELECT sum(cnt)::int AS total_edges_before FROM (
+    SELECT count(*) AS cnt FROM cypher('company', $$ MATCH ()-[e]->() RETURN e $$) AS (e agtype)
+    UNION ALL
+    SELECT count(*) FROM cypher('network', $$ MATCH ()-[e]->() RETURN e $$) AS (e agtype)
+    UNION ALL
+    SELECT count(*) FROM cypher('routes', $$ MATCH ()-[e]->() RETURN e $$) AS (e agtype)
+) sub;
+ total_edges_before 
+--------------------
+                 28
+(1 row)
+
+-- Count of distinct labels (ag_label entries) across all graphs
+SELECT count(*)::int AS total_labels_before
+FROM ag_label al JOIN ag_graph ag ON al.graph = ag.graphid
+WHERE ag.name <> '_ag_catalog';
+ total_labels_before 
+---------------------
+                  21
+(1 row)
+
+-- Step 6: Upgrade AGE to the synthetic next version via the stamped template.
+DO $$
+DECLARE next_ver text;
+BEGIN
+    SELECT version INTO next_ver
+    FROM pg_available_extension_versions
+    WHERE name = 'age' AND version <> (
+        SELECT default_version FROM pg_available_extensions WHERE name = 'age'
+    )
+    ORDER BY string_to_array(version, '.')::int[] DESC
+    LIMIT 1;
+
+    IF next_ver IS NULL THEN
+        RAISE EXCEPTION 'No next version available for upgrade test';
+    END IF;
+
+    EXECUTE format('ALTER EXTENSION age UPDATE TO %L', next_ver);
+END;
+$$;
+-- Step 7: Confirm version changed.
+SELECT installed_version <> default_version AS upgraded_past_default
+FROM pg_available_extensions WHERE name = 'age';
+ upgraded_past_default 
+-----------------------
+ t
+(1 row)
+
+-- Step 8: Verify all data survived — reload and recheck.
+LOAD 'age';
+SET search_path TO ag_catalog, "$user", public;
+-- Repeat integrity checksums — must match pre-upgrade values exactly.
+SELECT * FROM cypher('company', $$
+    MATCH (n) WHERE n.val IS NOT NULL RETURN sum(n.val)
+$$) AS (company_val_sum_after agtype);
+ company_val_sum_after 
+-----------------------
+ 335.14612999999997
+(1 row)
+
+SELECT * FROM cypher('network', $$
+    MATCH (n:User) RETURN sum(n.score)
+$$) AS (network_score_sum_after agtype);
+ network_score_sum_after 
+-------------------------
+ 15000.149999999998
+(1 row)
+
+SELECT * FROM cypher('routes', $$
+    MATCH (c:City) RETURN sum(c.lat)
+$$) AS (routes_lat_sum_after agtype);
+ routes_lat_sum_after 
+----------------------
+ 142.4041
+(1 row)
+
+SELECT sum(cnt)::int AS total_vertices_after FROM (
+    SELECT count(*) AS cnt FROM cypher('company', $$ MATCH (n) RETURN n $$) AS (n agtype)
+    UNION ALL
+    SELECT count(*) FROM cypher('network', $$ MATCH (n) RETURN n $$) AS (n agtype)
+    UNION ALL
+    SELECT count(*) FROM cypher('routes', $$ MATCH (n) RETURN n $$) AS (n agtype)
+) sub;
+ total_vertices_after 
+----------------------
+                   23
+(1 row)
+
+SELECT sum(cnt)::int AS total_edges_after FROM (
+    SELECT count(*) AS cnt FROM cypher('company', $$ MATCH ()-[e]->() RETURN e $$) AS (e agtype)
+    UNION ALL
+    SELECT count(*) FROM cypher('network', $$ MATCH ()-[e]->() RETURN e $$) AS (e agtype)
+    UNION ALL
+    SELECT count(*) FROM cypher('routes', $$ MATCH ()-[e]->() RETURN e $$) AS (e agtype)
+) sub;
+ total_edges_after 
+-------------------
+                28
+(1 row)
+
+SELECT count(*)::int AS total_labels_after
+FROM ag_label al JOIN ag_graph ag ON al.graph = ag.graphid
+WHERE ag.name <> '_ag_catalog';
+ total_labels_after 
+--------------------
+                 21
+(1 row)
+
+-- Step 9: Verify specific structural queries across all three graphs.
+-- company: management chain
+SELECT * FROM cypher('company', $$
+    MATCH (boss:Employee)-[:MANAGES*]->(report:Employee)
+    RETURN boss.name, report.name
+    ORDER BY boss.name, report.name
+$$) AS (boss agtype, report agtype);
+  boss   |  report   
+---------+-----------
+ "Alice" | "Bob"
+ "Alice" | "Charlie"
+ "Bob"   | "Charlie"
+(3 rows)
+
+-- network: circular follow chain (proves full cycle survived)
+SELECT * FROM cypher('network', $$
+    MATCH (a:User)-[:FOLLOWS]->(b:User)
+    RETURN a.handle, b.handle
+    ORDER BY a.handle
+$$) AS (follower agtype, followed agtype);
+  follower  |  followed  
+------------+------------
+ "@alpha"   | "@beta"
+ "@beta"    | "@gamma"
+ "@delta"   | "@epsilon"
+ "@epsilon" | "@alpha"
+ "@gamma"   | "@delta"
+(5 rows)
+
+-- routes: all flights with distances (proves edge properties intact)
+SELECT * FROM cypher('routes', $$
+    MATCH (a:Airport)-[f:FLIGHT]->(b:Airport)
+    RETURN a.code, b.code, f.distance_km
+    ORDER BY a.code, b.code
+$$) AS (origin agtype, dest agtype, dist agtype);
+ origin | dest  | dist  
+--------+-------+-------
+ "PDX"  | "SEA" | 229.0
+ "PDX"  | "YVR" | 426.0
+ "SEA"  | "YVR" | 198.0
+(3 rows)
+
+-- Step 10: Verify GIN indexes still exist after upgrade.
+SELECT indexname FROM pg_indexes
+WHERE schemaname IN ('company', 'network', 'routes')
+  AND tablename IN ('Employee', 'User', 'Post', 'City')
+  AND indexdef LIKE '%gin%'
+ORDER BY indexname;
+      indexname       
+----------------------
+ company_employee_gin
+ network_post_gin
+ network_user_gin
+ routes_city_gin
+(4 rows)
+
+-- Step 11: Cleanup and restore AGE at the default version for subsequent tests.
+SELECT drop_graph('routes', true);
+NOTICE:  drop cascades to 6 other objects
+DETAIL:  drop cascades to table routes._ag_label_vertex
+drop cascades to table routes._ag_label_edge
+drop cascades to table routes."City"
+drop cascades to table routes."Airport"
+drop cascades to table routes."ROAD"
+drop cascades to table routes."FLIGHT"
+NOTICE:  graph "routes" has been dropped
+ drop_graph 
+------------
+ 
+(1 row)
+
+SELECT drop_graph('network', true);
+NOTICE:  drop cascades to 7 other objects
+DETAIL:  drop cascades to table network._ag_label_vertex
+drop cascades to table network._ag_label_edge
+drop cascades to table network."User"
+drop cascades to table network."Post"
+drop cascades to table network."FOLLOWS"
+drop cascades to table network."AUTHORED"
+drop cascades to table network."LIKES"
+NOTICE:  graph "network" has been dropped
+ drop_graph 
+------------
+ 
+(1 row)
+
+SELECT drop_graph('company', true);
+NOTICE:  drop cascades to 8 other objects
+DETAIL:  drop cascades to table company._ag_label_vertex
+drop cascades to table company._ag_label_edge
+drop cascades to table company."Employee"
+drop cascades to table company."Department"
+drop cascades to table company."Project"
+drop cascades to table company."WORKS_IN"
+drop cascades to table company."MANAGES"
+drop cascades to table company."ASSIGNED_TO"
+NOTICE:  graph "company" has been dropped
+ drop_graph 
+------------
+ 
+(1 row)
+
+DROP EXTENSION age;
+CREATE EXTENSION age;
+-- Step 12: Remove synthetic upgrade test files from the extension directory.
+\! sh ./regress/age_upgrade_cleanup.sh

--- a/regress/sql/age_upgrade.sql
+++ b/regress/sql/age_upgrade.sql
@@ -1,0 +1,296 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+--
+-- Extension upgrade regression test
+--
+-- This test validates the upgrade template (age--<VER>--y.y.y.sql) by:
+--   1. Installing AGE at the current version (built from the initial
+--      version-bump commit's SQL — the "day-one release" state)
+--   2. Creating three graphs with multiple labels, edges, GIN indexes,
+--      and numeric properties that serve as integrity checksums
+--   3. Upgrading to a synthetic "next" version via the stamped template
+--   4. Verifying all data, structure, and checksums survived the upgrade
+--
+-- The Makefile builds:
+--   age--<CURR>.sql        from the initial version-bump commit (git history)
+--   age--<NEXT>.sql        from current HEAD's sql/sql_files
+--   age--<CURR>--<NEXT>.sql stamped from the upgrade template
+--
+-- All version discovery is dynamic — no hardcoded versions anywhere.
+-- This test is version-agnostic and works on any branch for any version.
+--
+
+LOAD 'age';
+SET search_path TO ag_catalog;
+
+-- Step 1: Clean up any state left by prior tests, then drop AGE entirely.
+-- The --load-extension=age flag installed AGE at the current (default) version.
+-- We need to remove it so we can cleanly re-create for this test.
+SELECT drop_graph(name, true) FROM ag_graph ORDER BY name;
+DROP EXTENSION age;
+
+-- Step 2: Verify we have multiple installable versions.
+SELECT count(*) > 1 AS has_upgrade_path
+FROM pg_available_extension_versions WHERE name = 'age';
+
+-- Step 3: Install AGE at the default version (the initial release SQL).
+CREATE EXTENSION age;
+SELECT extversion IS NOT NULL AS version_installed FROM pg_extension WHERE extname = 'age';
+
+-- Step 4: Create three test graphs with diverse labels, edges, and data.
+LOAD 'age';
+SET search_path TO ag_catalog, "$user", public;
+
+--
+-- Graph 1: "company" — organization hierarchy with numeric checksums.
+-- Labels: Employee, Department, Project
+-- Edges: WORKS_IN, MANAGES, ASSIGNED_TO
+-- Each vertex has a "val" property (float) for checksum validation.
+--
+SELECT create_graph('company');
+
+SELECT * FROM cypher('company', $$
+    CREATE (e1:Employee {name: 'Alice',   role: 'VP',        val: 3.14159})
+    CREATE (e2:Employee {name: 'Bob',     role: 'Manager',   val: 2.71828})
+    CREATE (e3:Employee {name: 'Charlie', role: 'Engineer',  val: 1.41421})
+    CREATE (e4:Employee {name: 'Diana',   role: 'Engineer',  val: 1.73205})
+    CREATE (d1:Department {name: 'Engineering', budget: 500000, val: 42.0})
+    CREATE (d2:Department {name: 'Research',    budget: 300000, val: 17.5})
+    CREATE (p1:Project {name: 'Atlas',   priority: 1, val: 99.99})
+    CREATE (p2:Project {name: 'Beacon',  priority: 2, val: 88.88})
+    CREATE (p3:Project {name: 'Cipher',  priority: 3, val: 77.77})
+    CREATE (e1)-[:WORKS_IN {since: 2019}]->(d1)
+    CREATE (e2)-[:WORKS_IN {since: 2020}]->(d1)
+    CREATE (e3)-[:WORKS_IN {since: 2021}]->(d1)
+    CREATE (e4)-[:WORKS_IN {since: 2022}]->(d2)
+    CREATE (e1)-[:MANAGES {level: 1}]->(e2)
+    CREATE (e2)-[:MANAGES {level: 2}]->(e3)
+    CREATE (e3)-[:ASSIGNED_TO {hours: 40}]->(p1)
+    CREATE (e3)-[:ASSIGNED_TO {hours: 20}]->(p2)
+    CREATE (e4)-[:ASSIGNED_TO {hours: 30}]->(p2)
+    CREATE (e4)-[:ASSIGNED_TO {hours: 10}]->(p3)
+    RETURN 'company graph created'
+$$) AS (result agtype);
+
+-- GIN index on Employee properties in company graph
+CREATE INDEX company_employee_gin ON company."Employee" USING GIN (properties);
+
+--
+-- Graph 2: "network" — social network with weighted edges.
+-- Labels: User, Post
+-- Edges: FOLLOWS, AUTHORED, LIKES
+--
+SELECT create_graph('network');
+
+SELECT * FROM cypher('network', $$
+    CREATE (u1:User {handle: '@alpha',   score: 1000.01})
+    CREATE (u2:User {handle: '@beta',    score: 2000.02})
+    CREATE (u3:User {handle: '@gamma',   score: 3000.03})
+    CREATE (u4:User {handle: '@delta',   score: 4000.04})
+    CREATE (u5:User {handle: '@epsilon', score: 5000.05})
+    CREATE (p1:Post {title: 'Hello World',        views: 150})
+    CREATE (p2:Post {title: 'Graph Databases 101', views: 890})
+    CREATE (p3:Post {title: 'AGE is awesome',      views: 2200})
+    CREATE (u1)-[:FOLLOWS {weight: 0.9}]->(u2)
+    CREATE (u2)-[:FOLLOWS {weight: 0.8}]->(u3)
+    CREATE (u3)-[:FOLLOWS {weight: 0.7}]->(u4)
+    CREATE (u4)-[:FOLLOWS {weight: 0.6}]->(u5)
+    CREATE (u5)-[:FOLLOWS {weight: 0.5}]->(u1)
+    CREATE (u1)-[:AUTHORED]->(p1)
+    CREATE (u2)-[:AUTHORED]->(p2)
+    CREATE (u3)-[:AUTHORED]->(p3)
+    CREATE (u4)-[:LIKES]->(p1)
+    CREATE (u5)-[:LIKES]->(p2)
+    CREATE (u1)-[:LIKES]->(p3)
+    CREATE (u2)-[:LIKES]->(p3)
+    RETURN 'network graph created'
+$$) AS (result agtype);
+
+-- GIN indexes on network graph
+CREATE INDEX network_user_gin ON network."User" USING GIN (properties);
+CREATE INDEX network_post_gin ON network."Post" USING GIN (properties);
+
+--
+-- Graph 3: "routes" — geographic routing with precise coordinates.
+-- Labels: City, Airport
+-- Edges: ROAD, FLIGHT
+-- Coordinates use precise decimals that are easy to checksum.
+--
+SELECT create_graph('routes');
+
+SELECT * FROM cypher('routes', $$
+    CREATE (c1:City    {name: 'Portland',   lat: 45.5152, lon: -122.6784, pop: 652503})
+    CREATE (c2:City    {name: 'Seattle',    lat: 47.6062, lon: -122.3321, pop: 749256})
+    CREATE (c3:City    {name: 'Vancouver',  lat: 49.2827, lon: -123.1207, pop: 631486})
+    CREATE (a1:Airport {code: 'PDX', elev: 30.5})
+    CREATE (a2:Airport {code: 'SEA', elev: 131.7})
+    CREATE (a3:Airport {code: 'YVR', elev: 4.3})
+    CREATE (c1)-[:ROAD    {distance_km: 279.5,  toll: 0.0}]->(c2)
+    CREATE (c2)-[:ROAD    {distance_km: 225.3,  toll: 5.0}]->(c3)
+    CREATE (c1)-[:ROAD    {distance_km: 502.1,  toll: 5.0}]->(c3)
+    CREATE (a1)-[:FLIGHT  {distance_km: 229.0, duration_min: 55}]->(a2)
+    CREATE (a2)-[:FLIGHT  {distance_km: 198.0, duration_min: 50}]->(a3)
+    CREATE (a1)-[:FLIGHT  {distance_km: 426.0, duration_min: 75}]->(a3)
+    RETURN 'routes graph created'
+$$) AS (result agtype);
+
+-- GIN index on routes graph
+CREATE INDEX routes_city_gin ON routes."City" USING GIN (properties);
+
+-- Step 5: Record pre-upgrade integrity checksums.
+-- These sums use the "val" / "score" / coordinate properties as fingerprints.
+
+-- company: sum of all val properties (should be a precise known value)
+SELECT * FROM cypher('company', $$
+    MATCH (n) WHERE n.val IS NOT NULL RETURN sum(n.val)
+$$) AS (company_val_sum_before agtype);
+
+-- network: sum of all score properties
+SELECT * FROM cypher('network', $$
+    MATCH (n:User) RETURN sum(n.score)
+$$) AS (network_score_sum_before agtype);
+
+-- routes: sum of all latitude values
+SELECT * FROM cypher('routes', $$
+    MATCH (c:City) RETURN sum(c.lat)
+$$) AS (routes_lat_sum_before agtype);
+
+-- Total vertex and edge counts across all three graphs
+SELECT sum(cnt)::int AS total_vertices_before FROM (
+    SELECT count(*) AS cnt FROM cypher('company', $$ MATCH (n) RETURN n $$) AS (n agtype)
+    UNION ALL
+    SELECT count(*) FROM cypher('network', $$ MATCH (n) RETURN n $$) AS (n agtype)
+    UNION ALL
+    SELECT count(*) FROM cypher('routes', $$ MATCH (n) RETURN n $$) AS (n agtype)
+) sub;
+
+SELECT sum(cnt)::int AS total_edges_before FROM (
+    SELECT count(*) AS cnt FROM cypher('company', $$ MATCH ()-[e]->() RETURN e $$) AS (e agtype)
+    UNION ALL
+    SELECT count(*) FROM cypher('network', $$ MATCH ()-[e]->() RETURN e $$) AS (e agtype)
+    UNION ALL
+    SELECT count(*) FROM cypher('routes', $$ MATCH ()-[e]->() RETURN e $$) AS (e agtype)
+) sub;
+
+-- Count of distinct labels (ag_label entries) across all graphs
+SELECT count(*)::int AS total_labels_before
+FROM ag_label al JOIN ag_graph ag ON al.graph = ag.graphid
+WHERE ag.name <> '_ag_catalog';
+
+-- Step 6: Upgrade AGE to the synthetic next version via the stamped template.
+DO $$
+DECLARE next_ver text;
+BEGIN
+    SELECT version INTO next_ver
+    FROM pg_available_extension_versions
+    WHERE name = 'age' AND version <> (
+        SELECT default_version FROM pg_available_extensions WHERE name = 'age'
+    )
+    ORDER BY string_to_array(version, '.')::int[] DESC
+    LIMIT 1;
+
+    IF next_ver IS NULL THEN
+        RAISE EXCEPTION 'No next version available for upgrade test';
+    END IF;
+
+    EXECUTE format('ALTER EXTENSION age UPDATE TO %L', next_ver);
+END;
+$$;
+
+-- Step 7: Confirm version changed.
+SELECT installed_version <> default_version AS upgraded_past_default
+FROM pg_available_extensions WHERE name = 'age';
+
+-- Step 8: Verify all data survived — reload and recheck.
+LOAD 'age';
+SET search_path TO ag_catalog, "$user", public;
+
+-- Repeat integrity checksums — must match pre-upgrade values exactly.
+SELECT * FROM cypher('company', $$
+    MATCH (n) WHERE n.val IS NOT NULL RETURN sum(n.val)
+$$) AS (company_val_sum_after agtype);
+
+SELECT * FROM cypher('network', $$
+    MATCH (n:User) RETURN sum(n.score)
+$$) AS (network_score_sum_after agtype);
+
+SELECT * FROM cypher('routes', $$
+    MATCH (c:City) RETURN sum(c.lat)
+$$) AS (routes_lat_sum_after agtype);
+
+SELECT sum(cnt)::int AS total_vertices_after FROM (
+    SELECT count(*) AS cnt FROM cypher('company', $$ MATCH (n) RETURN n $$) AS (n agtype)
+    UNION ALL
+    SELECT count(*) FROM cypher('network', $$ MATCH (n) RETURN n $$) AS (n agtype)
+    UNION ALL
+    SELECT count(*) FROM cypher('routes', $$ MATCH (n) RETURN n $$) AS (n agtype)
+) sub;
+
+SELECT sum(cnt)::int AS total_edges_after FROM (
+    SELECT count(*) AS cnt FROM cypher('company', $$ MATCH ()-[e]->() RETURN e $$) AS (e agtype)
+    UNION ALL
+    SELECT count(*) FROM cypher('network', $$ MATCH ()-[e]->() RETURN e $$) AS (e agtype)
+    UNION ALL
+    SELECT count(*) FROM cypher('routes', $$ MATCH ()-[e]->() RETURN e $$) AS (e agtype)
+) sub;
+
+SELECT count(*)::int AS total_labels_after
+FROM ag_label al JOIN ag_graph ag ON al.graph = ag.graphid
+WHERE ag.name <> '_ag_catalog';
+
+-- Step 9: Verify specific structural queries across all three graphs.
+
+-- company: management chain
+SELECT * FROM cypher('company', $$
+    MATCH (boss:Employee)-[:MANAGES*]->(report:Employee)
+    RETURN boss.name, report.name
+    ORDER BY boss.name, report.name
+$$) AS (boss agtype, report agtype);
+
+-- network: circular follow chain (proves full cycle survived)
+SELECT * FROM cypher('network', $$
+    MATCH (a:User)-[:FOLLOWS]->(b:User)
+    RETURN a.handle, b.handle
+    ORDER BY a.handle
+$$) AS (follower agtype, followed agtype);
+
+-- routes: all flights with distances (proves edge properties intact)
+SELECT * FROM cypher('routes', $$
+    MATCH (a:Airport)-[f:FLIGHT]->(b:Airport)
+    RETURN a.code, b.code, f.distance_km
+    ORDER BY a.code, b.code
+$$) AS (origin agtype, dest agtype, dist agtype);
+
+-- Step 10: Verify GIN indexes still exist after upgrade.
+SELECT indexname FROM pg_indexes
+WHERE schemaname IN ('company', 'network', 'routes')
+  AND tablename IN ('Employee', 'User', 'Post', 'City')
+  AND indexdef LIKE '%gin%'
+ORDER BY indexname;
+
+-- Step 11: Cleanup and restore AGE at the default version for subsequent tests.
+SELECT drop_graph('routes', true);
+SELECT drop_graph('network', true);
+SELECT drop_graph('company', true);
+DROP EXTENSION age;
+CREATE EXTENSION age;
+
+-- Step 12: Remove synthetic upgrade test files from the extension directory.
+\! sh ./regress/age_upgrade_cleanup.sh


### PR DESCRIPTION
Note: This PR was created with AI tools and a human.

Add a version-agnostic regression test (age_upgrade) that validates the upgrade template (age--<VER>--y.y.y.sql) works correctly by simulating a full extension version upgrade within "make installcheck".

Add full upgrade scripts to the install path (DATA) in the Makefile, excluding template upgrade files. This enables the install to copy all version upgrade files into the PG AGE install. This is needed for ALTER EXTENSION

Adjusted installcheck.yaml to allow git commit history for this test.

Makefile infrastructure:
- Build the install SQL (age--<CURR>.sql) from the initial version-bump commit in git history, so CREATE EXTENSION installs "day-one" SQL while the .so comes from current HEAD — implicitly testing backward compat.
- Build a synthetic "next" version (age--<NEXT>.sql) from HEAD and stamp the upgrade template to produce age--<CURR>--<NEXT>.sql.
- Add an installcheck prerequisite that temporarily installs both synthetic files into the PG extension directory; a generated cleanup script removes them at the end of the test via \! shell escape. EXTRA_CLEAN catches stragglers on "make clean".
- Skip the test automatically when: (a) no git history (tarball builds), (b) no upgrade template exists, or (c) a real upgrade script from the current version is already committed (detected via git ls-files).o

Regression test (regress/sql/age_upgrade.sql):
- Creates 3 graphs (company, network, routes) with 8 vertex labels, 8 edge labels, 23 vertices, 28 edges, and 4 GIN indexes.
- Records integrity checksums (agtype sums), vertex/edge counts, and label counts before the upgrade; repeats all checks after ALTER EXTENSION UPDATE to the synthetic next version.
- Verifies structural queries: VLE management chains, circular follow chains, flight distances with edge properties.
- Verifies all 4 GIN indexes survive the upgrade via pg_indexes.
- Uses ORDER BY on all multi-row queries for deterministic output.
- Returns agtype natively (no ::numeric casts) for portability.
- Avoids version-dependent output (checks boolean IS NOT NULL instead of printing the version string).
- Uses JOIN-based label counts to avoid NULL comparison bugs with the internal _ag_catalog graph.
- Cleans up all 3 graphs and restores the default AGE version.

modified:   Makefile
new file:   regress/expected/age_upgrade.out
new file:   regress/sql/age_upgrade.sql
modified:   .github/workflows/installcheck.yaml