### PR TITLE
Critical: fix inverted logic here

### DIFF
--- a/src/backend/utils/adt/agtype_ops.c
+++ b/src/backend/utils/adt/agtype_ops.c
@@ -2098,7 +2098,7 @@ static Datum get_agtype_path_all(FunctionCallInfo fcinfo, bool as_text)
                 char* str = NULL;
                 lindex = strtol(cur_key->val.string.val, &str, 10);
 
-                if (strcmp(str, ""))
+                if (strcmp(str, "") != 0)
                 {
                     PG_RETURN_NULL();
                 }


### PR DESCRIPTION
strcmp(str, "") returns 0 (false) when str is empty, meaning the check is inverted: it returns NULL when parsing succeeds and continues when parsing fails. This allows non-numeric strings to pass through as array indices, leading to type confusion and potentially incorrect memory access.

The strcmp logic handles most cases correctly (non-numeric strings return NULL, valid integers pass through). However, the empty string "" is accepted as a valid array index of 0: [10, 20, 30] #> '[""]' returns 10 instead of NULL. This occurs because strtol("") sets lindex=0 and str="", so strcmp("", "") returns 0, bypassing the error check.