### PR TITLE
Point PG19 driver tests at the PG19 image (dev_snapshot_PG19)

### DIFF
--- a/drivers/docker-compose.yml
+++ b/drivers/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
   db:
-    image: apache/age:dev_snapshot_master
+    image: apache/age:dev_snapshot_PG19
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=agens

--- a/drivers/jdbc/lib/src/test/java/org/apache/age/jdbc/BaseDockerizedTest.java
+++ b/drivers/jdbc/lib/src/test/java/org/apache/age/jdbc/BaseDockerizedTest.java
@@ -54,7 +54,7 @@ public class BaseDockerizedTest {
         String CORRECT_DB_PASSWORDS = "postgres";
 
         agensGraphContainer = new GenericContainer<>(DockerImageName
-            .parse("apache/age:dev_snapshot_master"))
+            .parse("apache/age:dev_snapshot_PG19"))
             .withEnv("POSTGRES_PASSWORD", CORRECT_DB_PASSWORDS)
             .withExposedPorts(5432)
             .waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*\\n", 2)

--- a/drivers/nodejs/test/index.test.ts
+++ b/drivers/nodejs/test/index.test.ts
@@ -38,7 +38,7 @@ const config = {
 const testGraphName = 'age_test'
 
 // DESIGN NOTE: All test suites use { createExtension: false } intentionally.
-// The CI Docker image (apache/age:dev_snapshot_master) has the AGE extension
+// The CI Docker image (apache/age:dev_snapshot_PG19) has the AGE extension
 // pre-installed, matching the GitHub Actions workflow. Using createExtension: false
 // is the correct security default — auto-creating extensions requires SUPERUSER
 // privileges and conflates extension lifecycle management with session setup.


### PR DESCRIPTION
The PG19 branch's driver test suites referenced apache/age:dev_snapshot_master -- the master (PG18) snapshot -- instead of the branch's own PG19 image. Each branch self-references its dev_snapshot_PG<N> image on Docker Hub (dev_snapshot_PG19 is published), matching master's use of dev_snapshot_master.

Update the three references so the go/nodejs/python (docker compose) and JDBC (testcontainers) driver suites test against PG19:
- drivers/docker-compose.yml
- drivers/jdbc/lib/src/test/java/org/apache/age/jdbc/BaseDockerizedTest.java
- drivers/nodejs/test/index.test.ts (design-note comment)

Co-authored-by: Copilot <copilot@github.com>

modified:   drivers/docker-compose.yml
modified:   drivers/jdbc/lib/src/test/java/org/apache/age/jdbc/BaseDockerizedTest.java
modified:   drivers/nodejs/test/index.test.ts