### PR TITLE
Critical: add recursive limit to prevent resource exhaustion

### DIFF
--- a/src/backend/utils/adt/age_vle.c
+++ b/src/backend/utils/adt/age_vle.c
@@ -18,6 +18,7 @@
  */
 
 #include "postgres.h"
+#include "miscadmin.h"
 
 #include "common/hashfn.h"
 #include "funcapi.h"
@@ -25,6 +26,7 @@
 #include "utils/lsyscache.h"
 
 #include "utils/age_vle.h"
+#include "utils/ag_guc.h"
 #include "catalog/ag_graph.h"
 #include "catalog/ag_label.h"
 #include "nodes/cypher_nodes.h"
@@ -937,6 +939,7 @@ static bool dfs_find_a_path_between(VLE_local_context *vlelctx)
     ListGraphId *edge_stack = NULL;
     ListGraphId *path_stack = NULL;
     graphid end_vertex_id;
+    int max_vle_depth;
 
     Assert(vlelctx != NULL);
 
@@ -946,14 +949,18 @@ static bool dfs_find_a_path_between(VLE_local_context *vlelctx)
     path_stack = vlelctx->dfs_path_stack;
     end_vertex_id = vlelctx->veid;
 
+    max_vle_depth = age_max_vle_depth;
+
     /* while we have edges to process */
-    while (!(IS_GRAPHID_STACK_EMPTY(edge_stack)))
+    while (!(IS_GRAPHID_STACK_EMPTY(edge_stack)) && (--max_vle_depth > 0))
     {
         graphid edge_id;
         graphid next_vertex_id;
         edge_state_entry *ese = NULL;
         edge_entry *ee = NULL;
         bool found = false;
+
+        CHECK_FOR_INTERRUPTS();
 
         /* get an edge, but leave it on the stack for now */
         edge_id = PEEK_GRAPHID_STACK(edge_stack);
@@ -1066,6 +1073,7 @@ static bool dfs_find_a_path_from(VLE_local_context *vlelctx)
     ListGraphId *vertex_stack = NULL;
     ListGraphId *edge_stack = NULL;
     ListGraphId *path_stack = NULL;
+    int max_vle_depth;
 
     Assert(vlelctx != NULL);
 
@@ -1074,14 +1082,18 @@ static bool dfs_find_a_path_from(VLE_local_context *vlelctx)
     edge_stack = vlelctx->dfs_edge_stack;
     path_stack = vlelctx->dfs_path_stack;
 
+    max_vle_depth = age_max_vle_depth;
+
     /* while we have edges to process */
-    while (!(IS_GRAPHID_STACK_EMPTY(edge_stack)))
+    while (!(IS_GRAPHID_STACK_EMPTY(edge_stack)) && (--max_vle_depth > 0))
     {
         graphid edge_id;
         graphid next_vertex_id;
         edge_state_entry *ese = NULL;
         edge_entry *ee = NULL;
         bool found = false;
+
+        CHECK_FOR_INTERRUPTS();
 
         /* get an edge, but leave it on the stack for now */
         edge_id = PEEK_GRAPHID_STACK(edge_stack);

--- a/src/backend/utils/ag_guc.c
+++ b/src/backend/utils/ag_guc.c
@@ -19,10 +19,13 @@
 
 #include "postgres.h"
 
+#include <limits.h>
+
 #include "utils/guc.h"
 #include "utils/ag_guc.h"
 
 bool age_enable_containment = true;
+int  age_max_vle_depth = 1000;
 
 /*
  * Defines AGE's custom configuration parameters.
@@ -42,5 +45,19 @@ void define_config_params(void)
                              NULL,
                              NULL,
                              NULL);
+
+    DefineCustomIntVariable("age.max_vle_depth",
+                            "Limit recursion in vle detection to the given number of iterations.",
+                            NULL,
+                            &age_max_vle_depth,
+                            1000,
+                            1,
+                            INT_MAX,
+                            PGC_SUSET,
+                            0,
+                            NULL,
+                            NULL,
+                            NULL);
+
     EmitWarningsOnPlaceholders("age");
 }

--- a/src/include/utils/ag_guc.h
+++ b/src/include/utils/ag_guc.h
@@ -39,6 +39,11 @@
  */
 extern bool age_enable_containment;
 
+/*
+ * Set the maximum recursion depth for vle graph traversal.
+ */
+extern int age_max_vle_depth;
+
 void define_config_params(void);
 
 #endif


### PR DESCRIPTION
A Cypher query like MATCH (a)-[*]->(b) RETURN * explores all paths of any length, consuming unbounded memory and CPU. In VLE_FUNCTION_PATHS_ALL mode, every possible path is materialized. The DFS loops (dfs_find_a_path_between, dfs_find_a_path_from) also lack CHECK_FOR_INTERRUPTS(), making runaway queries uncancellable. When uidx_infinite is true, traversal on cyclic graphs runs indefinitely. Unbounded stack growth via push_graphid_stack() calls (lines 1006, 1134) can consume all available process memory.

In order to address this issue we add a GUC to limit the resources.  We also add CHECK_FOR_INTERRUPTS() to the call to allow the cancelation of a high-cycle graph computation.