### PR TITLE
Fix installcheck fetch-depth parameter to 100

### DIFF
--- a/.github/workflows/installcheck.yaml
+++ b/.github/workflows/installcheck.yaml
@@ -69,7 +69,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 75
+          fetch-depth: 100
 
       - name: Build AGE
         id: build


### PR DESCRIPTION
Fix the installcheck.yaml fetch-depth parameter to 100. This release, being rather large, exceeded the original value of 75 (commits) and caused the upgrade test to fail. The new value will resolve this and make it unlikely to become a problem in the future.

NOTE: We need to keep releases under this number of commits.

modified:   .github/workflows/installcheck.yaml