### PR TITLE
Fix UNWIND [null] causing count() to miscount null rows (#2383)

### DIFF
--- a/age--1.7.0--y.y.y.sql
+++ b/age--1.7.0--y.y.y.sql
@@ -459,3 +459,15 @@ BEGIN
     END LOOP;
 END;
 $$;
+
+--
+-- Issue #2383: add age_unwind() for Cypher UNWIND clause. Behaves like
+-- age_unnest() but emits SQL NULL for top-level agtype JSON null elements
+-- so null-strict operators (count, IS NULL) match Neo4j/openCypher.
+--
+CREATE FUNCTION ag_catalog.age_unwind(agtype)
+    RETURNS SETOF agtype
+LANGUAGE c
+IMMUTABLE
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';

--- a/regress/expected/cypher_unwind.out
+++ b/regress/expected/cypher_unwind.out
@@ -260,6 +260,83 @@ $$) as (i agtype);
 (1 row)
 
 --
+-- Issue 2383: UNWIND over a list containing JSON null must produce an
+-- SQL NULL row so that null-strict operators (count, IS NULL, ...) behave
+-- like they do for `WITH null AS x`.
+--
+SELECT * FROM cypher('cypher_unwind', $$
+    UNWIND [null] AS x
+    RETURN count(x) AS c
+$$) as (c agtype);
+ c 
+---
+ 0
+(1 row)
+
+SELECT * FROM cypher('cypher_unwind', $$
+    UNWIND [1, null, 2, null, 3] AS x
+    RETURN count(x) AS c
+$$) as (c agtype);
+ c 
+---
+ 3
+(1 row)
+
+SELECT * FROM cypher('cypher_unwind', $$
+    UNWIND [null] AS x
+    RETURN x IS NULL AS is_null
+$$) as (is_null agtype);
+ is_null 
+---------
+ true
+(1 row)
+
+SELECT * FROM cypher('cypher_unwind', $$
+    UNWIND [1, null, 2] AS x
+    WITH x WHERE x IS NOT NULL
+    RETURN count(x) AS c
+$$) as (c agtype);
+ c 
+---
+ 2
+(1 row)
+
+-- count(*) must still see the row produced by UNWIND [null]
+SELECT * FROM cypher('cypher_unwind', $$
+    UNWIND [null] AS x
+    RETURN count(*) AS c
+$$) as (c agtype);
+ c 
+---
+ 1
+(1 row)
+
+-- only the unwound top-level element becomes SQL NULL; nested nulls
+-- stay as agtype-null inside the returned container, so the outer rows
+-- themselves are non-NULL and counted.
+SELECT * FROM cypher('cypher_unwind', $$
+    UNWIND [[null], {k: null}] AS x
+    RETURN count(x) AS c
+$$) as (c agtype);
+ c 
+---
+ 2
+(1 row)
+
+-- The unwound row value itself must be SQL NULL (not a datum wrapping
+-- agtype-null). Without this, count(x)=0 could be achieved by tricks
+-- in count() rather than by UNWIND emitting a real SQL NULL.
+SELECT x IS NULL
+FROM cypher('cypher_unwind', $$
+    UNWIND [null] AS x
+    RETURN x
+$$) as (x agtype);
+ ?column? 
+----------
+ t
+(1 row)
+
+--
 -- Clean up
 --
 SELECT drop_graph('cypher_unwind', true);

--- a/regress/sql/cypher_unwind.sql
+++ b/regress/sql/cypher_unwind.sql
@@ -149,6 +149,57 @@ SELECT * FROM cypher('cypher_unwind', $$
 $$) as (i agtype);
 
 --
+-- Issue 2383: UNWIND over a list containing JSON null must produce an
+-- SQL NULL row so that null-strict operators (count, IS NULL, ...) behave
+-- like they do for `WITH null AS x`.
+--
+
+SELECT * FROM cypher('cypher_unwind', $$
+    UNWIND [null] AS x
+    RETURN count(x) AS c
+$$) as (c agtype);
+
+SELECT * FROM cypher('cypher_unwind', $$
+    UNWIND [1, null, 2, null, 3] AS x
+    RETURN count(x) AS c
+$$) as (c agtype);
+
+SELECT * FROM cypher('cypher_unwind', $$
+    UNWIND [null] AS x
+    RETURN x IS NULL AS is_null
+$$) as (is_null agtype);
+
+SELECT * FROM cypher('cypher_unwind', $$
+    UNWIND [1, null, 2] AS x
+    WITH x WHERE x IS NOT NULL
+    RETURN count(x) AS c
+$$) as (c agtype);
+
+-- count(*) must still see the row produced by UNWIND [null]
+SELECT * FROM cypher('cypher_unwind', $$
+    UNWIND [null] AS x
+    RETURN count(*) AS c
+$$) as (c agtype);
+
+-- only the unwound top-level element becomes SQL NULL; nested nulls
+-- stay as agtype-null inside the returned container, so the outer rows
+-- themselves are non-NULL and counted.
+SELECT * FROM cypher('cypher_unwind', $$
+    UNWIND [[null], {k: null}] AS x
+    RETURN count(x) AS c
+$$) as (c agtype);
+
+
+-- The unwound row value itself must be SQL NULL (not a datum wrapping
+-- agtype-null). Without this, count(x)=0 could be achieved by tricks
+-- in count() rather than by UNWIND emitting a real SQL NULL.
+SELECT x IS NULL
+FROM cypher('cypher_unwind', $$
+    UNWIND [null] AS x
+    RETURN x
+$$) as (x agtype);
+
+--
 -- Clean up
 --
 

--- a/sql/agtype_typecast.sql
+++ b/sql/agtype_typecast.sql
@@ -188,6 +188,13 @@ IMMUTABLE
 PARALLEL SAFE
 AS 'MODULE_PATHNAME';
 
+CREATE FUNCTION ag_catalog.age_unwind(agtype)
+    RETURNS SETOF agtype
+LANGUAGE c
+IMMUTABLE
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
 CREATE FUNCTION ag_catalog.age_vertex_stats(agtype, agtype)
     RETURNS agtype
     LANGUAGE c

--- a/src/backend/parser/cypher_clause.c
+++ b/src/backend/parser/cypher_clause.c
@@ -1443,8 +1443,8 @@ static Query *transform_cypher_delete(cypher_parsestate *cpstate,
 /*
  * transform_cypher_unwind
  *      It contains logic to convert the form of an array into a row. Here, we
- *      are simply calling `age_unnest` function, and the actual transformation
- *      is handled by `age_unnest` function.
+ *      are simply calling `age_unwind` function, and the actual transformation
+ *      is handled by `age_unwind` function.
  */
 static Query *transform_cypher_unwind(cypher_parsestate *cpstate,
                                       cypher_clause *clause)
@@ -1501,7 +1501,7 @@ static Query *transform_cypher_unwind(cypher_parsestate *cpstate,
                 parser_errposition(pstate, self->target->location));
     }
 
-    unwind = makeFuncCall(list_make1(makeString("age_unnest")), NIL,
+    unwind = makeFuncCall(list_make1(makeString("age_unwind")), NIL,
                           COERCE_SQL_SYNTAX, -1);
 
     old_expr_kind = pstate->p_expr_kind;

--- a/src/backend/utils/adt/agtype.c
+++ b/src/backend/utils/adt/agtype.c
@@ -12450,6 +12450,109 @@ Datum age_unnest(PG_FUNCTION_ARGS)
     PG_RETURN_NULL();
 }
 
+PG_FUNCTION_INFO_V1(age_unwind);
+/*
+ * Function to convert an agtype array into a set of rows for the Cypher
+ * `UNWIND` clause. Behaves like age_unnest() but, per Neo4j/openCypher
+ * semantics, emits an SQL NULL row for each top-level element that is an
+ * agtype JSON null (AGTV_NULL). This lets null-strict operators such as
+ * count(x) and IS NULL treat `UNWIND [null] AS x` the same as
+ * `WITH null AS x`. Nested nulls inside arrays/objects are preserved as
+ * agtype-null so container semantics are unchanged. See issue #2383.
+ */
+Datum age_unwind(PG_FUNCTION_ARGS)
+{
+    agtype *agtype_arg = NULL;
+    ReturnSetInfo *rsi;
+    Tuplestorestate *tuple_store;
+    TupleDesc tupdesc;
+    TupleDesc ret_tdesc;
+    MemoryContext old_cxt, tmp_cxt;
+    bool skipNested = false;
+    agtype_iterator *it;
+    agtype_value v;
+    agtype_iterator_token r;
+
+    /* check for a NULL expr */
+    if (PG_ARGISNULL(0))
+    {
+        PG_RETURN_NULL();
+    }
+
+    agtype_arg = AG_GET_ARG_AGTYPE_P(0);
+    if (!AGT_ROOT_IS_ARRAY(agtype_arg))
+    {
+        ereport(ERROR,
+                (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                        errmsg("cannot extract elements from a non-array")));
+    }
+
+    rsi = (ReturnSetInfo *) fcinfo->resultinfo;
+
+    rsi->returnMode = SFRM_Materialize;
+
+    /* it's a simple type, so don't use get_call_result_type() */
+    tupdesc = rsi->expectedDesc;
+
+    old_cxt = MemoryContextSwitchTo(rsi->econtext->ecxt_per_query_memory);
+
+    ret_tdesc = CreateTupleDescCopy(tupdesc);
+    BlessTupleDesc(ret_tdesc);
+    tuple_store =
+            tuplestore_begin_heap(rsi->allowedModes & SFRM_Materialize_Random,
+                                  false, work_mem);
+
+    MemoryContextSwitchTo(old_cxt);
+
+    tmp_cxt = AllocSetContextCreate(CurrentMemoryContext,
+                                    "age_unwind temporary cxt",
+                                    ALLOCSET_DEFAULT_SIZES);
+
+    it = agtype_iterator_init(&agtype_arg->root);
+
+    while ((r = agtype_iterator_next(&it, &v, skipNested)) != WAGT_DONE)
+    {
+        skipNested = true;
+
+        if (r == WAGT_ELEM)
+        {
+            HeapTuple tuple;
+            Datum values[1] = {(Datum) 0};
+            bool nulls[1] = {false};
+
+            /* use the tmp context so we can clean up after each tuple is done */
+            old_cxt = MemoryContextSwitchTo(tmp_cxt);
+
+            if (v.type == AGTV_NULL)
+            {
+                /* emit SQL NULL for agtype JSON null (issue #2383) */
+                nulls[0] = true;
+            }
+            else
+            {
+                agtype *val = agtype_value_to_agtype(&v);
+
+                values[0] = PointerGetDatum(val);
+            }
+
+            tuple = heap_form_tuple(ret_tdesc, values, nulls);
+
+            tuplestore_puttuple(tuple_store, tuple);
+
+            /* clean up and switch back (mirror age_unnest's pattern) */
+            MemoryContextSwitchTo(old_cxt);
+            MemoryContextReset(tmp_cxt);
+        }
+    }
+
+    MemoryContextDelete(tmp_cxt);
+
+    rsi->setResult = tuple_store;
+    rsi->setDesc = ret_tdesc;
+
+    PG_RETURN_NULL();
+}
+
 /*
  * Volatile wrapper replacement. The previous version was PL/SQL
  * and could only handle AGTYPE input and returned AGTYPE output.


### PR DESCRIPTION
Fixes #2383.

## Problem

Per Neo4j / openCypher semantics, `count()` must ignore nulls. On Apache AGE:

```cypher
UNWIND [null] AS x RETURN count(x)   -- returns 1 (buggy), should be 0
```

The control cases already returned the correct `0`:

```cypher
RETURN count(null)
WITH null AS x RETURN count(x)
```

## Root cause

`age_unnest()` in `src/backend/utils/adt/agtype.c` materialized every top-level array element into a heap tuple with `nulls[0] = false`, even when the element's `agtype_value.type == AGTV_NULL`. The row that reached `count()` therefore carried a non-NULL datum wrapping an agtype JSON null, so the aggregate's strict null check never skipped it.

## Fix

A naïve fix inside `age_unnest()` breaks other callers. `construct_age_function_name()` in `src/backend/parser/cypher_expr.c` rewrites `unnest` → `age_unnest`, so list comprehensions and the predicate functions (`all` / `any` / `none` / `single`) also route through `age_unnest`. Those callers deliberately rely on the quirk that AGE's `agtype_null > agtype_integer` evaluates to `agtype_null` (truthy), not SQL NULL. Changing the SRF broke five `predicate_functions` expected results.

Introduce a dedicated SRF `age_unwind()` with UNWIND-specific null semantics:

- Top-level `AGTV_NULL` elements → SQL NULL rows so null-strict operators (`count`, `IS NULL`, `WHERE x IS NOT NULL`, …) match `WITH null AS x`.
- Non-null elements are returned unchanged.
- Nested nulls inside arrays/objects are preserved as agtype-null.

`transform_cypher_unwind()` is the only call site changed from `age_unnest` to `age_unwind`. List comprehensions and predicate functions continue to use `age_unnest` and their behavior is untouched.

## Before / after

```text
-- before
UNWIND [null] AS x RETURN count(x)                  -- 1
UNWIND [1, null, 2, null, 3] AS x RETURN count(x)   -- 5
UNWIND [null] AS x RETURN x IS NULL                 -- false

-- after
UNWIND [null] AS x RETURN count(x)                  -- 0 ✓
UNWIND [1, null, 2, null, 3] AS x RETURN count(x)   -- 3 ✓
UNWIND [null] AS x RETURN x IS NULL                 -- true ✓
```

## Regression tests (`regress/sql/cypher_unwind.sql`)

- `UNWIND [null] RETURN count(x) = 0`
- `UNWIND [1, null, 2, null, 3] RETURN count(x) = 3`
- `UNWIND [null] RETURN x IS NULL`
- `UNWIND [1, null, 2] WITH x WHERE x IS NOT NULL RETURN count(x) = 2`
- `UNWIND [null] RETURN count(*) = 1` (row still produced)
- `UNWIND [[null], {k: null}] RETURN count(x) = 2` (nested nulls preserved)
- `UNWIND [null] RETURN x` — asserts the row value itself is SQL NULL

## Files changed

- `src/backend/utils/adt/agtype.c` — new `age_unwind` SRF
- `src/backend/parser/cypher_clause.c` — UNWIND calls `age_unwind`
- `sql/agtype_typecast.sql` — declare `age_unwind`
- `age--1.7.0--y.y.y.sql` — add `age_unwind` for in-place upgrades
- `regress/sql/cypher_unwind.sql` + `regress/expected/cypher_unwind.out`

## Test results

`make installcheck` with PostgreSQL 18 on Ubuntu 24.04:

- **32/33 tests pass.**
- `age_upgrade` fails identically on `apache/age` master `HEAD` (pre-existing, unrelated; same `age_prepare_pg_upgrade already exists` error).
- `cypher_unwind`, `predicate_functions`, `list_comprehension` all pass.