### PR TITLE
fix docs: update dead links

### DIFF
--- a/drivers/golang/README.md
+++ b/drivers/golang/README.md
@@ -34,7 +34,7 @@ Check [latest version](https://github.com/apache/age/releases)
 ### For more information about [Apache AGE](https://age.apache.org/)
 * Apache Age : https://age.apache.org/
 * GitHub : https://github.com/apache/age
-* Document : https://age.apache.org/docs/
+* Document : https://age.apache.org/age-manual/
 
 ### Check that Apache AGE is loaded on your PostgreSQL database
 Connect to your containerized Postgres instance and then run the following commands:

--- a/drivers/golang/TYPES.md
+++ b/drivers/golang/TYPES.md
@@ -1,6 +1,6 @@
 # Apache AGE - Go driver Type mapping
 
-* For more information about Apache AGE result types : https://age.apache.org/docs/Apache_AGE_Guide.pdf
+* For more information about Apache AGE result types : https://age.apache.org/age-manual/master/intro/types.html
 
 | Type | AGE Result | Go Type |
 |------|------------|---------|

--- a/drivers/jdbc/README.md
+++ b/drivers/jdbc/README.md
@@ -9,8 +9,8 @@ You should have installed following jar files and packages.
 - [gradle](https://gradle.org/install/) build tool
 - [postgres JDBC driver](https://jdbc.postgresql.org/download/)
 - [antlr4-4.9.2-complete](https://repo1.maven.org/maven2/org/antlr/antlr4/4.9.2/)
-- [common-lang3](http://www.java2s.com/Code/Jar/c/Downloadcommonlang3jar.htm)
-- [commons-text-1.6](http://www.java2s.com/ref/jar/download-commonstext16jar-file.html)
+- [common-lang3](https://mvnrepository.com/artifact/org.apache.commons/commons-lang3)
+- [commons-text-1.6](https://mvnrepository.com/artifact/org.apache.commons/commons-text)
 
 Kindly unzip the jars if they are zipped before using them.
 


### PR DESCRIPTION
1.  drivers/golang/README.md 
	-  https://age.apache.org/docs/ -> 404
	- Changed to https://age.apache.org/age-manual/master/index.html

2. drivers/golang/TYPES.md
	- https://age.apache.org/docs/Apache_AGE_Guide.pdf -> 404
	- Changed to https://age.apache.org/age-manual/master/intro/types.html
	
3. drivers/jdbc/README.md 
	-  http://www.java2s.com/Code/Jar/c/Downloadcommonlang3jar.htm -> wordpress test page
	- changed to https://mvnrepository.com/artifact/org.apache.commons/commons-lang3
	
	- http://www.java2s.com/ref/jar/download-commonstext16jar-file.html -> wordpress test page
	- changed to https://mvnrepository.com/artifact/org.apache.commons/commons-text