### PR TITLE
Zero-initialize parent_cpstate in analyze_cypher

### DIFF
--- a/src/backend/parser/cypher_analyze.c
+++ b/src/backend/parser/cypher_analyze.c
@@ -961,9 +961,8 @@ static Query *analyze_cypher(List *stmt, ParseState *parent_pstate,
      * convert ParseState into cypher_parsestate temporarily to pass it to
      * make_cypher_parsestate()
      */
+    MemSet(&parent_cpstate, 0, sizeof(parent_cpstate));
     parent_cpstate.pstate = *parent_pstate;
-    parent_cpstate.graph_name = NULL;
-    parent_cpstate.params = NULL;
 
     cpstate = make_cypher_parsestate(&parent_cpstate);
 


### PR DESCRIPTION
cypher_parsestate parent_cpstate is declared on the stack in analyze_cypher() and only pstate, graph_name, and params are explicitly set before it is passed to make_cypher_parsestate(). The latter reads parent_cpstate->subquery_where_flag (and other fields) in cypher_parse_node.c, which leaves them with indeterminate values. Yugabyte UBSan flagged the garbage bool (value 8) and aborted the backend.

Use MemSet to zero the struct before populating the explicit fields so all remaining members start with a defined value.