### PR TITLE
Fix Docker Hub build: use postgres:19beta1 base image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,9 @@
 #
 
 # Build stage: Install necessary development tools for compilation and installation
-FROM postgres:19 AS build
+# PG19 is still in beta: Docker Hub has no `postgres:19` tag yet, only `19beta1`.
+# Bump both stages to `postgres:19` once the PG19 GA image is published.
+FROM postgres:19beta1 AS build
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends --no-install-suggests \
@@ -34,7 +36,8 @@ RUN make && make install
 
 
 # Final stage: Create a final image by copying the files created in the build stage
-FROM postgres:19
+# PG19 beta: use `19beta1` until the `postgres:19` GA tag exists (see build stage).
+FROM postgres:19beta1
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends --no-install-suggests \

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -17,7 +17,9 @@
 #
 
 
-FROM postgres:19
+# PG19 is still in beta: Docker Hub has no `postgres:19` tag yet, only `19beta1`.
+# Bump to `postgres:19` once the PG19 GA image is published.
+FROM postgres:19beta1
 
 RUN apt-get update
 RUN apt-get install --assume-yes --no-install-recommends --no-install-suggests \


### PR DESCRIPTION
PostgreSQL 19 is still in beta, so the official Docker Hub postgres image has no `19` tag yet -- only `19beta1`. The Docker Hub autobuild failed with:

    postgres:19: not found
    failed to resolve source metadata for docker.io/library/postgres:19

Point both docker/Dockerfile (build and final stages) and docker/Dockerfile.dev at postgres:19beta1 until the PG19 GA image is published.

Co-authored-by: Copilot <copilot@github.com>

modified:   docker/Dockerfile
modified:   docker/Dockerfile.dev