### PR TITLE
Fix misleading text in README Pre-Installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Refer to our latest [Apache AGE documentation](https://age.apache.org/age-manual
 
 <h2><img height="30" src="/img/installation.svg">&nbsp;&nbsp;Pre-Installation</h2>
 
-Install the following essential libraries according to each OS. Building AGE from the source depends on the following Linux libraries (Ubuntu package names shown below):
+Install the following essential libraries according to each OS. Building AGE from the source depends on the following Linux libraries:
 
 - **CentOS**
 ```bash


### PR DESCRIPTION
## What this PR does

Removes the misleading '(Ubuntu package names shown below)' text from the Pre-Installation section.

## Why

The section lists package installation commands for CentOS, Fedora, and Ubuntu - not just Ubuntu. The original text was confusing since Ubuntu packages were listed last, not first.

Fixes #403