### PR TITLE
Support building against PostgreSQL 19

### DIFF
--- a/regress/expected/cypher_call.out
+++ b/regress/expected/cypher_call.out
@@ -80,7 +80,6 @@ SELECT * FROM cypher('cypher_call', $$CALL ag_catalog.add_agtype(1,2)$$) as (sqr
 ERROR:  function ag_catalog.add_agtype(agtype, agtype) does not exist
 LINE 2: ...cypher('cypher_call', $$CALL ag_catalog.add_agtype(1,2)$$) a...
                                                              ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 /* CALL YIELD WHERE, should fail */
 SELECT * FROM cypher('cypher_call', $$CALL sqrt(64) YIELD sqrt WHERE sqrt > 1$$) as (sqrt agtype);
 ERROR:  Cannot use standalone CALL with WHERE
@@ -287,12 +286,11 @@ SELECT * FROM cypher('cypher_call', $$ CALL ag_catalog.myfunc() YIELD myfunc RET
 ERROR:  function ag_catalog.myfunc() does not exist
 LINE 1: ...T * FROM cypher('cypher_call', $$ CALL ag_catalog.myfunc() Y...
                                                              ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM cypher('cypher_call', $$ CALL ag_catalog.myfunz(25) YIELD myfunc RETURN myfunc $$) as (result agtype);
 ERROR:  function ag_catalog.myfunz(agtype) does not exist
 LINE 1: ...OM cypher('cypher_call', $$ CALL ag_catalog.myfunz(25) YIELD...
                                                              ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 DROP FUNCTION myfunc;
 DROP SCHEMA call_stmt_test CASCADE;
 NOTICE:  drop cascades to function call_stmt_test.add_agtype(agtype,agtype)

--- a/regress/expected/cypher_match.out
+++ b/regress/expected/cypher_match.out
@@ -333,13 +333,14 @@ SELECT * FROM cypher('cypher_match', $$
 	MATCH ()<-[]-(n:v2)-[]->()
 	MATCH p=(n)-[]->()
 	RETURN p
+	ORDER BY p
 $$) AS (i agtype);
                                                                                                                                                   i                                                                                                                                                   
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- [{"id": 1688849860263938, "label": "v2", "properties": {"id": "middle"}}::vertex, {"id": 1970324836974594, "label": "e2", "end_id": 1688849860263937, "start_id": 1688849860263938, "properties": {}}::edge, {"id": 1688849860263937, "label": "v2", "properties": {"id": "initial"}}::vertex]::path
+ [{"id": 1688849860263938, "label": "v2", "properties": {"id": "middle"}}::vertex, {"id": 1970324836974593, "label": "e2", "end_id": 1688849860263939, "start_id": 1688849860263938, "properties": {}}::edge, {"id": 1688849860263939, "label": "v2", "properties": {"id": "end"}}::vertex]::path
  [{"id": 1688849860263938, "label": "v2", "properties": {"id": "middle"}}::vertex, {"id": 1970324836974593, "label": "e2", "end_id": 1688849860263939, "start_id": 1688849860263938, "properties": {}}::edge, {"id": 1688849860263939, "label": "v2", "properties": {"id": "end"}}::vertex]::path
  [{"id": 1688849860263938, "label": "v2", "properties": {"id": "middle"}}::vertex, {"id": 1970324836974594, "label": "e2", "end_id": 1688849860263937, "start_id": 1688849860263938, "properties": {}}::edge, {"id": 1688849860263937, "label": "v2", "properties": {"id": "initial"}}::vertex]::path
- [{"id": 1688849860263938, "label": "v2", "properties": {"id": "middle"}}::vertex, {"id": 1970324836974593, "label": "e2", "end_id": 1688849860263939, "start_id": 1688849860263938, "properties": {}}::edge, {"id": 1688849860263939, "label": "v2", "properties": {"id": "end"}}::vertex]::path
+ [{"id": 1688849860263938, "label": "v2", "properties": {"id": "middle"}}::vertex, {"id": 1970324836974594, "label": "e2", "end_id": 1688849860263937, "start_id": 1688849860263938, "properties": {}}::edge, {"id": 1688849860263937, "label": "v2", "properties": {"id": "initial"}}::vertex]::path
 (4 rows)
 
 SELECT * FROM cypher('cypher_match', $$
@@ -1494,14 +1495,14 @@ AS (u agtype);
 ERROR:  function ag_catalog.age_isempty(agtype, agtype, agtype) does not exist
 LINE 2:  $$MATCH (u:for_pred) WHERE isEmpty(1,2,3) RETURN properties...
                                            ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM cypher('for_isEmpty',
  $$MATCH (u:for_pred) WHERE isEmpty() RETURN properties(u) $$)
 AS (u agtype);
 ERROR:  function ag_catalog.age_isempty() does not exist
 LINE 2:  $$MATCH (u:for_pred) WHERE isEmpty() RETURN properties(u) $...
                                     ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 -- clean up
 SELECT drop_graph('for_isEmpty', true);
 NOTICE:  drop cascades to 3 other objects

--- a/regress/expected/expr.out
+++ b/regress/expected/expr.out
@@ -2739,7 +2739,7 @@ $$) AS (id agtype);
 ERROR:  function ag_catalog.age_id() does not exist
 LINE 2:     RETURN id()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 -- start_id()
 SELECT * FROM cypher('expr', $$
     MATCH ()-[e]-() RETURN start_id(e)
@@ -2774,7 +2774,7 @@ $$) AS (start_id agtype);
 ERROR:  function ag_catalog.age_start_id() does not exist
 LINE 2:     RETURN start_id()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 -- end_id()
 SELECT * FROM cypher('expr', $$
     MATCH ()-[e]-() RETURN end_id(e)
@@ -2809,7 +2809,7 @@ $$) AS (end_id agtype);
 ERROR:  function ag_catalog.age_end_id() does not exist
 LINE 2:     RETURN end_id()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 -- startNode()
 SELECT * FROM cypher('expr', $$
     MATCH ()-[e]-() RETURN id(e), start_id(e), startNode(e)
@@ -2844,7 +2844,7 @@ $$) AS (startNode agtype);
 ERROR:  function ag_catalog.age_startnode() does not exist
 LINE 2:     RETURN startNode()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 -- endNode()
 SELECT * FROM cypher('expr', $$
     MATCH ()-[e]-() RETURN id(e), end_id(e), endNode(e)
@@ -2879,7 +2879,7 @@ $$) AS (endNode agtype);
 ERROR:  function ag_catalog.age_endnode() does not exist
 LINE 2:     RETURN endNode()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 -- type()
 SELECT * FROM cypher('expr', $$
     MATCH ()-[e]-() RETURN type(e)
@@ -2914,7 +2914,7 @@ $$) AS (type agtype);
 ERROR:  function ag_catalog.age_type() does not exist
 LINE 2:     RETURN type()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 -- label ()
 SELECT * FROM cypher('expr', $$
     MATCH (v) RETURN label(v)
@@ -3033,7 +3033,7 @@ $$) AS (size agtype);
 ERROR:  function ag_catalog.age_size() does not exist
 LINE 2:     RETURN size()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM cypher('expr', $$
     MATCH ()-[vle_array *]-()
     WHERE size(vle_array[0]) = 0
@@ -3097,7 +3097,7 @@ $$) AS (head agtype);
 ERROR:  function ag_catalog.age_head() does not exist
 LINE 2:     RETURN head()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM cypher('expr', $$
     MATCH ()-[vle_array *]-()
     RETURN head(vle_array[0])
@@ -3160,7 +3160,7 @@ $$) AS (last agtype);
 ERROR:  function ag_catalog.age_last() does not exist
 LINE 2:     RETURN last()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM cypher('expr', $$
     MATCH ()-[vle_array *]-()
     RETURN last(vle_array[0])
@@ -3215,7 +3215,7 @@ $$) AS (properties agtype);
 ERROR:  function ag_catalog.age_properties() does not exist
 LINE 2:     RETURN properties()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 -- coalesce
 SELECT * FROM cypher('expr', $$
     RETURN coalesce(null, 1, null, null)
@@ -3354,7 +3354,7 @@ $$) AS (toBoolean agtype);
 ERROR:  function ag_catalog.age_toboolean() does not exist
 LINE 2:     RETURN toBoolean()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 -- toBooleanList()
 SELECT * FROM cypher('expr', $$
     RETURN toBooleanList([true, false, true])
@@ -3506,7 +3506,7 @@ $$) AS (toFloat agtype);
 ERROR:  function ag_catalog.age_tofloat() does not exist
 LINE 2:     RETURN toFloat()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 -- toFloatList()
 SELECT * FROM cypher('expr', $$
     RETURN toFloatList([1.3])
@@ -3670,7 +3670,7 @@ $$) AS (toInteger agtype);
 ERROR:  function ag_catalog.age_tointeger() does not exist
 LINE 2:     RETURN toInteger()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 -- toIntegerList()
 SELECT * FROM cypher('expr', $$
     RETURN toIntegerList([1, 7.8, 9.0, '88'])
@@ -3777,7 +3777,7 @@ $$) AS (length agtype);
 ERROR:  function ag_catalog.age_length() does not exist
 LINE 2:     RETURN length()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 --
 -- toString()
 --
@@ -3909,12 +3909,12 @@ SELECT * FROM age_toString();
 ERROR:  function age_tostring() does not exist
 LINE 1: SELECT * FROM age_toString();
                       ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM cypher('expr', $$ RETURN toString() $$) AS (results agtype);
 ERROR:  function ag_catalog.age_tostring() does not exist
 LINE 1: SELECT * FROM cypher('expr', $$ RETURN toString() $$) AS (re...
                                                ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 -- toStringList() --
 SELECT * FROM cypher('expr', $$ 
     RETURN toStringList([5, 10, 7.8, 9, 1.3]) 
@@ -4163,12 +4163,12 @@ $$) AS (results agtype);
 ERROR:  function ag_catalog.age_reverse() does not exist
 LINE 2:     RETURN reverse()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM age_reverse();
 ERROR:  function age_reverse() does not exist
 LINE 1: SELECT * FROM age_reverse();
                       ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM cypher('expr', $$
     MATCH (v)
     RETURN reverse(v)
@@ -4330,7 +4330,7 @@ $$) AS (toUpper agtype);
 ERROR:  function ag_catalog.age_toupper() does not exist
 LINE 2:     RETURN toUpper()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM cypher('expr', $$
     RETURN toLower(true)
 $$) AS (toLower agtype);
@@ -4341,17 +4341,17 @@ $$) AS (toLower agtype);
 ERROR:  function ag_catalog.age_tolower() does not exist
 LINE 2:     RETURN toLower()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM age_toupper();
 ERROR:  function age_toupper() does not exist
 LINE 1: SELECT * FROM age_toupper();
                       ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM age_tolower();
 ERROR:  function age_tolower() does not exist
 LINE 1: SELECT * FROM age_tolower();
                       ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 --
 -- lTrim(), rTrim(), trim()
 --
@@ -4526,36 +4526,36 @@ $$) AS (results agtype);
 ERROR:  function ag_catalog.age_ltrim() does not exist
 LINE 2:     RETURN lTrim()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM cypher('expr', $$
     RETURN rTrim()
 $$) AS (results agtype);
 ERROR:  function ag_catalog.age_rtrim() does not exist
 LINE 2:     RETURN rTrim()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM cypher('expr', $$
     RETURN trim()
 $$) AS (results agtype);
 ERROR:  function ag_catalog.age_trim() does not exist
 LINE 2:     RETURN trim()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM age_ltrim();
 ERROR:  function age_ltrim() does not exist
 LINE 1: SELECT * FROM age_ltrim();
                       ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM age_rtrim();
 ERROR:  function age_rtrim() does not exist
 LINE 1: SELECT * FROM age_rtrim();
                       ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM age_trim();
 ERROR:  function age_trim() does not exist
 LINE 1: SELECT * FROM age_trim();
                       ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 --
 -- left(), right(), & substring()
 -- left()
@@ -4628,7 +4628,7 @@ $$) AS (results agtype);
 ERROR:  function ag_catalog.age_left() does not exist
 LINE 2:     RETURN left()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM age_left('123456789', null);
 ERROR:  left() length parameter cannot be null
 SELECT * FROM age_left('123456789', -1);
@@ -4637,7 +4637,7 @@ SELECT * FROM age_left();
 ERROR:  function age_left() does not exist
 LINE 1: SELECT * FROM age_left();
                       ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM cypher('expr', $$
     RETURN left('abcdef', -2147483648)
 $$) AS (result agtype);
@@ -4720,7 +4720,7 @@ $$) AS (results agtype);
 ERROR:  function ag_catalog.age_right() does not exist
 LINE 2:     RETURN right()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM age_right('123456789', null);
 ERROR:  right() length parameter cannot be null
 SELECT * FROM age_right('123456789', -1);
@@ -4729,7 +4729,7 @@ SELECT * FROM age_right();
 ERROR:  function age_right() does not exist
 LINE 1: SELECT * FROM age_right();
                       ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM cypher('expr', $$
     RETURN right('abcdef', -2147483648)
 $$) AS (result agtype);
@@ -4888,7 +4888,7 @@ SELECT * FROM age_substring();
 ERROR:  function age_substring() does not exist
 LINE 1: SELECT * FROM age_substring();
                       ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 --
 -- split()
 --
@@ -5002,7 +5002,7 @@ $$) AS (results agtype);
 ERROR:  function ag_catalog.age_split() does not exist
 LINE 2:     RETURN split()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM age_split(123456789, ',');
 ERROR:  split() unsupported argument type 23
 SELECT * FROM age_split('a,b,c,d,e,f', -1);
@@ -5013,7 +5013,7 @@ SELECT * FROM age_split();
 ERROR:  function age_split() does not exist
 LINE 1: SELECT * FROM age_split();
                       ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 --
 -- replace()
 --
@@ -5150,7 +5150,7 @@ $$) AS (results agtype);
 ERROR:  function ag_catalog.age_replace() does not exist
 LINE 2:     RETURN replace()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM cypher('expr', $$
     RETURN replace("Hello")
 $$) AS (results agtype);
@@ -5171,7 +5171,7 @@ SELECT * FROM age_replace();
 ERROR:  function age_replace() does not exist
 LINE 1: SELECT * FROM age_replace();
                       ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM age_replace(null);
 ERROR:  replace() invalid number of arguments
 SELECT * FROM age_replace(null, null);
@@ -5319,28 +5319,28 @@ $$) AS (results agtype);
 ERROR:  function ag_catalog.age_sin() does not exist
 LINE 2:     RETURN sin()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM cypher('expr', $$
     RETURN cos()
 $$) AS (results agtype);
 ERROR:  function ag_catalog.age_cos() does not exist
 LINE 2:     RETURN cos()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM cypher('expr', $$
     RETURN tan()
 $$) AS (results agtype);
 ERROR:  function ag_catalog.age_tan() does not exist
 LINE 2:     RETURN tan()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM cypher('expr', $$
     RETURN cot()
 $$) AS (results agtype);
 ERROR:  function ag_catalog.age_cot() does not exist
 LINE 2:     RETURN cot()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM age_sin('0');
 ERROR:  sin() unsupported argument type 25
 SELECT * FROM age_cos('0');
@@ -5353,22 +5353,22 @@ SELECT * FROM age_sin();
 ERROR:  function age_sin() does not exist
 LINE 1: SELECT * FROM age_sin();
                       ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM age_cos();
 ERROR:  function age_cos() does not exist
 LINE 1: SELECT * FROM age_cos();
                       ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM age_tan();
 ERROR:  function age_tan() does not exist
 LINE 1: SELECT * FROM age_tan();
                       ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM age_cot();
 ERROR:  function age_cot() does not exist
 LINE 1: SELECT * FROM age_cot();
                       ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 --
 -- Arc functions: asin, acos, atan, & atan2
 --
@@ -5572,28 +5572,28 @@ $$) AS (results agtype);
 ERROR:  function ag_catalog.age_asin() does not exist
 LINE 2:     RETURN asin()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM cypher('expr', $$
     RETURN acos()
 $$) AS (results agtype);
 ERROR:  function ag_catalog.age_acos() does not exist
 LINE 2:     RETURN acos()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM cypher('expr', $$
     RETURN atan()
 $$) AS (results agtype);
 ERROR:  function ag_catalog.age_atan() does not exist
 LINE 2:     RETURN atan()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM cypher('expr', $$
     RETURN atan2()
 $$) AS (results agtype);
 ERROR:  function ag_catalog.age_atan2() does not exist
 LINE 2:     RETURN atan2()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM cypher('expr', $$
     RETURN atan2(null)
 $$) AS (results agtype);
@@ -5612,22 +5612,22 @@ SELECT * FROM age_asin();
 ERROR:  function age_asin() does not exist
 LINE 1: SELECT * FROM age_asin();
                       ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM age_acos();
 ERROR:  function age_acos() does not exist
 LINE 1: SELECT * FROM age_acos();
                       ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM age_atan();
 ERROR:  function age_atan() does not exist
 LINE 1: SELECT * FROM age_atan();
                       ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM age_atan2();
 ERROR:  function age_atan2() does not exist
 LINE 1: SELECT * FROM age_atan2();
                       ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM age_atan2(1);
 ERROR:  atan2() invalid number of arguments
 --
@@ -5688,14 +5688,14 @@ $$) AS (results agtype);
 ERROR:  function ag_catalog.age_pi(agtype) does not exist
 LINE 2:     RETURN pi(null)
                      ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM cypher('expr', $$
     RETURN pi(1)
 $$) AS (results agtype);
 ERROR:  function ag_catalog.age_pi(agtype) does not exist
 LINE 2:     RETURN pi(1)
                      ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 --
 -- radians() & degrees()
 --
@@ -5787,14 +5787,14 @@ $$) AS (results agtype);
 ERROR:  function ag_catalog.age_radians() does not exist
 LINE 2:     RETURN radians()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM cypher('expr', $$
     RETURN degrees()
 $$) AS (results agtype);
 ERROR:  function ag_catalog.age_degrees() does not exist
 LINE 2:     RETURN degrees()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM cypher('expr', $$
     RETURN radians("1")
 $$) AS (results agtype);
@@ -6078,35 +6078,35 @@ $$) AS (results agtype);
 ERROR:  function ag_catalog.age_abs() does not exist
 LINE 2:     RETURN abs()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM cypher('expr', $$
     RETURN ceil()
 $$) AS (results agtype);
 ERROR:  function ag_catalog.age_ceil() does not exist
 LINE 2:     RETURN ceil()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM cypher('expr', $$
     RETURN floor()
 $$) AS (results agtype);
 ERROR:  function ag_catalog.age_floor() does not exist
 LINE 2:     RETURN floor()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM cypher('expr', $$
     RETURN round()
 $$) AS (results agtype);
 ERROR:  function ag_catalog.age_round() does not exist
 LINE 2:     RETURN round()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM cypher('expr', $$
     RETURN sign()
 $$) AS (results agtype);
 ERROR:  function ag_catalog.age_sign() does not exist
 LINE 2:     RETURN sign()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM cypher('expr', $$
     RETURN abs("1")
 $$) AS (results agtype);
@@ -6226,14 +6226,14 @@ $$) as (result agtype);
 ERROR:  function ag_catalog.age_log() does not exist
 LINE 2:     RETURN log()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * from cypher('expr', $$
     RETURN log10()
 $$) as (result agtype);
 ERROR:  function ag_catalog.age_log10() does not exist
 LINE 2:     RETURN log10()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 --
 -- e()
 --
@@ -6288,7 +6288,7 @@ $$) as (result agtype);
 ERROR:  function ag_catalog.age_exp() does not exist
 LINE 2:     RETURN exp()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * from cypher('expr', $$
     RETURN exp("1")
 $$) as (result agtype);
@@ -6344,7 +6344,7 @@ $$) as (result agtype);
 ERROR:  function ag_catalog.age_sqrt() does not exist
 LINE 2:     RETURN sqrt()
                    ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * from cypher('expr', $$
     RETURN sqrt("1")
 $$) as (result agtype);
@@ -6392,7 +6392,7 @@ $$) as (result agtype);
 ERROR:  function pg_catalog.sqrt() does not exist
 LINE 2:     RETURN pg_catalog.sqrt()
                               ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * from cypher('expr', $$
     RETURN pg_catalog.sqrt(-1::pg_float8)
 $$) as (result agtype);
@@ -6537,12 +6537,12 @@ SELECT * FROM cypher('UCSC', $$ RETURN avg() $$) AS (avg agtype);
 ERROR:  function ag_catalog.age_avg() does not exist
 LINE 1: SELECT * FROM cypher('UCSC', $$ RETURN avg() $$) AS (avg agt...
                                                ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM cypher('UCSC', $$ RETURN sum() $$) AS (sum agtype);
 ERROR:  function ag_catalog.age_sum() does not exist
 LINE 1: SELECT * FROM cypher('UCSC', $$ RETURN sum() $$) AS (sum agt...
                                                ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM cypher('UCSC', $$ RETURN count() $$) AS (count agtype);
 ERROR:  pg_catalog.count(*) must be used to call a parameterless aggregate function
 LINE 1: SELECT * FROM cypher('UCSC', $$ RETURN count() $$) AS (count...
@@ -6648,22 +6648,22 @@ SELECT * FROM cypher('UCSC', $$ RETURN min() $$) AS (min agtype);
 ERROR:  function ag_catalog.age_min() does not exist
 LINE 1: SELECT * FROM cypher('UCSC', $$ RETURN min() $$) AS (min agt...
                                                ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM cypher('UCSC', $$ RETURN max() $$) AS (max agtype);
 ERROR:  function ag_catalog.age_max() does not exist
 LINE 1: SELECT * FROM cypher('UCSC', $$ RETURN max() $$) AS (max agt...
                                                ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT age_min();
 ERROR:  function age_min() does not exist
 LINE 1: SELECT age_min();
                ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT age_min();
 ERROR:  function age_min() does not exist
 LINE 1: SELECT age_min();
                ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 --
 -- aggregate functions stDev() & stDevP()
 --
@@ -6692,12 +6692,12 @@ SELECT * FROM cypher('UCSC', $$ RETURN stDev() $$) AS (stDev agtype);
 ERROR:  function ag_catalog.age_stdev() does not exist
 LINE 1: SELECT * FROM cypher('UCSC', $$ RETURN stDev() $$) AS (stDev...
                                                ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 SELECT * FROM cypher('UCSC', $$ RETURN stDevP() $$) AS (stDevP agtype);
 ERROR:  function ag_catalog.age_stdevp() does not exist
 LINE 1: SELECT * FROM cypher('UCSC', $$ RETURN stDevP() $$) AS (stDe...
                                                ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 --
 -- aggregate functions percentileCont() & percentileDisc()
 --
@@ -6788,7 +6788,7 @@ SELECT * FROM cypher('UCSC', $$ RETURN collect() $$) AS (collect agtype);
 ERROR:  function ag_catalog.age_collect() does not exist
 LINE 1: SELECT * FROM cypher('UCSC', $$ RETURN collect() $$) AS (col...
                                                ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 -- test DISTINCT inside aggregate functions
 SELECT * FROM cypher('UCSC', $$CREATE (:students {name: "Sven", gpa: 3.2, age: 27, zip: 94110})$$)
 AS (a agtype);
@@ -8098,7 +8098,7 @@ SELECT * FROM cypher('list', $$ RETURN tail() $$) AS (tail agtype);
 ERROR:  function ag_catalog.age_tail() does not exist
 LINE 1: SELECT * FROM cypher('list', $$ RETURN tail() $$) AS (tail a...
                                                ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No function of that name accepts the given number of arguments.
 -- labels()
 SELECT * from cypher('list', $$CREATE (u:People {name: "John"}) RETURN u$$) as (Vertices agtype);
                                       vertices                                       

--- a/regress/expected/jsonb_operators.out
+++ b/regress/expected/jsonb_operators.out
@@ -1418,17 +1418,20 @@ SELECT '["a","b","c",[1,2],null]'::agtype ->> '3'::agtype ->> '1'::agtype;
 ERROR:  operator does not exist: text ->> agtype
 LINE 1: ...["a","b","c",[1,2],null]'::agtype ->> '3'::agtype ->> '1'::a...
                                                              ^
-HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No operator of that name accepts the given argument types.
+HINT:  You might need to add explicit type casts.
 SELECT '["a","b","c",[1,2],null]'::agtype ->> '3'::agtype -> '1'::agtype;
 ERROR:  operator does not exist: text -> agtype
 LINE 1: ...["a","b","c",[1,2],null]'::agtype ->> '3'::agtype -> '1'::ag...
                                                              ^
-HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No operator of that name accepts the given argument types.
+HINT:  You might need to add explicit type casts.
 SELECT '[1, 2, "e", true, null, {"a": true, "b": {}, "c": [{}, [[], {}]]}, null]'::agtype ->> 0.1::float::bigint;
 ERROR:  operator does not exist: agtype ->> bigint
 LINE 1: ...ue, "b": {}, "c": [{}, [[], {}]]}, null]'::agtype ->> 0.1::f...
                                                              ^
-HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No operator of that name accepts the given argument types.
+HINT:  You might need to add explicit type casts.
 SELECT '{"a": [{"b": "c"}, {"b": "cc"}]}'::agtype ->> "'z'"::agtype;
 ERROR:  column "'z'" does not exist
 LINE 1: ...CT '{"a": [{"b": "c"}, {"b": "cc"}]}'::agtype ->> "'z'"::agt...
@@ -1925,12 +1928,14 @@ SELECT '[0,1,2,[3,4],{"5":"five"}]'::agtype #>> '[-1, "5"]' #> '[]';
 ERROR:  operator does not exist: text #> unknown
 LINE 1: ...[0,1,2,[3,4],{"5":"five"}]'::agtype #>> '[-1, "5"]' #> '[]';
                                                                ^
-HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No operator of that name accepts the given argument types.
+HINT:  You might need to add explicit type casts.
 SELECT '{"a":"b","c":[1,2,3], "1" : [{}, {}, [[-3, {"a": {"b": {"d": [-1.9::numeric, false]}, "c": "foo"}}]]]}'::agtype #>> '["1", -1, -1, -1, "a"]' #> '["b", "d", -1]';
 ERROR:  operator does not exist: text #> unknown
 LINE 1: ..."foo"}}]]]}'::agtype #>> '["1", -1, -1, -1, "a"]' #> '["b", ...
                                                              ^
-HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No operator of that name accepts the given argument types.
+HINT:  You might need to add explicit type casts.
 --
 -- concat || operator
 --
@@ -2353,12 +2358,14 @@ SELECT '3'::agtype || 4;
 ERROR:  operator does not exist: agtype || integer
 LINE 1: SELECT '3'::agtype || 4;
                            ^
-HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No operator of that name accepts the given argument types.
+HINT:  You might need to add explicit type casts.
 SELECT '3'::agtype || true;
 ERROR:  operator does not exist: agtype || boolean
 LINE 1: SELECT '3'::agtype || true;
                            ^
-HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  No operator of that name accepts the given argument types.
+HINT:  You might need to add explicit type casts.
 --
 -- Agtype containment operator
 --

--- a/regress/expected/subgraph.out
+++ b/regress/expected/subgraph.out
@@ -275,7 +275,7 @@ SELECT create_subgraph('sg_bad', 'sg_src', 'n.pid <<>> 1', '*');
 ERROR:  operator does not exist: agtype <<>> agtype
 LINE 1: ...her('sg_src', $age_subgraph$MATCH (n) WHERE n.pid <<>> 1 RET...
                                                              ^
-HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
+DETAIL:  There is no operator of that name.
 QUERY:  CREATE TEMP TABLE _ag_sg_kept_v ON COMMIT DROP AS SELECT DISTINCT ag_catalog.agtype_to_graphid(vid) AS gid FROM ag_catalog.cypher('sg_src', $age_subgraph$MATCH (n) WHERE n.pid <<>> 1 RETURN id(n)$age_subgraph$) AS (vid agtype)
 CONTEXT:  PL/pgSQL function create_subgraph(name,name,text,text) line 80 at EXECUTE
 -- cleanup

--- a/regress/sql/cypher_match.sql
+++ b/regress/sql/cypher_match.sql
@@ -165,6 +165,7 @@ SELECT * FROM cypher('cypher_match', $$
 	MATCH ()<-[]-(n:v2)-[]->()
 	MATCH p=(n)-[]->()
 	RETURN p
+	ORDER BY p
 $$) AS (i agtype);
 
 SELECT * FROM cypher('cypher_match', $$

--- a/src/backend/catalog/ag_label.c
+++ b/src/backend/catalog/ag_label.c
@@ -341,7 +341,7 @@ List *get_all_edge_labels_per_graph(EState *estate, Oid graph_oid)
         ScanKeyInit(&scan_keys[0], 1, BTEqualStrategyNumber,
                     F_OIDEQ, ObjectIdGetDatum(graph_oid));
 
-        index_scan_desc = index_beginscan(ag_label, index_rel, estate->es_snapshot, NULL, 1, 0);
+        index_scan_desc = index_beginscan(ag_label, index_rel, estate->es_snapshot, NULL, 1, 0, SO_NONE);
         index_rescan(index_scan_desc, scan_keys, 1, NULL, 0);
 
         while (index_getnext_slot(index_scan_desc, ForwardScanDirection, slot))
@@ -391,7 +391,7 @@ List *get_all_edge_labels_per_graph(EState *estate, Oid graph_oid)
         ScanKeyInit(&scan_keys[0], Anum_ag_label_kind, BTEqualStrategyNumber,
                   F_CHAREQ, CharGetDatum(LABEL_TYPE_EDGE));
 
-        scan_desc = table_beginscan(ag_label, estate->es_snapshot, 2, scan_keys);
+        scan_desc = table_beginscan(ag_label, estate->es_snapshot, 2, scan_keys, SO_NONE);
 
         /* scan through the results and get all the label names. */
         while(true)

--- a/src/backend/commands/graph_commands.c
+++ b/src/backend/commands/graph_commands.c
@@ -25,6 +25,7 @@
 #include "commands/tablecmds.h"
 #include "miscadmin.h"
 #include "nodes/makefuncs.h"
+#include "parser/parse_node.h"
 #include "parser/parser.h"
 
 #include "catalog/ag_graph.h"
@@ -139,6 +140,7 @@ Datum age_graph_exists(PG_FUNCTION_ARGS)
 
 static Oid create_schema_for_graph(const Name graph_name)
 {
+    ParseState *pstate = make_parsestate(NULL);
     char *graph_name_str = NameStr(*graph_name);
     CreateSchemaStmt *schema_stmt;
     CreateSeqStmt *seq_stmt;
@@ -180,9 +182,10 @@ static Oid create_schema_for_graph(const Name graph_name)
     seq_stmt->if_not_exists = false;
     schema_stmt->schemaElts = list_make1(seq_stmt);
     schema_stmt->if_not_exists = false;
-    nsp_id = CreateSchemaCommand(schema_stmt,
-                                 "(generated CREATE SCHEMA command)", -1, -1);
+    pstate->p_sourcetext = "(generated CREATE SCHEMA command)";
+    nsp_id = CreateSchemaCommand(pstate, schema_stmt, -1, -1);
     /* CommandCounterIncrement() is called in CreateSchemaCommand() */
+    free_parsestate(pstate);
 
     return nsp_id;
 }
@@ -394,7 +397,7 @@ List *get_graphnames(void)
     scan_desc = systable_beginscan(ag_graph, ag_graph_name_index_id(), true,
                                    NULL, 0, NULL);
 
-    slot = MakeTupleTableSlot(RelationGetDescr(ag_graph), &TTSOpsHeapTuple);
+    slot = MakeTupleTableSlot(RelationGetDescr(ag_graph), &TTSOpsHeapTuple, 0);
 
     for (;;)
     {

--- a/src/backend/executor/cypher_create.c
+++ b/src/backend/executor/cypher_create.c
@@ -75,7 +75,7 @@ static void begin_cypher_create(CustomScanState *node, EState *estate,
 
     ExecInitScanTupleSlot(estate, &node->ss,
                           ExecGetResultType(node->ss.ps.lefttree),
-                          &TTSOpsHeapTuple);
+                          &TTSOpsHeapTuple, 0);
 
     if (!CYPHER_CLAUSE_IS_TERMINAL(css->flags))
     {

--- a/src/backend/executor/cypher_delete.c
+++ b/src/backend/executor/cypher_delete.c
@@ -19,6 +19,7 @@
 
 #include "postgres.h"
 
+#include "access/genam.h"
 #include "executor/executor.h"
 #include "storage/bufmgr.h"
 #include "common/hashfn.h"
@@ -86,7 +87,7 @@ static void begin_cypher_delete(CustomScanState *node, EState *estate,
     /* setup scan tuple slot and projection info */
     ExecInitScanTupleSlot(estate, &node->ss,
                           ExecGetResultType(node->ss.ps.lefttree),
-                          &TTSOpsHeapTuple);
+                          &TTSOpsHeapTuple, 0);
 
     if (!CYPHER_CLAUSE_IS_TERMINAL(css->flags))
     {
@@ -317,9 +318,8 @@ static void delete_entity(EState *estate, ResultRelInfo *resultRelInfo,
     if (lock_result == TM_Ok)
     {
         delete_result = heap_delete(resultRelInfo->ri_RelationDesc,
-                                    &tuple->t_self, GetCurrentCommandId(true),
-                                    estate->es_crosscheck_snapshot, true, &hufd,
-                                    false);
+                                    &tuple->t_self, GetCurrentCommandId(true), 0,
+                                    estate->es_crosscheck_snapshot, true, &hufd);
 
         /*
          * Unlike locking, the heap_delete either succeeded
@@ -487,7 +487,7 @@ static void process_delete_list(CustomScanState *node)
             slot = table_slot_create(rel, NULL);
 
             index_rel = index_open(index_oid, RowExclusiveLock);
-            index_scan_desc = index_beginscan(rel, index_rel, estate->es_snapshot, NULL, 1, 0);
+            index_scan_desc = index_beginscan(rel, index_rel, estate->es_snapshot, NULL, 1, 0, SO_NONE);
             index_rescan(index_scan_desc, scan_keys, 1, NULL, 0);
 
             if (index_getnext_slot(index_scan_desc, ForwardScanDirection, slot))
@@ -497,7 +497,8 @@ static void process_delete_list(CustomScanState *node)
         }
         else
         {
-            scan_desc = table_beginscan(rel, estate->es_snapshot, 1, scan_keys);
+            scan_desc = table_beginscan(rel, estate->es_snapshot, 1, scan_keys,
+                                        SO_NONE);
             /* Retrieve the tuple. */
             heap_tuple = heap_getnext(scan_desc, ForwardScanDirection);
         }
@@ -596,7 +597,7 @@ static void process_edges_by_index(Oid index_oid,
     slot = table_slot_create(rel, NULL);
 
     index_rel = index_open(index_oid, RowExclusiveLock);
-    scan = index_beginscan(rel, index_rel, estate->es_snapshot, NULL, 1, 0);
+    scan = index_beginscan(rel, index_rel, estate->es_snapshot, NULL, 1, 0, SO_NONE);
 
     /* Initialize ScanKey with a dummy argument (0), updated in the loop */
     ScanKeyInit(&key, 1, BTEqualStrategyNumber, F_GRAPHIDEQ, 0);
@@ -745,7 +746,8 @@ static void check_for_connected_edges(CustomScanState *node)
         }
         else
         {
-            scan_desc = table_beginscan(rel, estate->es_snapshot, 0, NULL);
+            scan_desc = table_beginscan(rel, estate->es_snapshot, 0, NULL,
+                                        SO_NONE);
             slot = ExecInitExtraTupleSlot(
                 estate, RelationGetDescr(rel),
                 &TTSOpsHeapTuple);

--- a/src/backend/executor/cypher_merge.c
+++ b/src/backend/executor/cypher_merge.c
@@ -122,7 +122,7 @@ static void begin_cypher_merge(CustomScanState *node, EState *estate,
 
     ExecInitScanTupleSlot(estate, &node->ss,
                           ExecGetResultType(node->ss.ps.lefttree),
-                          &TTSOpsVirtual);
+                          &TTSOpsVirtual, 0);
 
     /*
      * When MERGE is not the last clause in a cypher query. Setup projection
@@ -990,7 +990,7 @@ static TupleTableSlot *exec_cypher_merge(CustomScanState *node)
              */
             ExecInitScanTupleSlot(estate, &sss->ss,
                                   ExecGetResultType(sss->subplan),
-                                  &TTSOpsVirtual);
+                                  &TTSOpsVirtual, 0);
 
             /* setup the scantuple that the process_path needs */
             econtext->ecxt_scantuple = sss->ss.ss_ScanTupleSlot;

--- a/src/backend/executor/cypher_set.c
+++ b/src/backend/executor/cypher_set.c
@@ -19,6 +19,7 @@
 
 #include "postgres.h"
 
+#include "access/genam.h"
 #include "common/hashfn.h"
 #include "executor/executor.h"
 #include "executor/nodeModifyTable.h"
@@ -72,7 +73,7 @@ static void begin_cypher_set(CustomScanState *node, EState *estate,
 
     ExecInitScanTupleSlot(estate, &node->ss,
                           ExecGetResultType(node->ss.ps.lefttree),
-                          &TTSOpsHeapTuple);
+                          &TTSOpsHeapTuple, 0);
 
     if (!CYPHER_CLAUSE_IS_TERMINAL(css->flags))
     {
@@ -173,7 +174,7 @@ static HeapTuple update_entity_tuple(ResultRelInfo *resultRelInfo,
 
         result = table_tuple_update(resultRelInfo->ri_RelationDesc,
                                     &tuple->t_self, elemTupleSlot,
-                                    cid, estate->es_snapshot,
+                                    cid, 0, estate->es_snapshot,
                                     estate->es_crosscheck_snapshot,
                                     true /* wait for commit */ ,
                                     &hufd, &lockmode, &update_indexes);
@@ -205,8 +206,9 @@ static HeapTuple update_entity_tuple(ResultRelInfo *resultRelInfo,
         /* Insert index entries for the tuple */
         if (resultRelInfo->ri_NumIndices > 0 && update_indexes != TU_None)
         {
-          ExecInsertIndexTuples(resultRelInfo, elemTupleSlot, estate, false, false, NULL, NIL,
-                                (update_indexes == TU_Summarizing));
+          ExecInsertIndexTuples(resultRelInfo, estate,
+                                (update_indexes == TU_Summarizing) ? EIIT_ONLY_SUMMARIZING : 0,
+                                elemTupleSlot, NIL, NULL);
         }
 
         if (close_indices)
@@ -730,7 +732,7 @@ void apply_update_list(CustomScanState *node,
                             GRAPHID_GET_DATUM(id->val.int_value));
 
                 index_slot = table_slot_create(rel, NULL);
-                idx_scan_desc = index_beginscan(rel, index_rel, estate->es_snapshot, NULL, 1, 0);
+                idx_scan_desc = index_beginscan(rel, index_rel, estate->es_snapshot, NULL, 1, 0, SO_NONE);
                 index_rescan(idx_scan_desc, scan_keys, 1, NULL, 0);
 
                 if (index_getnext_slot(idx_scan_desc, ForwardScanDirection, index_slot))
@@ -797,7 +799,8 @@ void apply_update_list(CustomScanState *node,
                  * keys.
                  */
                 scan_desc = table_beginscan(resultRelInfo->ri_RelationDesc,
-                                            estate->es_snapshot, 1, scan_keys);
+                                            estate->es_snapshot, 1, scan_keys,
+                                            SO_NONE);
                 /* Retrieve the tuple. */
                 heap_tuple = heap_getnext(scan_desc, ForwardScanDirection);
 

--- a/src/backend/executor/cypher_utils.c
+++ b/src/backend/executor/cypher_utils.c
@@ -24,6 +24,7 @@
 
 #include "postgres.h"
 
+#include "access/genam.h"
 #include "executor/executor.h"
 #include "executor/nodeModifyTable.h"
 #include "miscadmin.h"
@@ -275,7 +276,7 @@ bool entity_exists(EState *estate, Oid graph_oid, graphid id)
 
         index_rel = index_open(index_oid, AccessShareLock);
 
-        index_scan_desc = index_beginscan(rel, index_rel, estate->es_snapshot, NULL, 1, 0);
+        index_scan_desc = index_beginscan(rel, index_rel, estate->es_snapshot, NULL, 1, 0, SO_NONE);
         index_rescan(index_scan_desc, scan_keys, 1, NULL, 0);
 
         if (!index_getnext_slot(index_scan_desc, ForwardScanDirection, slot))
@@ -289,7 +290,8 @@ bool entity_exists(EState *estate, Oid graph_oid, graphid id)
     } 
     else
     {        
-        scan_desc = table_beginscan(rel, estate->es_snapshot, 1, scan_keys);
+        scan_desc = table_beginscan(rel, estate->es_snapshot, 1, scan_keys,
+                                    SO_NONE);
         tuple = heap_getnext(scan_desc, ForwardScanDirection);
 
         /*
@@ -388,8 +390,8 @@ HeapTuple insert_entity_tuple_cid(ResultRelInfo *resultRelInfo,
     /* Insert index entries for the tuple */
     if (resultRelInfo->ri_NumIndices > 0)
     {
-        ExecInsertIndexTuples(resultRelInfo, elemTupleSlot, estate,
-                              false, false, NULL, NIL, false);
+        ExecInsertIndexTuples(resultRelInfo, estate, 0, elemTupleSlot,
+                              NIL, NULL);
     }
 
     return tuple;

--- a/src/backend/parser/cypher_analyze.c
+++ b/src/backend/parser/cypher_analyze.c
@@ -52,7 +52,7 @@ static void build_explain_query(Query *query, Node *explain_node);
 
 static post_parse_analyze_hook_type prev_post_parse_analyze_hook;
 
-static void post_parse_analyze(ParseState *pstate, Query *query, JumbleState *jstate);
+static void post_parse_analyze(ParseState *pstate, Query *query, const JumbleState *jstate);
 static bool convert_cypher_walker(Node *node, ParseState *pstate);
 static bool is_rte_cypher(RangeTblEntry *rte);
 static bool is_func_cypher(FuncExpr *funcexpr);
@@ -80,7 +80,7 @@ void post_parse_analyze_fini(void)
     post_parse_analyze_hook = prev_post_parse_analyze_hook;
 }
 
-static void post_parse_analyze(ParseState *pstate, Query *query, JumbleState *jstate)
+static void post_parse_analyze(ParseState *pstate, Query *query, const JumbleState *jstate)
 {
     if (prev_post_parse_analyze_hook)
     {

--- a/src/backend/parser/cypher_expr.c
+++ b/src/backend/parser/cypher_expr.c
@@ -24,6 +24,7 @@
 
 #include "postgres.h"
 
+#include "access/htup_details.h"
 #include "catalog/pg_proc.h"
 #include "catalog/dependency.h"
 #include "commands/extension.h"

--- a/src/backend/parser/cypher_keywords.c
+++ b/src/backend/parser/cypher_keywords.c
@@ -24,6 +24,7 @@
 
 #include "postgres.h"
 
+#include "catalog/pg_type.h"
 #include "common/keywords.h"
 #include "funcapi.h"
 

--- a/src/backend/utils/adt/age_global_graph.c
+++ b/src/backend/utils/adt/age_global_graph.c
@@ -19,6 +19,7 @@
 
 #include "postgres.h"
 
+#include "access/genam.h"
 #include "access/heapam.h"
 #include "catalog/namespace.h"
 #include "commands/trigger.h"
@@ -417,7 +418,7 @@ static List *get_ag_labels_names(Snapshot snapshot, Oid graph_oid,
         ScanKeyInit(&key, 1, BTEqualStrategyNumber,
                     F_OIDEQ, ObjectIdGetDatum(graph_oid));
 
-        idx_scan_desc = index_beginscan(ag_label, index_rel, snapshot, NULL, 1, 0);
+        idx_scan_desc = index_beginscan(ag_label, index_rel, snapshot, NULL, 1, 0, SO_NONE);
         index_rescan(idx_scan_desc, &key, 1, NULL, 0);
 
         while (index_getnext_slot(idx_scan_desc, ForwardScanDirection, slot))
@@ -472,7 +473,7 @@ static List *get_ag_labels_names(Snapshot snapshot, Oid graph_oid,
         ScanKeyInit(&scan_keys[0], Anum_ag_label_kind, BTEqualStrategyNumber,
                     F_CHAREQ, CharGetDatum(label_type));
 
-        scan_desc = table_beginscan(ag_label, snapshot, 2, scan_keys);
+        scan_desc = table_beginscan(ag_label, snapshot, 2, scan_keys, SO_NONE);
 
         /* get all of the label names */
         while((tuple = heap_getnext(scan_desc, ForwardScanDirection)) != NULL)
@@ -745,7 +746,7 @@ static void load_vertex_hashtable(GRAPH_global_context *ggctx)
                                                    graph_namespace_oid);
         /* open the relation (table) and begin the scan */
         graph_vertex_label = table_open(vertex_label_table_oid, AccessShareLock);
-        scan_desc = table_beginscan(graph_vertex_label, snapshot, 0, NULL);
+        scan_desc = table_beginscan(graph_vertex_label, snapshot, 0, NULL, SO_NONE);
         /* get the tupdesc - we don't need to release this one */
         tupdesc = RelationGetDescr(graph_vertex_label);
         /* bail if the number of columns differs */
@@ -847,7 +848,7 @@ static void load_edge_hashtable(GRAPH_global_context *ggctx)
                                                  graph_namespace_oid);
         /* open the relation (table) and begin the scan */
         graph_edge_label = table_open(edge_label_table_oid, AccessShareLock);
-        scan_desc = table_beginscan(graph_edge_label, snapshot, 0, NULL);
+        scan_desc = table_beginscan(graph_edge_label, snapshot, 0, NULL, SO_NONE);
         /* get the tupdesc - we don't need to release this one */
         tupdesc = RelationGetDescr(graph_edge_label);
         /* bail if the number of columns differs */
@@ -1754,13 +1755,20 @@ Datum age_graph_stats(PG_FUNCTION_ARGS)
  * DSM path: GetNamedDSMSegment init callback.
  * Called once when the DSM segment is first created.
  */
-static void age_dsm_init_callback(void *ptr)
+static void age_dsm_init_callback(void *ptr, void *arg)
 {
     GraphVersionState *state = (GraphVersionState *) ptr;
 
+    /*
+     * arg is unused. Its presence is mandated by the GetNamedDSMSegment()
+     * init-callback type void (*)(void *ptr, void *arg); AGE passes NULL for
+     * it because no per-call initialization context is needed. Acknowledge it
+     * explicitly so the build stays clean under -Wextra/-Wunused-parameter.
+     */
+    (void) arg;
+
     LWLockInitialize(&state->lock,
-                     LWLockNewTrancheId());
-    LWLockRegisterTranche(state->lock.tranche, "age_graph_version");
+                     LWLockNewTrancheId("age_graph_version"));
     state->num_entries = 0;
     memset(state->entries, 0, sizeof(state->entries));
 }
@@ -1777,7 +1785,7 @@ static GraphVersionState *get_version_state_dsm(void)
         GetNamedDSMSegment("age_graph_versions",
                            sizeof(GraphVersionState),
                            age_dsm_init_callback,
-                           &found);
+                           &found, NULL);
 }
 #endif /* PG_VERSION_NUM >= 170000 */
 

--- a/src/backend/utils/adt/age_vle.c
+++ b/src/backend/utils/adt/age_vle.c
@@ -63,6 +63,7 @@
 
 #include "postgres.h"
 
+#include "access/htup_details.h"
 #include "common/hashfn.h"
 #include "funcapi.h"
 #include "miscadmin.h"

--- a/src/backend/utils/adt/agtype.c
+++ b/src/backend/utils/adt/agtype.c
@@ -32,6 +32,7 @@
 #include "varatt.h"
 #include "utils/jsonfuncs.h"
 #include <math.h>
+#include <time.h>
 
 #include <float.h>
 
@@ -56,6 +57,8 @@
 #include "utils/float.h"
 #include "utils/lsyscache.h"
 #include "utils/snapmgr.h"
+#include "utils/tuplesort.h"
+#include "utils/tuplestore.h"
 #include "utils/typcache.h"
 #include "utils/age_vle.h"
 #include "utils/agtype_parser.h"
@@ -6169,7 +6172,7 @@ static Datum get_vertex(const char *graph, const char *vertex_label,
                     F_GRAPHIDEQ, Int64GetDatum(graphid));
 
         index_scan_desc = index_beginscan(graph_vertex_label, index_rel, 
-                                          snapshot, NULL, 1, 0);
+                                          snapshot, NULL, 1, 0, SO_NONE);
         index_rescan(index_scan_desc, scan_keys, 1, NULL, 0);
 
         if (index_getnext_slot(index_scan_desc, ForwardScanDirection, slot))
@@ -6188,7 +6191,8 @@ static Datum get_vertex(const char *graph, const char *vertex_label,
         ScanKeyInit(&scan_keys[0], 1, BTEqualStrategyNumber, F_GRAPHIDEQ,
                     GRAPHID_GET_DATUM(graphid));
 
-        scan_desc = table_beginscan(graph_vertex_label, snapshot, 1, scan_keys);
+        scan_desc = table_beginscan(graph_vertex_label, snapshot, 1, scan_keys,
+                                    SO_NONE);
         tuple = heap_getnext(scan_desc, ForwardScanDirection);
     }
 
@@ -9487,7 +9491,7 @@ Datum age_split(PG_FUNCTION_ARGS)
                                          PointerGetDatum(text_delimiter));
 
     /* now build an agtype array of strings */
-    if (PointerIsValid(DatumGetPointer(text_array)))
+    if (DatumGetPointer(text_array) != NULL)
     {
         ArrayType *array = DatumGetArrayTypeP(text_array);
         agtype_in_state result;
@@ -9512,8 +9516,8 @@ Datum age_split(PG_FUNCTION_ARGS)
             Datum d;
 
             /* get the string element from the array */
-            string = VARDATA(elements[i]);
-            string_len = VARSIZE(elements[i]) - VARHDRSZ;
+            string = VARDATA(DatumGetPointer(elements[i]));
+            string_len = VARSIZE(DatumGetPointer(elements[i])) - VARHDRSZ;
 
             /* make a copy */
             string_copy = palloc0(string_len);

--- a/src/backend/utils/adt/agtype_ops.c
+++ b/src/backend/utils/adt/agtype_ops.c
@@ -1703,8 +1703,8 @@ Datum agtype_exists_any(PG_FUNCTION_ARGS)
         }
 
         strVal.type = AGTV_STRING;
-        strVal.val.string.val = VARDATA(key_datums[i]);
-        strVal.val.string.len = VARSIZE(key_datums[i]) - VARHDRSZ;
+        strVal.val.string.val = VARDATA(DatumGetPointer(key_datums[i]));
+        strVal.val.string.len = VARSIZE(DatumGetPointer(key_datums[i])) - VARHDRSZ;
 
         if (find_agtype_value_from_container(&agt->root,
                                         AGT_FOBJECT | AGT_FARRAY,
@@ -1744,8 +1744,8 @@ Datum agtype_exists_all(PG_FUNCTION_ARGS)
         }
 
         strVal.type = AGTV_STRING;
-        strVal.val.string.val = VARDATA(key_datums[i]);
-        strVal.val.string.len = VARSIZE(key_datums[i]) - VARHDRSZ;
+        strVal.val.string.val = VARDATA(DatumGetPointer(key_datums[i]));
+        strVal.val.string.len = VARSIZE(DatumGetPointer(key_datums[i])) - VARHDRSZ;
 
         if (find_agtype_value_from_container(&agt->root,
                                         AGT_FOBJECT | AGT_FARRAY,

--- a/src/backend/utils/adt/agtype_util.c
+++ b/src/backend/utils/adt/agtype_util.c
@@ -1300,7 +1300,7 @@ static agtype_value *push_agtype_value_scalar(agtype_parse_state **pstate,
         break;
     case WAGT_END_OBJECT:
         uniqueify_agtype_object(&(*pstate)->cont_val);
-        /* fall through! */
+        pg_fallthrough;
     case WAGT_END_ARRAY:
         /* Steps here common to WAGT_END_OBJECT case */
         Assert(!scalar_val);

--- a/src/backend/utils/load/age_load.c
+++ b/src/backend/utils/load/age_load.c
@@ -540,9 +540,8 @@ void insert_batch(batch_insert_state *batch_state)
         for (i = 0; i < batch_state->num_tuples; i++)
         {
             result = ExecInsertIndexTuples(batch_state->resultRelInfo,
-                                           batch_state->slots[i],
-                                           batch_state->estate, false,
-                                           true, NULL, NIL, false);
+                                           batch_state->estate, EIIT_NO_DUPE_ERROR,
+                                           batch_state->slots[i], NIL, NULL);
 
             /* Check if the unique constraint is violated */
             if (list_length(result) != 0)


### PR DESCRIPTION
**Note:** A big thank you to Alexander Kukushkin <cyberdemn@gmail.com>
who's work helped to make this possible.
      
**Note:** This is a beta branch for PostgreSQL 19. This PR is part of the work to get the PG19 branch up and running. Other items will follow.

Adapt AGE to PostgreSQL 19's C API changes so the extension compiles cleanly (verified with COPT=-Werror) and passes the full regression suite against 19beta1. Each prototype change was matched to how AGE actually uses the function rather than blindly appending arguments.

Access-method scans: table_beginscan() and index_beginscan() gained a trailing uint32 flags. Pass SO_NONE (no special scan options); table_beginscan() still ORs in SO_TYPE_SEQSCAN internally, so behavior is unchanged. Add access/genam.h to the files that use index_*/IndexScanDesc (previously reached only transitively through now-leaner PG headers).

Tuple-slot init: MakeTupleTableSlot() and ExecInitScanTupleSlot() gained a uint16 flags. Pass 0. AGE's DML executors are CustomScanState nodes whose input tuples are synthesized agtype rows, so -- like PostgreSQL's own nodeCustom.c and nodeSubqueryscan.c -- 0 is correct. The TTS_FLAG_OBEYS_NOT_NULL_CONSTRAINTS hint that heap seq/index scans pass would be unsound here since these tuples are not guaranteed to obey a base relation's NOT NULL constraints.

DML tuple ops: heap_delete() added a uint32 options argument and dropped the trailing changingPart bool; table_tuple_update() added a uint32 options argument. Pass 0 in both (AGE used changingPart=false and no special options, so 0 preserves behavior).

ExecInsertIndexTuples() was reworked to
(resultRelInfo, estate, uint32 flags, slot, arbiterIndexes, specConflict) with flags EIIT_IS_UPDATE / EIIT_NO_DUPE_ERROR / EIIT_ONLY_SUMMARIZING. The old booleans map to flags: plain inserts (cypher_utils) use 0; SET uses EIIT_ONLY_SUMMARIZING when update_indexes == TU_Summarizing. Importantly, the bulk loader (age_load) previously passed noDupErr=true so it could detect the conflict list and raise its own error; this maps to EIIT_NO_DUPE_ERROR (not 0), preserving AGE's "Cannot insert duplicate vertex id" message instead of surfacing the raw unique-constraint violation.

CreateSchemaCommand() replaced its const char *queryString parameter with a ParseState *. Build one with make_parsestate(), set p_sourcetext to the generated command string, and free_parsestate() afterward (mirroring standard_ProcessUtility). The argument count is unchanged, so this mismatch only warns under default flags -- another reason the build uses -Werror.

Shared-memory/locks: LWLockNewTrancheId() now takes the tranche name directly and LWLockRegisterTranche() was removed; GetNamedDSMSegment() and its init callback gained a void *arg. Update the graph-version DSM setup accordingly, passing NULL for the unused callback argument.

Miscellaneous: add includes exposed by leaner PG19 headers (catalog/pg_type.h for TEXTOID/CHAROID, <time.h> for CLOCK_REALTIME, utils/tuplesort.h and utils/tuplestore.h, access/htup_details.h for GETSTRUCT/heap_form_tuple); PointerIsValid() was removed (use != NULL); VARDATA()/VARSIZE() now require a pointer, so wrap the Datum in DatumGetPointer(); replace the fall-through comment with the pg_fallthrough macro; and const-qualify JumbleState * in the post_parse_analyze hook signature.

Regression output: the only differences under PG19 are cosmetic and are reflected in the expected files. PostgreSQL 19 reworded undefined function/operator errors -- the "HINT: No function/operator matches the given name and argument types" line became "DETAIL: No function/operator of that name accepts...", and for a wholly unknown operator "DETAIL: There is no operator of that name."; the ERROR lines themselves are unchanged. This accounts for the expr, cypher_call, jsonb_operators and subgraph updates. Separately, a divergent-path query in cypher_match returned the same four paths in a different, non-deterministic order under PG19; add ORDER BY p to make it deterministic (matching the project's practice of ordering non-deterministic RETURN queries). The returned row multiset is unchanged -- it is purely a reordering, not a data difference.

Co-authored-by: Copilot <copilot@github.com>
Co-authored-by: Alexander Kukushkin <cyberdemn@gmail.com>

modified:   regress/expected/cypher_call.out
modified:   regress/expected/cypher_match.out
modified:   regress/expected/expr.out
modified:   regress/expected/jsonb_operators.out
modified:   regress/expected/subgraph.out
modified:   regress/sql/cypher_match.sql
modified:   src/backend/catalog/ag_label.c
modified:   src/backend/commands/graph_commands.c
modified:   src/backend/executor/cypher_create.c
modified:   src/backend/executor/cypher_delete.c
modified:   src/backend/executor/cypher_merge.c
modified:   src/backend/executor/cypher_set.c
modified:   src/backend/executor/cypher_utils.c
modified:   src/backend/parser/cypher_analyze.c
modified:   src/backend/parser/cypher_expr.c
modified:   src/backend/parser/cypher_keywords.c
modified:   src/backend/utils/adt/age_global_graph.c
modified:   src/backend/utils/adt/age_vle.c
modified:   src/backend/utils/adt/agtype.c
modified:   src/backend/utils/adt/agtype_ops.c
modified:   src/backend/utils/adt/agtype_util.c
modified:   src/backend/utils/load/age_load.c