### PR TITLE
resolve subgraph staging sequences via regclass

### DIFF
--- a/age--1.7.0--y.y.y.sql
+++ b/age--1.7.0--y.y.y.sql
@@ -1013,7 +1013,7 @@ BEGIN
         EXECUTE format(
             'CREATE TEMP TABLE _ag_sg_vstage ON COMMIT DROP AS '
             'SELECT t.id AS old_id, '
-            '       ag_catalog._graphid(%s, nextval(%L)) AS new_id, '
+            '       ag_catalog._graphid(%s, nextval(%L::regclass)) AS new_id, '
             '       t.properties AS props '
             'FROM ONLY %s t '
             'WHERE EXISTS (SELECT 1 FROM _ag_sg_kept_v k WHERE k.gid = t.id)',
@@ -1076,7 +1076,7 @@ BEGIN
         DROP TABLE IF EXISTS _ag_sg_estage;
         EXECUTE format(
             'CREATE TEMP TABLE _ag_sg_estage ON COMMIT DROP AS '
-            'SELECT ag_catalog._graphid(%s, nextval(%L)) AS new_id, '
+            'SELECT ag_catalog._graphid(%s, nextval(%L::regclass)) AS new_id, '
             '       vs.new_id AS new_start, ve.new_id AS new_end, '
             '       x.properties AS props '
             'FROM ONLY %s x '

--- a/sql/age_subgraph.sql
+++ b/sql/age_subgraph.sql
@@ -205,7 +205,7 @@ BEGIN
         EXECUTE format(
             'CREATE TEMP TABLE _ag_sg_vstage ON COMMIT DROP AS '
             'SELECT t.id AS old_id, '
-            '       ag_catalog._graphid(%s, nextval(%L)) AS new_id, '
+            '       ag_catalog._graphid(%s, nextval(%L::regclass)) AS new_id, '
             '       t.properties AS props '
             'FROM ONLY %s t '
             'WHERE EXISTS (SELECT 1 FROM _ag_sg_kept_v k WHERE k.gid = t.id)',
@@ -268,7 +268,7 @@ BEGIN
         DROP TABLE IF EXISTS _ag_sg_estage;
         EXECUTE format(
             'CREATE TEMP TABLE _ag_sg_estage ON COMMIT DROP AS '
-            'SELECT ag_catalog._graphid(%s, nextval(%L)) AS new_id, '
+            'SELECT ag_catalog._graphid(%s, nextval(%L::regclass)) AS new_id, '
             '       vs.new_id AS new_start, ve.new_id AS new_end, '
             '       x.properties AS props '
             'FROM ONLY %s x '


### PR DESCRIPTION
The vertex/edge staging copies in create_subgraph() generated new graphids with nextval(%L), which binds the sequence as a string literal and invokes the nextval(text) overload. That re-resolves the schema-qualified sequence name on each call.

Cast the literal to regclass (nextval(%L::regclass)) so the sequence is resolved once to its OID, matching how AGE defines its label id defaults (nextval('schema.seq'::regclass)). Applied to both the vertex and edge staging queries, in sql/age_subgraph.sql and the identical body in the age--1.7.0--y.y.y.sql upgrade template so the upgrade-path catalog comparison still matches.

Behavior is unchanged; all 38 regression tests pass against PostgreSQL 18.

Addresses Copilot review feedback on apache/age#2441.

Co-authored-by: GitHub Copilot (Claude Opus 4.8) <[email protected]>

modified:   age--1.7.0--y.y.y.sql
modified:   sql/age_subgraph.sql