### PR TITLE
Improve extension upgrade regression test (addendum to #2364)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ age_sql = age--1.7.0.sql
 #   1. Builds the install SQL from the INITIAL version-bump commit (the "from"
 #      version). This is the age--<CURR>.sql used by CREATE EXTENSION age.
 #   2. Builds the install SQL from current HEAD as a synthetic "next" version
-#      (the "to" version). This is age--<NEXT>.sql where NEXT = CURR.minor+1.
+#      (the "to" version). This is age--<NEXT>.sql where NEXT = CURR_upgrade_test.
 #   3. Stamps the upgrade template with the synthetic version, producing the
 #      upgrade script age--<CURR>--<NEXT>.sql.
 #   4. Temporarily installs both synthetic files into the PG extension directory
@@ -53,8 +53,8 @@ age_sql = age--1.7.0.sql
 AGE_CURR_VER := $(shell awk -F"'" '/default_version/ {print $$2}' age.control 2>/dev/null)
 # Git commit that last changed age.control — the "initial release" commit
 AGE_VER_COMMIT := $(shell git log -1 --format=%H -- age.control 2>/dev/null)
-# Synthetic next version: current minor + 1 (e.g., 1.7.0 -> 1.8.0)
-AGE_NEXT_VER := $(shell echo $(AGE_CURR_VER) | awk -F. '{printf "%s.%s.%s", $$1, $$2+1, $$3}')
+# Synthetic next version: current version with _upgrade_test suffix (e.g., 1.7.0 -> 1.7.0_upgrade_test)
+AGE_NEXT_VER := $(AGE_CURR_VER)_upgrade_test
 # The upgrade template file (e.g., age--1.7.0--y.y.y.sql); empty if not present
 AGE_UPGRADE_TEMPLATE := $(wildcard age--$(AGE_CURR_VER)--y.y.y.sql)
 
@@ -296,7 +296,7 @@ ifneq ($(AGE_HAS_UPGRADE_TEST),)
 _install_upgrade_test_files: $(age_next_sql) $(age_upgrade_test_sql)  ## Build, install synthetic files, generate cleanup script
 	@echo "Installing upgrade test files to $(SHAREDIR)/extension/"
 	@$(INSTALL_DATA) $(age_next_sql) $(age_upgrade_test_sql) '$(SHAREDIR)/extension/'
-	@printf '#!/bin/sh\nrm -f "$(SHAREDIR)/extension/$(age_next_sql)" "$(SHAREDIR)/extension/$(age_upgrade_test_sql)"\n' > $(ag_regress_dir)/age_upgrade_cleanup.sh
+	@printf '#!/bin/sh\nrm -f "$(SHAREDIR)/extension/$(age_next_sql)" "$(SHAREDIR)/extension/$(age_upgrade_test_sql)"\nrm -f "$(age_next_sql)" "$(age_upgrade_test_sql)" "$(ag_regress_dir)/age_upgrade_cleanup.sh"\n' > $(ag_regress_dir)/age_upgrade_cleanup.sh
 	@chmod +x $(ag_regress_dir)/age_upgrade_cleanup.sh
 
 installcheck: _install_upgrade_test_files

--- a/regress/expected/age_upgrade.out
+++ b/regress/expected/age_upgrade.out
@@ -254,12 +254,9 @@ DECLARE next_ver text;
 BEGIN
     SELECT version INTO next_ver
     FROM pg_available_extension_versions
-    WHERE name = 'age' AND version <> (
-        SELECT default_version FROM pg_available_extensions WHERE name = 'age'
-    )
-    ORDER BY string_to_array(version, '.')::int[] DESC
+    WHERE name = 'age' AND version LIKE '%_upgrade_test'
+    ORDER BY version DESC
     LIMIT 1;
-
     IF next_ver IS NULL THEN
         RAISE EXCEPTION 'No next version available for upgrade test';
     END IF;

--- a/regress/sql/age_upgrade.sql
+++ b/regress/sql/age_upgrade.sql
@@ -200,12 +200,9 @@ DECLARE next_ver text;
 BEGIN
     SELECT version INTO next_ver
     FROM pg_available_extension_versions
-    WHERE name = 'age' AND version <> (
-        SELECT default_version FROM pg_available_extensions WHERE name = 'age'
-    )
-    ORDER BY string_to_array(version, '.')::int[] DESC
+    WHERE name = 'age' AND version LIKE '%_upgrade_test'
+    ORDER BY version DESC
     LIMIT 1;
-
     IF next_ver IS NULL THEN
         RAISE EXCEPTION 'No next version available for upgrade test';
     END IF;


### PR DESCRIPTION
Note: This PR was created with AI tools and a human.

This is an addendum to PR #2364 with three improvements.

Makefile:
- Replace awk-based synthetic version (minor+1) with an _upgrade_test suffix (e.g., 1.7.0 -> 1.7.0_upgrade_test). The awk approach produced numeric versions like 1.8.0 that could collide with real future upgrade scripts, and the ::int[] cast in the SQL version lookup fails on non-numeric version strings. The _upgrade_test suffix avoids both issues and is unambiguously synthetic.
- Extend the generated cleanup script to also remove repo-root copies of the synthetic files and to self-delete, preventing stale artifacts from accumulating across repeated test runs.

Regression test (regress/sql/age_upgrade.sql):
- Simplify version lookup to directly select the _upgrade_test version via LIKE '%_upgrade_test' instead of picking the highest non-default version with string_to_array(version, '.')::int[] DESC. The old approach would fail with a cast error on the _upgrade_test suffix and was unnecessarily indirect — the test knows exactly what synthetic version the Makefile installed.

modified:   Makefile
modified:   regress/expected/age_upgrade.out
modified:   regress/sql/age_upgrade.sql