### PR TITLE
Fix locale-dependent string comparison in direct_field_access test

### DIFF
--- a/regress/expected/direct_field_access.out
+++ b/regress/expected/direct_field_access.out
@@ -78,7 +78,7 @@ $$) AS (lt agtype, gt agtype, eq agtype, ne agtype);
 (1 row)
 
 SELECT * FROM cypher('direct_access', $$
-    RETURN 'hello world' < 'hello worlds', 'test' > 'TEST'
+    RETURN 'hello world' < 'hello worlds', 'abd' > 'abc'
 $$) AS (lt agtype, gt agtype);
   lt  |  gt  
 ------+------

--- a/regress/sql/direct_field_access.sql
+++ b/regress/sql/direct_field_access.sql
@@ -61,7 +61,7 @@ SELECT * FROM cypher('direct_access', $$
 $$) AS (lt agtype, gt agtype, eq agtype, ne agtype);
 
 SELECT * FROM cypher('direct_access', $$
-    RETURN 'hello world' < 'hello worlds', 'test' > 'TEST'
+    RETURN 'hello world' < 'hello worlds', 'abd' > 'abc'
 $$) AS (lt agtype, gt agtype);
 
 -- Boolean comparisons


### PR DESCRIPTION
Replace `'test' > 'TEST'` with deterministic `'abd' > 'abc'`. The original comparison returns different results depending on system collation settings (`true` under `C` locale, `false` under `en_US.UTF-8`).