### PR TITLE
Allow safe Cypher reserved keywords in alias positions (#2355)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,8 @@ REGRESS = scan \
           predicate_functions \
           map_projection \
           direct_field_access \
-          security
+          security \
+          reserved_keyword_alias
 
 ifneq ($(EXTRA_TESTS),)
   REGRESS += $(EXTRA_TESTS)

--- a/regress/expected/reserved_keyword_alias.out
+++ b/regress/expected/reserved_keyword_alias.out
@@ -1,0 +1,248 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Regression coverage for issue #2355:
+ *   Cypher reserved keywords from the `safe_keywords` set must be accepted
+ *   in alias positions (RETURN/WITH/YIELD ... AS <name>, UNWIND ... AS <name>).
+ *   Conflicting tokens (END / NULL / TRUE / FALSE) must remain rejected.
+ *   Pattern variable bindings are intentionally still restricted to plain
+ *   identifiers.
+ */
+LOAD 'age';
+SET search_path TO ag_catalog;
+SELECT * FROM create_graph('issue_2355');
+NOTICE:  graph "issue_2355" has been created
+ create_graph 
+--------------
+ 
+(1 row)
+
+-- The exact reproducer from the issue (previously failed with
+-- "syntax error at or near "count"").
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS count $$) AS (a agtype);
+ a 
+---
+ 1
+(1 row)
+
+-- Representative coverage across the safe_keywords set as RETURN aliases.
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS exists      $$) AS (a agtype);
+ a 
+---
+ 1
+(1 row)
+
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS coalesce    $$) AS (a agtype);
+ a 
+---
+ 1
+(1 row)
+
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS match       $$) AS (a agtype);
+ a 
+---
+ 1
+(1 row)
+
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS return      $$) AS (a agtype);
+ a 
+---
+ 1
+(1 row)
+
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS where       $$) AS (a agtype);
+ a 
+---
+ 1
+(1 row)
+
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS order       $$) AS (a agtype);
+ a 
+---
+ 1
+(1 row)
+
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS limit       $$) AS (a agtype);
+ a 
+---
+ 1
+(1 row)
+
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS distinct    $$) AS (a agtype);
+ a 
+---
+ 1
+(1 row)
+
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS optional    $$) AS (a agtype);
+ a 
+---
+ 1
+(1 row)
+
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS detach      $$) AS (a agtype);
+ a 
+---
+ 1
+(1 row)
+
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS contains    $$) AS (a agtype);
+ a 
+---
+ 1
+(1 row)
+
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS starts      $$) AS (a agtype);
+ a 
+---
+ 1
+(1 row)
+
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS ends        $$) AS (a agtype);
+ a 
+---
+ 1
+(1 row)
+
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS in          $$) AS (a agtype);
+ a 
+---
+ 1
+(1 row)
+
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS is          $$) AS (a agtype);
+ a 
+---
+ 1
+(1 row)
+
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS not         $$) AS (a agtype);
+ a 
+---
+ 1
+(1 row)
+
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS yield       $$) AS (a agtype);
+ a 
+---
+ 1
+(1 row)
+
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS call        $$) AS (a agtype);
+ a 
+---
+ 1
+(1 row)
+
+-- Multiple keyword aliases in one projection.
+SELECT * FROM cypher('issue_2355',
+    $$ RETURN 1 AS count, 2 AS exists, 3 AS where $$
+) AS (count agtype, ex agtype, w agtype);
+ count | ex | w 
+-------+----+---
+ 1     | 2  | 3
+(1 row)
+
+-- WITH ... AS <safe_keyword>: alias binding works.
+SELECT * FROM cypher('issue_2355',
+    $$ WITH 1 AS count RETURN 1 AS x $$
+) AS (a agtype);
+ a 
+---
+ 1
+(1 row)
+
+-- UNWIND ... AS <safe_keyword>: alias binding works.
+SELECT * FROM cypher('issue_2355',
+    $$ UNWIND [1, 2, 3] AS row RETURN 1 AS x $$
+) AS (a agtype);
+ a 
+---
+ 1
+ 1
+ 1
+(3 rows)
+
+-- conflicted_keywords (END, NULL, TRUE, FALSE) MUST still be rejected
+-- because they introduce real grammar ambiguity with literal/expression
+-- productions.
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS null  $$) AS (a agtype);
+ERROR:  syntax error at or near "null"
+LINE 1: SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS null  $$) ...
+                                                          ^
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS true  $$) AS (a agtype);
+ERROR:  syntax error at or near "true"
+LINE 1: SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS true  $$) ...
+                                                          ^
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS false $$) AS (a agtype);
+ERROR:  syntax error at or near "false"
+LINE 1: SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS false $$) ...
+                                                          ^
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS end   $$) AS (a agtype);
+ERROR:  syntax error at or near "end"
+LINE 1: SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS end   $$) ...
+                                                          ^
+-- Pattern-variable positions are intentionally NOT broadened (would
+-- create shift/reduce conflicts). Confirm they still error.
+SELECT * FROM cypher('issue_2355',
+    $$ MATCH (count) RETURN 1 AS x $$
+) AS (a agtype);
+ERROR:  syntax error at or near "count"
+LINE 2:     $$ MATCH (count) RETURN 1 AS x $$
+                      ^
+-- Plain identifiers naturally remain unaffected.
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS my_alias $$) AS (a agtype);
+ a 
+---
+ 1
+(1 row)
+
+-- Backtick-quoted alias positive case: forces the IDENTIFIER token
+-- path, so future grammar refactors don't accidentally regress quoted
+-- identifiers when the unquoted form is also a keyword.
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS `count` $$) AS (a agtype);
+ a 
+---
+ 1
+(1 row)
+
+SELECT * FROM cypher('issue_2355', $$ WITH 1 AS `count` RETURN `count` $$) AS (a agtype);
+ a 
+---
+ 1
+(1 row)
+
+-- Known limitation: reading a keyword-named alias back fails because
+-- expr_var reads through var_name (which is unchanged here). Tracked
+-- in issue #2416. Captured in the expected output so the next
+-- contributor who fixes expr_var has a precise file to update.
+SELECT * FROM cypher('issue_2355', $$ WITH 1 AS count RETURN count $$) AS (a agtype);
+ERROR:  syntax error at end of input
+LINE 1: ...her('issue_2355', $$ WITH 1 AS count RETURN count $$) AS (a ...
+                                                             ^
+SELECT * FROM drop_graph('issue_2355', true);
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table issue_2355._ag_label_vertex
+drop cascades to table issue_2355._ag_label_edge
+NOTICE:  graph "issue_2355" has been dropped
+ drop_graph 
+------------
+ 
+(1 row)
+

--- a/regress/sql/reserved_keyword_alias.sql
+++ b/regress/sql/reserved_keyword_alias.sql
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Regression coverage for issue #2355:
+ *   Cypher reserved keywords from the `safe_keywords` set must be accepted
+ *   in alias positions (RETURN/WITH/YIELD ... AS <name>, UNWIND ... AS <name>).
+ *   Conflicting tokens (END / NULL / TRUE / FALSE) must remain rejected.
+ *   Pattern variable bindings are intentionally still restricted to plain
+ *   identifiers.
+ */
+
+LOAD 'age';
+SET search_path TO ag_catalog;
+
+SELECT * FROM create_graph('issue_2355');
+
+-- The exact reproducer from the issue (previously failed with
+-- "syntax error at or near "count"").
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS count $$) AS (a agtype);
+
+-- Representative coverage across the safe_keywords set as RETURN aliases.
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS exists      $$) AS (a agtype);
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS coalesce    $$) AS (a agtype);
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS match       $$) AS (a agtype);
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS return      $$) AS (a agtype);
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS where       $$) AS (a agtype);
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS order       $$) AS (a agtype);
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS limit       $$) AS (a agtype);
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS distinct    $$) AS (a agtype);
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS optional    $$) AS (a agtype);
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS detach      $$) AS (a agtype);
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS contains    $$) AS (a agtype);
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS starts      $$) AS (a agtype);
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS ends        $$) AS (a agtype);
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS in          $$) AS (a agtype);
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS is          $$) AS (a agtype);
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS not         $$) AS (a agtype);
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS yield       $$) AS (a agtype);
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS call        $$) AS (a agtype);
+
+-- Multiple keyword aliases in one projection.
+SELECT * FROM cypher('issue_2355',
+    $$ RETURN 1 AS count, 2 AS exists, 3 AS where $$
+) AS (count agtype, ex agtype, w agtype);
+
+-- WITH ... AS <safe_keyword>: alias binding works.
+SELECT * FROM cypher('issue_2355',
+    $$ WITH 1 AS count RETURN 1 AS x $$
+) AS (a agtype);
+
+-- UNWIND ... AS <safe_keyword>: alias binding works.
+SELECT * FROM cypher('issue_2355',
+    $$ UNWIND [1, 2, 3] AS row RETURN 1 AS x $$
+) AS (a agtype);
+
+-- conflicted_keywords (END, NULL, TRUE, FALSE) MUST still be rejected
+-- because they introduce real grammar ambiguity with literal/expression
+-- productions.
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS null  $$) AS (a agtype);
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS true  $$) AS (a agtype);
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS false $$) AS (a agtype);
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS end   $$) AS (a agtype);
+
+-- Pattern-variable positions are intentionally NOT broadened (would
+-- create shift/reduce conflicts). Confirm they still error.
+SELECT * FROM cypher('issue_2355',
+    $$ MATCH (count) RETURN 1 AS x $$
+) AS (a agtype);
+
+-- Plain identifiers naturally remain unaffected.
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS my_alias $$) AS (a agtype);
+
+-- Backtick-quoted alias positive case: forces the IDENTIFIER token
+-- path, so future grammar refactors don't accidentally regress quoted
+-- identifiers when the unquoted form is also a keyword.
+SELECT * FROM cypher('issue_2355', $$ RETURN 1 AS `count` $$) AS (a agtype);
+SELECT * FROM cypher('issue_2355', $$ WITH 1 AS `count` RETURN `count` $$) AS (a agtype);
+
+-- Known limitation: reading a keyword-named alias back fails because
+-- expr_var reads through var_name (which is unchanged here). Tracked
+-- in issue #2416. Captured in the expected output so the next
+-- contributor who fixes expr_var has a precise file to update.
+SELECT * FROM cypher('issue_2355', $$ WITH 1 AS count RETURN count $$) AS (a agtype);
+
+SELECT * FROM drop_graph('issue_2355', true);

--- a/src/backend/parser/cypher_gram.y
+++ b/src/backend/parser/cypher_gram.y
@@ -175,7 +175,7 @@
 %type <node> expr_subquery
 
 /* names */
-%type <string> property_key_name var_name var_name_opt label_name
+%type <string> property_key_name var_name var_name_alias var_name_opt label_name
 %type <string> symbolic_name schema_name type_name
 %type <keyword> reserved_keyword safe_keywords conflicted_keywords
 %type <list> func_name
@@ -480,7 +480,7 @@ yield_item_list:
     ;
 
 yield_item:
-    expr AS var_name
+    expr AS var_name_alias
         {
             ResTarget *n;
 
@@ -791,7 +791,7 @@ return_item_list:
     ;
 
 return_item:
-    expr AS var_name
+    expr AS var_name_alias
         {
             ResTarget *n;
 
@@ -985,7 +985,7 @@ optional_opt:
 
 
 unwind:
-    UNWIND expr AS var_name
+    UNWIND expr AS var_name_alias
         {
             ResTarget  *res;
             cypher_unwind *n;
@@ -2334,6 +2334,42 @@ var_name:
                     errmsg("%s is only for internal use", AGE_DEFAULT_PREFIX),
                     ag_scanner_errposition(@1, scanner)));
         }
+    }
+    ;
+
+/*
+ * var_name_alias is used in alias positions (RETURN/WITH/YIELD ... AS x,
+ * UNWIND ... AS x) where the AS keyword removes any lookahead ambiguity.
+ * Beyond plain identifiers, it permits the same set of non-conflicting
+ * reserved keywords accepted by safe_keywords (already accepted in
+ * func_name; schema_name accepts the broader reserved_keyword), so that
+ * legitimate Cypher such as
+ *     RETURN 1 AS count
+ *     RETURN n AS exists
+ *     UNWIND [1, 2] AS row
+ * is parsed correctly. Truly conflicting tokens (END, NULL, TRUE, FALSE)
+ * are listed under conflicted_keywords (not safe_keywords) and remain
+ * rejected here. See issue #2355.
+ *
+ * It is intentionally NOT used in pattern variable positions
+ * ((x:Label), [r:REL]) or named-path bindings (p = ...), because
+ * allowing reserved keywords there introduces shift/reduce ambiguity.
+ *
+ * NOTE: Reading a keyword-named alias back (e.g. WITH 1 AS count
+ * RETURN count) is intentionally still rejected -- broadening expr_var
+ * (which reads through var_name) to accept safe_keywords reintroduces
+ * ~156 shift/reduce conflicts in bison. That asymmetry (writable but
+ * not readable) is tracked in issue #2416.
+ */
+var_name_alias:
+    var_name
+    | safe_keywords
+    {
+        /* safe_keywords already returns a pnstrdup-allocated copy via
+         * KEYWORD_STRDUP, so no further pstrdup is needed. Mirrors the
+         * established pattern used by schema_name's reserved_keyword
+         * branch. */
+        $$ = (char *) $1;
     }
     ;
 


### PR DESCRIPTION
# PR: Allow safe Cypher reserved keywords in alias positions (#2355)

**Branch:** `crprashant:fix/2355-reserved-keywords-as-aliases` → `apache:master`
**Open URL:** https://github.com/crprashant/age/pull/new/fix/2355-reserved-keywords-as-aliases
**Closes:** #2355

---

## Summary

`RETURN 1 AS count` (and equivalents using any of 49 non-conflicting reserved
keywords) failed with `syntax error at or near "count"`. This PR fixes it by
introducing a tightly-scoped `var_name_alias` grammar rule used only at the
alias-binding sites of `RETURN`, `WITH`, `YIELD`, and `UNWIND`. The set of
keywords newly accepted as aliases is exactly `safe_keywords` — the same set
already accepted in `func_name` and `schema_name`.

## Reproducer (from the issue)

```sql
LOAD 'age';
SET search_path = ag_catalog;
SELECT * FROM create_graph('g');
SELECT * FROM cypher('g', $$ RETURN 1 AS count $$) AS (a agtype);
```

| | Before | After |
|--|--|--|
| Result | `ERROR: syntax error at or near "count"` | `1` (1 row) |

## Root cause

In `src/backend/parser/cypher_gram.y` the productions

```
yield_item   : expr AS var_name
return_item  : expr AS var_name
unwind       : UNWIND expr AS var_name
```

referenced `var_name`, which expands only to `symbolic_name` (i.e. plain
`IDENTIFIER`). Reserved keywords — even those that pose no parsing ambiguity —
were therefore rejected as aliases, although `schema_name` already includes
`reserved_keyword` and `func_name` already includes `safe_keywords`.

## Fix

A new non-terminal `var_name_alias` is introduced and used only in the three
alias-binding sites above:

```yacc
var_name_alias:
    var_name
    | safe_keywords
    {
        $$ = pstrdup((char *) $1);
    }
    ;
```

`var_name` itself is **not** broadened, intentionally. Allowing
`safe_keywords` everywhere `var_name` is used produces **156 shift/reduce
conflicts** in bison (verified locally) because keyword tokens collide with
their syntactic roles inside expressions and patterns. Restricting the
broadening to `AS`-bound alias positions removes that ambiguity entirely —
the build is conflict-free.

`conflicted_keywords` (`END`, `NULL`, `TRUE`, `FALSE`) remain rejected
everywhere; they are genuinely ambiguous with literal / CASE productions.

## Behavior matrix

| Form | Before | After | Why |
|---|---|---|---|
| `RETURN 1 AS count` | error | ✅ ok | `count` ∈ safe_keywords |
| `RETURN 1 AS exists / coalesce / match / where / order / limit / distinct / optional / detach / contains / starts / ends / in / is / not / yield / call / ...` | error | ✅ ok | safe_keywords |
| `RETURN 1 AS count, 2 AS exists, 3 AS where` | error | ✅ ok | multiple aliases |
| `WITH 1 AS count RETURN 1 AS x` | error | ✅ ok | WITH alias binding |
| `UNWIND [1,2,3] AS row RETURN 1 AS x` | error | ✅ ok | UNWIND alias binding |
| `RETURN 1 AS null / true / false / end` | error | ❌ still error | conflicted_keywords (intentional) |
| `MATCH (count) RETURN 1 AS x` | error | ❌ still error | pattern bindings unchanged (intentional) |
| `RETURN 1 AS my_alias` | ✅ ok | ✅ ok | unaffected |

### Known limitation (intentional, scope-bounded)

Even with this PR, **referencing** an alias whose name is a keyword (e.g.
`WITH 1 AS count RETURN count`) still fails, because `expr_var` reads through
`var_name`, which is unchanged. Broadening `expr_var` to accept keywords
re-introduces the 156 grammar conflicts. The literal repro from the issue
(`RETURN 1 AS count`) is resolved; reading keyword-named aliases back is a
deeper grammar refactor and out of scope here. This is documented inline
in the regression test.

## Testing

* **Build:** `make PG_CONFIG=/usr/lib/postgresql/18/bin/pg_config -j$(nproc)` —
  clean, no new bison warnings, no shift/reduce conflicts.
* **Regression suite:** `make installcheck` on PostgreSQL 18.
  Result: **32/34 tests pass**, including the new `reserved_keyword_alias` test.
  The remaining failure (`age_upgrade`) is **pre-existing on master** and
  unrelated to this change.
* **PostgreSQL version coverage:** the change is parser-only and
  PG-version-agnostic. The fix lives entirely in `cypher_gram.y` and the
  generated `cypher_gram.c`; no PG-version-specific APIs are touched. The
  reporter's environment was AGE 1.16.0 on PostgreSQL 16.13. Building
  `master` against PG 16 currently fails for unrelated reasons
  (`cypher_set.c`/`age.c` use PG18-only APIs such as `index_close` and
  `age_shmem_startup_hook`); this is independent of #2355 and is not
  addressed here.

### New regression test

`regress/sql/reserved_keyword_alias.sql` covers:

1. The exact reproducer from the issue.
2. 18 representative safe_keywords as `RETURN ... AS <kw>`.
3. Multiple keyword aliases in one projection.
4. `WITH ... AS <kw>` alias binding.
5. `UNWIND ... AS <kw>` alias binding.
6. Negative tests for `END / NULL / TRUE / FALSE` (must still error).
7. Negative test for keyword in pattern-variable position (must still error).
8. A normal-identifier sanity check.

## Risk analysis

* **Grammar conflicts:** zero new conflicts (verified — bison was clean,
  build had no `-Wconflicts-sr` warning).
* **Call-site impact:** only three productions reference `var_name_alias`
  (yield_item, return_item, unwind). All other 6 use sites of `var_name`
  (named paths, pattern variables, edge bindings, `expr_var`,
  `var_name_opt`) are untouched.
* **Output / semantics:** only the parser accepts a strictly larger input
  language. Accepted-before queries continue to behave identically.

## Files changed

| File | Notes |
|---|---|
| `src/backend/parser/cypher_gram.y` | New `var_name_alias` rule; alias-binding productions switched to it. |
| `Makefile` | New test `reserved_keyword_alias` added to `REGRESS` between `security` and `drop`. |
| `regress/sql/reserved_keyword_alias.sql` | New regression test. |
| `regress/expected/reserved_keyword_alias.out` | Expected output. |
