### PR TITLE
ci: pin Build/Regression runner to ubuntu-24.04 and guard Bison version for GLR grammar

### DIFF
--- a/.github/workflows/installcheck.yaml
+++ b/.github/workflows/installcheck.yaml
@@ -9,7 +9,12 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # Pinned (not ubuntu-latest) so the Bison version stays fixed at 3.8.x.
+    # The Cypher GLR grammar pins exact conflict counts via %expect / %expect-rr
+    # in src/backend/parser/cypher_gram.y, and Bison treats %expect as exact-match:
+    # a different Bison version can report different counts and break the build.
+    # Freezing the runner image freezes Bison; bump both together, intentionally.
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Get latest commit id of PostgreSQL 18
@@ -27,6 +32,22 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential libreadline-dev zlib1g-dev flex bison
+
+      - name: Verify Bison version (grammar conflict counts are pinned)
+        run: |
+          ver=$(bison --version | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          echo "bison $ver"
+          case "$ver" in
+            3.8.*) ;;
+            *)
+              echo "::error::Bison $ver != 3.8.x. The Cypher GLR grammar pins exact"
+              echo "::error::%expect / %expect-rr conflict counts in src/backend/parser/cypher_gram.y."
+              echo "::error::A new Bison version may report different counts. Re-run bison locally,"
+              echo "::error::update the %expect/%expect-rr numbers (and the comment block), then bump"
+              echo "::error::the pinned runner image and this guard together."
+              exit 1
+              ;;
+          esac
 
       - name: Install PostgreSQL 18 and some extensions
         if: steps.pg18cache.outputs.cache-hit != 'true'

--- a/.github/workflows/installcheck.yaml
+++ b/.github/workflows/installcheck.yaml
@@ -35,7 +35,12 @@ jobs:
 
       - name: Verify Bison version (grammar conflict counts are pinned)
         run: |
-          ver=$(bison --version | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          ver=$(bison --version | awk 'NR==1 {print $NF}')
+          if [ -z "$ver" ]; then
+            echo "::error::Could not determine Bison version from 'bison --version'."
+            echo "::error::Expected the first line to end with a version (e.g. '... 3.8.2')."
+            exit 1
+          fi
           echo "bison $ver"
           case "$ver" in
             3.8.*) ;;


### PR DESCRIPTION
## What

Pin the **Build / Regression** CI runner image (`installcheck.yaml`) and guard the Bison version for the Cypher GLR grammar.

- `installcheck.yaml`: `runs-on: ubuntu-latest` → `ubuntu-24.04`
- Add a "Verify Bison version" step that fails with a clear, actionable message if Bison ever drifts off 3.8.x.

## Why

`src/backend/parser/cypher_gram.y` pins exact conflict counts via `%expect 7` / `%expect-rr 3`, and Bison treats `%expect` as **exact-match** (not a ceiling) — any deviation fails the build. `ubuntu-latest` floats to new Ubuntu releases, which can ship a different Bison version that reports different conflict counts, breaking the build with a cryptic grammar-generation error unrelated to the actual change.

Freezing the runner image freezes Bison at 3.8.x, so the pinned `%expect` counts stay reproducible. The version guard turns a future drift into an explicit, self-explanatory failure ("re-run bison, update `%expect`, and bump the pinned runner together") instead of a confusing one.

Reproducibility comes from pinning the variable rather than widening the conflict-count tolerance, keeping the exact-match alarm for genuinely new grammar conflicts intact. This mirrors PostgreSQL's own `gram.y`, which keeps an exact `%expect` and updates it on intentional changes.

## Scope — intentionally only Build / Regression

Only `installcheck.yaml` builds the Cypher grammar with Bison, so it is the only workflow whose result depends on the Bison version. The four driver workflows (`jdbc-driver.yaml`, `nodejs-driver.yaml`, `go-driver.yml`, `python-driver.yaml`) run their drivers against the AGE Docker image and never invoke Bison — pinning them here would freeze their runner for no functional reason (and would collide with their own runtime pins, e.g. the Node version set in `nodejs-driver.yaml`). They are intentionally left on `ubuntu-latest`.

## Testing

CI config only; no source or test changes. The existing `Build / Regression` workflow runs unchanged on the pinned image.
