### PR TITLE
Fix VLE [*0..N] zero-hop self-binding when edge label is missing (#2382)

### DIFF
--- a/regress/expected/cypher_vle.out
+++ b/regress/expected/cypher_vle.out
@@ -1220,5 +1220,120 @@ NOTICE:  graph "cypher_vle" has been dropped
 (1 row)
 
 --
+-- Issue #2382: variable-length relationships with a zero lower bound must
+-- still produce the zero-hop self-binding even when the edge label does not
+-- exist in the graph (Neo4j/openCypher semantics).
+--
+SELECT create_graph('issue_2382');
+NOTICE:  graph "issue_2382" has been created
+ create_graph 
+--------------
+ 
+(1 row)
+
+SELECT * FROM cypher('issue_2382', $$
+    CREATE (:Person {name: 'Alice'})-[:KNOWS]->(:Person {name: 'Bob'})
+$$) AS (v agtype);
+ v 
+---
+(0 rows)
+
+-- Plain MATCH on a non-existent edge label with [*0..N] must return the
+-- zero-hop self-binding row (Alice -> Alice). It must NOT match arbitrary
+-- edges of other labels (e.g. KNOWS).
+SELECT * FROM cypher('issue_2382', $$
+    MATCH (p:Person {name: 'Alice'})
+    MATCH (p)-[:NOEXIST*0..1]-(f:Person)
+    RETURN p.name AS person, f.name AS friend
+$$) AS (person agtype, friend agtype);
+ person  | friend  
+---------+---------
+ "Alice" | "Alice"
+(1 row)
+
+-- OPTIONAL MATCH form (the exact shape from the issue report).
+SELECT * FROM cypher('issue_2382', $$
+    MATCH (p:Person {name: 'Alice'})
+    OPTIONAL MATCH (p)-[:NOEXIST*0..1]-(f:Person)
+    RETURN p.name AS person, f.name AS friend
+$$) AS (person agtype, friend agtype);
+ person  | friend  
+---------+---------
+ "Alice" | "Alice"
+(1 row)
+
+-- [*0..0] still emits exactly the zero-hop self-binding.
+SELECT * FROM cypher('issue_2382', $$
+    MATCH (p:Person {name: 'Alice'})
+    MATCH (p)-[:NOEXIST*0..0]-(f:Person)
+    RETURN p.name AS person, f.name AS friend
+$$) AS (person agtype, friend agtype);
+ person  | friend  
+---------+---------
+ "Alice" | "Alice"
+(1 row)
+
+-- Fixed-length (lower bound > 0) on a missing label must still return zero
+-- rows: there is no edge of that label, so the pattern is unsatisfiable.
+SELECT * FROM cypher('issue_2382', $$
+    MATCH (p:Person {name: 'Alice'})
+    MATCH (p)-[:NOEXIST*1..1]-(f:Person)
+    RETURN p.name AS person, f.name AS friend
+$$) AS (person agtype, friend agtype);
+ person | friend 
+--------+--------
+(0 rows)
+
+-- OPTIONAL MATCH on the unsatisfiable fixed-length pattern still preserves
+-- the outer row with NULL bindings.
+SELECT * FROM cypher('issue_2382', $$
+    MATCH (p:Person {name: 'Alice'})
+    OPTIONAL MATCH (p)-[:NOEXIST*1..1]-(f:Person)
+    RETURN p.name AS person, f.name AS friend
+$$) AS (person agtype, friend agtype);
+ person  | friend 
+---------+--------
+ "Alice" | 
+(1 row)
+
+-- Mixed pattern: a zero-bound VLE on a missing label combined with another
+-- fixed-length missing label segment must still yield zero rows. The other
+-- segment is impossible regardless of the zero-hop case.
+SELECT * FROM cypher('issue_2382', $$
+    MATCH (a:Person {name: 'Alice'})
+    MATCH (a)-[:NOEXIST*0..1]-(b:Person)-[:STILL_MISSING]-(c:Person)
+    RETURN a.name, b.name, c.name
+$$) AS (a agtype, b agtype, c agtype);
+ a | b | c 
+---+---+---
+(0 rows)
+
+-- Sanity: zero-bound VLE on an EXISTING label still works the way it did
+-- before (Alice via zero-hop, Bob via 1-hop KNOWS).
+SELECT * FROM cypher('issue_2382', $$
+    MATCH (p:Person {name: 'Alice'})
+    MATCH (p)-[:KNOWS*0..1]-(f:Person)
+    RETURN p.name AS person, f.name AS friend
+    ORDER BY f.name
+$$) AS (person agtype, friend agtype);
+ person  | friend  
+---------+---------
+ "Alice" | "Alice"
+ "Alice" | "Bob"
+(2 rows)
+
+SELECT drop_graph('issue_2382', true);
+NOTICE:  drop cascades to 4 other objects
+DETAIL:  drop cascades to table issue_2382._ag_label_vertex
+drop cascades to table issue_2382._ag_label_edge
+drop cascades to table issue_2382."Person"
+drop cascades to table issue_2382."KNOWS"
+NOTICE:  graph "issue_2382" has been dropped
+ drop_graph 
+------------
+ 
+(1 row)
+
+--
 -- End
 --

--- a/regress/sql/cypher_vle.sql
+++ b/regress/sql/cypher_vle.sql
@@ -417,6 +417,75 @@ SELECT drop_graph('issue_2092', true);
 DROP TABLE start_and_end_points;
 
 SELECT drop_graph('cypher_vle', true);
+--
+-- Issue #2382: variable-length relationships with a zero lower bound must
+-- still produce the zero-hop self-binding even when the edge label does not
+-- exist in the graph (Neo4j/openCypher semantics).
+--
+SELECT create_graph('issue_2382');
+
+SELECT * FROM cypher('issue_2382', $$
+    CREATE (:Person {name: 'Alice'})-[:KNOWS]->(:Person {name: 'Bob'})
+$$) AS (v agtype);
+
+-- Plain MATCH on a non-existent edge label with [*0..N] must return the
+-- zero-hop self-binding row (Alice -> Alice). It must NOT match arbitrary
+-- edges of other labels (e.g. KNOWS).
+SELECT * FROM cypher('issue_2382', $$
+    MATCH (p:Person {name: 'Alice'})
+    MATCH (p)-[:NOEXIST*0..1]-(f:Person)
+    RETURN p.name AS person, f.name AS friend
+$$) AS (person agtype, friend agtype);
+
+-- OPTIONAL MATCH form (the exact shape from the issue report).
+SELECT * FROM cypher('issue_2382', $$
+    MATCH (p:Person {name: 'Alice'})
+    OPTIONAL MATCH (p)-[:NOEXIST*0..1]-(f:Person)
+    RETURN p.name AS person, f.name AS friend
+$$) AS (person agtype, friend agtype);
+
+-- [*0..0] still emits exactly the zero-hop self-binding.
+SELECT * FROM cypher('issue_2382', $$
+    MATCH (p:Person {name: 'Alice'})
+    MATCH (p)-[:NOEXIST*0..0]-(f:Person)
+    RETURN p.name AS person, f.name AS friend
+$$) AS (person agtype, friend agtype);
+
+-- Fixed-length (lower bound > 0) on a missing label must still return zero
+-- rows: there is no edge of that label, so the pattern is unsatisfiable.
+SELECT * FROM cypher('issue_2382', $$
+    MATCH (p:Person {name: 'Alice'})
+    MATCH (p)-[:NOEXIST*1..1]-(f:Person)
+    RETURN p.name AS person, f.name AS friend
+$$) AS (person agtype, friend agtype);
+
+-- OPTIONAL MATCH on the unsatisfiable fixed-length pattern still preserves
+-- the outer row with NULL bindings.
+SELECT * FROM cypher('issue_2382', $$
+    MATCH (p:Person {name: 'Alice'})
+    OPTIONAL MATCH (p)-[:NOEXIST*1..1]-(f:Person)
+    RETURN p.name AS person, f.name AS friend
+$$) AS (person agtype, friend agtype);
+
+-- Mixed pattern: a zero-bound VLE on a missing label combined with another
+-- fixed-length missing label segment must still yield zero rows. The other
+-- segment is impossible regardless of the zero-hop case.
+SELECT * FROM cypher('issue_2382', $$
+    MATCH (a:Person {name: 'Alice'})
+    MATCH (a)-[:NOEXIST*0..1]-(b:Person)-[:STILL_MISSING]-(c:Person)
+    RETURN a.name, b.name, c.name
+$$) AS (a agtype, b agtype, c agtype);
+
+-- Sanity: zero-bound VLE on an EXISTING label still works the way it did
+-- before (Alice via zero-hop, Bob via 1-hop KNOWS).
+SELECT * FROM cypher('issue_2382', $$
+    MATCH (p:Person {name: 'Alice'})
+    MATCH (p)-[:KNOWS*0..1]-(f:Person)
+    RETURN p.name AS person, f.name AS friend
+    ORDER BY f.name
+$$) AS (person agtype, friend agtype);
+
+SELECT drop_graph('issue_2382', true);
 
 --
 -- End

--- a/src/backend/parser/cypher_clause.c
+++ b/src/backend/parser/cypher_clause.c
@@ -132,6 +132,60 @@ static Expr *transform_cypher_edge(cypher_parsestate *cpstate,
 static Expr *transform_cypher_node(cypher_parsestate *cpstate,
                                    cypher_node *node, List **target_list,
                                    bool output_node, bool valid_label);
+/*
+ * Issue #2382: For variable-length relationships with a lower bound of 0
+ * (e.g., [:LABEL*0..N]), the zero-hop self-binding case must succeed even
+ * when LABEL is missing from the cache, because Neo4j/openCypher semantics
+ * say a zero-hop pattern matches the same node regardless of any edges.
+ *
+ * By the time match_check_valid_label() runs, build_VLE_relation() (in
+ * cypher_gram.y) has rewritten cypher_relationship.varlen from A_Indices
+ * into a FuncCall named "vle" whose argument list is:
+ *   (start_id, end_id, edge_match_proto, lidx, uidx, dir, unique_id)
+ * so the lower-bound is the 4th argument (1-based).
+ *
+ * This helper is intentionally defensive: every assumption about the shape
+ * of the FuncCall is guarded so any parser refactor that changes it will
+ * fall back to "not zero-bound", which is the safe behaviour (the existing
+ * false-where short-circuit will still kick in for impossible patterns).
+ */
+static bool is_zero_lower_bound_vle(Node *varlen)
+{
+    FuncCall *fc;
+    String *fname;
+    Node *lidx_node;
+    A_Const *lidx;
+
+    if (varlen == NULL || !IsA(varlen, FuncCall))
+        return false;
+
+    fc = (FuncCall *) varlen;
+
+    if (list_length(fc->funcname) != 1)
+        return false;
+    fname = (String *) linitial(fc->funcname);
+    if (fname == NULL || !IsA(fname, String))
+        return false;
+    if (strcmp(strVal(fname), "vle") != 0)
+        return false;
+
+    /* args = {start, end, edge_match, lidx, uidx, dir, uniq} */
+    if (list_length(fc->args) < 5)
+        return false;
+
+    lidx_node = (Node *) list_nth(fc->args, 3);
+    if (lidx_node == NULL || !IsA(lidx_node, A_Const))
+        return false;
+
+    lidx = (A_Const *) lidx_node;
+    if (lidx->isnull)
+        return false;
+    if (lidx->val.ival.type != T_Integer)
+        return false;
+
+    return lidx->val.ival.ival == 0;
+}
+
 static bool match_check_valid_label(cypher_match *match,
                                     cypher_parsestate *cpstate);
 static Node *make_vertex_expr(cypher_parsestate *cpstate,
@@ -2927,7 +2981,14 @@ static bool match_check_valid_label(cypher_match *match,
 
                     if (lcd == NULL || lcd->kind != LABEL_KIND_EDGE)
                     {
-                        return false;
+                        /*
+                         * Issue #2382: a missing edge label is fatal only if
+                         * the pattern actually requires an edge of that label.
+                         * For VLE with lower bound 0, the zero-hop self-bind
+                         * case must still produce rows.
+                         */
+                        if (!is_zero_lower_bound_vle(rel->varlen))
+                            return false;
                     }
                 }
             }
@@ -5047,7 +5108,15 @@ static bool path_check_valid_label(cypher_path *path,
 
                 if (lcd == NULL || lcd->kind != LABEL_KIND_EDGE)
                 {
-                    return false;
+                    /*
+                     * Issue #2382: Don't invalidate the whole path just
+                     * because a VLE edge with lower bound 0 references a
+                     * missing label. The zero-hop self-binding semantics
+                     * still allow the surrounding nodes to bind, so the
+                     * other vertex labels in this path must be honoured.
+                     */
+                    if (!is_zero_lower_bound_vle(rel->varlen))
+                        return false;
                 }
             }
         }

--- a/src/backend/utils/adt/age_vle.c
+++ b/src/backend/utils/adt/age_vle.c
@@ -418,6 +418,20 @@ static bool is_an_edge_match(VLE_local_context *vlelctx, edge_entry *ee)
     num_edge_property_constraints = AGT_ROOT_COUNT(vlelctx->edge_property_constraint);
 
     /*
+     * Issue #2382: If the user asked for a specific edge label but that label
+     * does not exist in the graph (edge_label_name_oid == InvalidOid while
+     * edge_label_name is non-NULL), no real edge can match. Returning false
+     * here ensures that for VLE patterns like [:NOEXIST*0..N] we do not
+     * traverse arbitrary other-label edges. Zero-hop self-binding is handled
+     * separately via build_VLE_zero_container() so this does not break it.
+     */
+    if (vlelctx->edge_label_name != NULL &&
+        vlelctx->edge_label_name_oid == InvalidOid)
+    {
+        return false;
+    }
+
+    /*
      * We only care about verifying that we have all of the property conditions.
      * We don't care about extra unmatched properties. If there aren't any edge
      * constraints, then the edge passes by default.


### PR DESCRIPTION
## Summary

Fixes [#2382](https://github.com/apache/age/issues/2382): variable-length relationship patterns with a zero lower bound (`[*0..N]`) failed to produce the zero-hop self-binding when the edge label did not exist in the graph.

Per Neo4j/openCypher semantics, a pattern like `(p)-[:FRIEND*0..1]-(f)` must always include the zero-length match where `f` binds to the same node as `p`, regardless of whether any `FRIEND` edge exists. Apache AGE was treating any missing edge label as fatal for the entire MATCH.

### Repro (before this PR)

```sql
SELECT * FROM cypher('fuzz_graph', $$ CREATE (:Person {name:'Alice'}) $$) AS (v agtype);

SELECT * FROM cypher('fuzz_graph', $$
  MATCH (p:Person {name: 'Alice'})
  OPTIONAL MATCH (p)-[:FRIEND*0..1]-(f:Person)
  RETURN p.name AS person, f.name AS friend
$$) AS (person agtype, friend agtype);

-- Before:  Alice | NULL
-- After:   Alice | Alice   (matches Neo4j)
```

### Root cause

Two separate label-validity gates short-circuited the MATCH when an edge label was not in the cache:

- `match_check_valid_label()` injected a `WHERE false` (or volatile equivalent) at the MATCH level.
- `path_check_valid_label()` made the planner emit `NULL::agtype` constants in place of vertex bindings even when the vertex labels themselves were valid.

Neither check distinguished fixed-length patterns (which legitimately require an edge of the label) from VLE patterns with a lower bound of 0 (which don't).

There was also a latent runtime bug in `is_an_edge_match()`: when the user requested a label that did not exist, the InvalidOid check fell through the existing "no constraints → match all" fast-path. Once the parser-side gate was relaxed, `[:NOEXIST*0..N]` would have begun traversing arbitrary other-label edges. This PR fixes that path too so the zero-hop case is the only thing that matches.

### Fix

1. **`src/backend/parser/cypher_clause.c`** — new helper `is_zero_lower_bound_vle()` that defensively inspects the `vle()` FuncCall built by `build_VLE_relation()` (in `cypher_gram.y`). Both `match_check_valid_label()` and `path_check_valid_label()` use it to skip the false-where short-circuit only for relationships that are zero-bound VLEs. Mixed patterns where another segment is genuinely unsatisfiable still short-circuit correctly.
2. **`src/backend/utils/adt/age_vle.c`** — `is_an_edge_match()` returns false early when the requested label does not exist. The zero-hop self-binding is generated by `build_VLE_zero_container()` and never calls `is_an_edge_match()`, so this fix does not affect the zero-hop semantics.
3. **`regress/sql/cypher_vle.sql`** — seven regression cases:
   - plain MATCH `[:NOEXIST*0..1]` → zero-hop only (no leakage onto other-label edges in the graph)
   - OPTIONAL MATCH form (issue's exact repro shape)
   - `[*0..0]` → zero-hop only
   - fixed-length `[:NOEXIST*1..1]` → 0 rows (preserved)
   - OPTIONAL fixed-length missing → outer row preserved with NULL
   - mixed pattern `(a)-[:NOEXIST*0..1]-(b)-[:STILL_MISSING]-(c)` → 0 rows
   - sanity: zero-bound on an existing label (unchanged behaviour)

### Validation

- `make installcheck EXTRA_TESTS="pgvector fuzzystrmatch pg_trgm"`: 36/37 pass on PG18. The single failure (`age_upgrade`) is pre-existing on `master` at `54e19fac` and is unrelated to this change.
- All 7 new regression cases pass.
- `cypher_vle` (which is the suite the new tests live in) passes cleanly.
- Manual rebuild + `EXPLAIN (VERBOSE, ANALYZE)` confirms the planner no longer constant-folds `f.name` to `NULL::agtype` and the query returns exactly the expected zero-hop row.

### Notes for reviewers

- The helper validates that `rel->varlen` is a `FuncCall` named `"vle"` with at least 5 args before reading `args[3]`; any deviation falls back to the existing short-circuit, so future parser refactors will be safe.
- `A_Const` integer inspection follows the same direct field access (`val.ival.type` / `val.ival.ival`) used elsewhere in `cypher_gram.y` (e.g. line 696).
- No bison or grammar changes; no new shift/reduce conflicts.

Closes #2382.
