### PR TITLE
Add missing include for PR: Add index scan (#2351)

### DIFF
--- a/src/backend/utils/adt/age_global_graph.c
+++ b/src/backend/utils/adt/age_global_graph.c
@@ -27,6 +27,7 @@
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 #include "utils/snapmgr.h"
+#include "utils/builtins.h"
 
 #include "utils/age_global_graph.h"
 #include "catalog/ag_graph.h"


### PR DESCRIPTION
The CI build did not fail the PR (we need to verify why and correct it) due to the missing include -

src/backend/utils/adt/age_global_graph.c:273:25: error: implicit declaration of function ‘namestrcpy’; did you mean ‘strcpy’? [-Wimplicit-function-declaration]
  273 |                         namestrcpy(lval, NameStr(*label_name_ptr));
      |                         ^~~~~~~~~~
      |                         strcpy

The build still works as the linker was able to resolve it. This PR will add it in to correct the error going forward.