### PR TITLE
Optimize writable entity lookup and preserve same-row alias updates

### DIFF
--- a/regress/expected/agtype.out
+++ b/regress/expected/agtype.out
@@ -3779,6 +3779,31 @@ SELECT ag_catalog.agtype_volatile_wrapper(-32767::int2);
  -32767
 (1 row)
 
+-- TID is packed as BlockNumber << 16 | OffsetNumber for hidden ctid transport.
+SELECT ag_catalog.agtype_volatile_wrapper('(0,1)'::tid);
+ agtype_volatile_wrapper 
+-------------------------
+ 1
+(1 row)
+
+SELECT ag_catalog.agtype_volatile_wrapper('(42,7)'::tid);
+ agtype_volatile_wrapper 
+-------------------------
+ 2752519
+(1 row)
+
+SELECT ag_catalog.agtype_volatile_wrapper('(65535,65535)'::tid);
+ agtype_volatile_wrapper 
+-------------------------
+ 4294967295
+(1 row)
+
+SELECT ag_catalog.agtype_volatile_wrapper('(4294967294,65535)'::tid);
+ agtype_volatile_wrapper 
+-------------------------
+ 281474976645119
+(1 row)
+
 -- These should fail
 SELECT ag_catalog.agtype_volatile_wrapper(32768::int2);
 ERROR:  smallint out of range

--- a/regress/expected/cypher_delete.out
+++ b/regress/expected/cypher_delete.out
@@ -812,15 +812,76 @@ SELECT id as "expected: 0 rows"              FROM setdelete._ag_label_edge;
 ------------------
 (0 rows)
 
+-- stale ctid fallback - SET one alias, then DELETE the same entity via another alias.
+SELECT * FROM cypher('setdelete', $$ CREATE (:B) $$) as ("CREATE" agtype);
+ CREATE 
+--------
+(0 rows)
+
+SELECT * FROM cypher('setdelete', $$ MATCH (n:B), (m:B) WHERE id(n) = id(m) SET n.flag = true DELETE m $$) as ("SET + DELETE alias" agtype);
+ SET + DELETE alias 
+--------------------
+(0 rows)
+
+SELECT count(*) as "expected: 0 rows" FROM setdelete."B";
+ expected: 0 rows 
+------------------
+                0
+(1 row)
+
+-- hidden ctid propagation through WITH.
+SELECT * FROM cypher('setdelete', $$ CREATE (:C) $$) as ("CREATE" agtype);
+ CREATE 
+--------
+(0 rows)
+
+SELECT * FROM cypher('setdelete', $$ MATCH (n:C) WITH n DELETE n $$) as ("WITH DELETE" agtype);
+ WITH DELETE 
+-------------
+(0 rows)
+
+SELECT count(*) as "expected: 0 rows" FROM setdelete."C";
+ expected: 0 rows 
+------------------
+                0
+(1 row)
+
+-- stale edge ctid fallback with DETACH DELETE through another alias.
+SELECT * FROM cypher('setdelete', $$ CREATE (:D)-[:de]->(:D) $$) AS ("CREATE" agtype);
+ CREATE 
+--------
+(0 rows)
+
+SELECT * FROM cypher('setdelete', $$ MATCH (n)-[e:de]->(m), (x)-[f:de]->(y) WHERE id(e) = id(f) SET e.i = 1 DETACH DELETE x $$) AS ("SET + DETACH alias" agtype);
+ SET + DETACH alias 
+--------------------
+(0 rows)
+
+SELECT count(*) as "expected: 1 row" FROM setdelete."D";
+ expected: 1 row 
+-----------------
+               1
+(1 row)
+
+SELECT count(*) as "expected: 0 rows" FROM setdelete.de;
+ expected: 0 rows 
+------------------
+                0
+(1 row)
+
 -- clean up
 SELECT drop_graph('setdelete', true);
-NOTICE:  drop cascades to 6 other objects
+NOTICE:  drop cascades to 10 other objects
 DETAIL:  drop cascades to table setdelete._ag_label_vertex
 drop cascades to table setdelete._ag_label_edge
 drop cascades to table setdelete."A"
 drop cascades to table setdelete.n
 drop cascades to table setdelete.e
 drop cascades to table setdelete.m
+drop cascades to table setdelete."B"
+drop cascades to table setdelete."C"
+drop cascades to table setdelete."D"
+drop cascades to table setdelete.de
 NOTICE:  graph "setdelete" has been dropped
  drop_graph 
 ------------

--- a/regress/expected/cypher_remove.out
+++ b/regress/expected/cypher_remove.out
@@ -457,6 +457,45 @@ SELECT * FROM cypher('cypher_remove', $$MATCH ()-[e:edge_multi_property]-() REMO
  {"id": 3659174697238529, "label": "edge_multi_property", "end_id": 281474976710664, "start_id": 281474976710663, "properties": {}}::edge
 (2 rows)
 
+-- Hidden ctid columns must propagate through WITH for REMOVE.
+SELECT * FROM cypher('cypher_remove', $$
+    CREATE (:ctid_remove {drop_me: 1})
+$$) AS (a agtype);
+ a 
+---
+(0 rows)
+
+SELECT * FROM cypher('cypher_remove', $$
+    MATCH (n:ctid_remove)
+    WITH n
+    REMOVE n.drop_me
+    RETURN n
+$$) AS (a agtype);
+                                     a                                      
+----------------------------------------------------------------------------
+ {"id": 3940649673949185, "label": "ctid_remove", "properties": {}}::vertex
+(1 row)
+
+-- REMOVE must fall back from a stale ctid after an earlier SET moves the row.
+SELECT * FROM cypher('cypher_remove', $$
+    CREATE (:ctid_remove_stale {drop_me: 1})
+$$) AS (a agtype);
+ a 
+---
+(0 rows)
+
+SELECT * FROM cypher('cypher_remove', $$
+    MATCH (n:ctid_remove_stale), (m:ctid_remove_stale)
+    WHERE id(n) = id(m)
+    SET n.changed = true
+    REMOVE m.drop_me
+    RETURN m
+$$) AS (a agtype);
+                                                a                                                
+-------------------------------------------------------------------------------------------------
+ {"id": 4222124650659841, "label": "ctid_remove_stale", "properties": {"changed": true}}::vertex
+(1 row)
+
 --Errors
 SELECT * FROM cypher('cypher_remove', $$REMOVE n.i$$) AS (a agtype);
 ERROR:  REMOVE cannot be the first clause in a Cypher query
@@ -475,7 +514,7 @@ LINE 1: SELECT * FROM cypher('cypher_remove', $$MATCH (n) REMOVE wro...
 --
 DROP FUNCTION remove_test;
 SELECT drop_graph('cypher_remove', true);
-NOTICE:  drop cascades to 13 other objects
+NOTICE:  drop cascades to 15 other objects
 DETAIL:  drop cascades to table cypher_remove._ag_label_vertex
 drop cascades to table cypher_remove._ag_label_edge
 drop cascades to table cypher_remove.test_1
@@ -489,6 +528,8 @@ drop cascades to table cypher_remove.test_6
 drop cascades to table cypher_remove.e
 drop cascades to table cypher_remove.test_7
 drop cascades to table cypher_remove.edge_multi_property
+drop cascades to table cypher_remove.ctid_remove
+drop cascades to table cypher_remove.ctid_remove_stale
 NOTICE:  graph "cypher_remove" has been dropped
  drop_graph 
 ------------

--- a/regress/expected/cypher_set.out
+++ b/regress/expected/cypher_set.out
@@ -1227,6 +1227,319 @@ $$) AS (a agtype);
  {"id": 5066549580791809, "label": "TestE2", "properties": {"pathRels": [{"id": 5348024557502465, "label": "E2REL", "end_id": 5066549580791810, "start_id": 5066549580791809, "properties": {}}::edge], "pathNodes": [{"id": 5066549580791809, "label": "TestE2", "properties": {}}::vertex, {"id": 5066549580791810, "label": "TestE2", "properties": {}}::vertex]}}::vertex
 (1 row)
 
+-- ============================================================================
+-- ctid lookup fallback tests
+-- ============================================================================
+SELECT create_graph('ctid_set');
+NOTICE:  graph "ctid_set" has been created
+ create_graph 
+--------------
+ 
+(1 row)
+
+-- Same entity referenced through two aliases: the second SET must fall back
+-- from the stale ctid to graphid lookup after the first SET moves the tuple.
+SELECT * FROM cypher('ctid_set', $$CREATE (:v {k: 1})$$) AS (a agtype);
+ a 
+---
+(0 rows)
+
+SELECT * FROM cypher('ctid_set', $$
+    MATCH (n:v), (m:v)
+    WHERE id(n) = id(m)
+    SET n.a = 1
+    SET m.a = 2
+    RETURN n.a, m.a
+$$) AS (n agtype, m agtype);
+ n | m 
+---+---
+ 2 | 2
+(1 row)
+
+SELECT * FROM cypher('ctid_set', $$MATCH (n:v) RETURN n.a$$) AS (a agtype);
+ a 
+---
+ 2
+(1 row)
+
+-- Updating the same entity through different aliases must preserve earlier
+-- changes, including when a later RHS depends on an earlier SET.
+SELECT * FROM cypher('ctid_set', $$
+    CREATE (:alias_vertex {k: 1})
+$$) AS (a agtype);
+ a 
+---
+(0 rows)
+
+SELECT * FROM cypher('ctid_set', $$
+    MATCH (n:alias_vertex), (m:alias_vertex)
+    WHERE id(n) = id(m)
+    SET n.a = 1
+    SET m.b = n.a + 1
+    RETURN n.a, m.a, m.b
+$$) AS (na agtype, ma agtype, mb agtype);
+ na | ma | mb 
+----+----+----
+ 1  | 1  | 2
+(1 row)
+
+SELECT * FROM cypher('ctid_set', $$
+    MATCH (n:alias_vertex)
+    RETURN n.a, n.b
+$$) AS (a agtype, b agtype);
+ a | b 
+---+---
+ 1 | 2
+(1 row)
+
+-- The same alias synchronization is required for edges.
+SELECT * FROM cypher('ctid_set', $$
+    CREATE ()-[:alias_edge {k: 1}]->()
+$$) AS (a agtype);
+ a 
+---
+(0 rows)
+
+SELECT * FROM cypher('ctid_set', $$
+    MATCH ()-[n:alias_edge]->(), ()-[m:alias_edge]->()
+    WHERE id(n) = id(m)
+    SET n.a = 1
+    SET m.b = n.a + 1
+    RETURN n.a, m.a, m.b
+$$) AS (na agtype, ma agtype, mb agtype);
+ na | ma | mb 
+----+----+----
+ 1  | 1  | 2
+(1 row)
+
+SELECT * FROM cypher('ctid_set', $$
+    MATCH ()-[n:alias_edge]->()
+    RETURN n.a, n.b
+$$) AS (a agtype, b agtype);
+ a | b 
+---+---
+ 1 | 2
+(1 row)
+
+-- Hidden ctid columns must propagate through WITH.
+SELECT * FROM cypher('ctid_set', $$CREATE (:w {k: 1})$$) AS (a agtype);
+ a 
+---
+(0 rows)
+
+SELECT * FROM cypher('ctid_set', $$
+    MATCH (n:w)
+    WITH n
+    SET n.k = 2
+    RETURN n.k
+$$) AS (a agtype);
+ a 
+---
+ 2
+(1 row)
+
+SELECT * FROM cypher('ctid_set', $$MATCH (n:w) RETURN n.k$$) AS (a agtype);
+ a 
+---
+ 2
+(1 row)
+
+-- Hidden ctid columns must follow simple WITH aliases too.
+SELECT * FROM cypher('ctid_set', $$
+    MATCH (n:w)
+    WITH n AS m
+    SET m.k = 3
+    RETURN m.k
+$$) AS (a agtype);
+ a 
+---
+ 3
+(1 row)
+
+SELECT * FROM cypher('ctid_set', $$MATCH (n:w) RETURN n.k$$) AS (a agtype);
+ a 
+---
+ 3
+(1 row)
+
+-- Computed WITH expressions must not inherit a ctid from one of their inputs.
+SELECT * FROM cypher('ctid_set', $$
+    CREATE (:expr {k: 1}), (:expr {k: 2})
+$$) AS (a agtype);
+ a 
+---
+(0 rows)
+
+SELECT * FROM cypher('ctid_set', $$
+    MATCH (a:expr {k: 1}), (b:expr {k: 2})
+    WITH CASE WHEN a.k = 1 THEN a ELSE b END AS n
+    SET n.mark = 1
+    RETURN n.k, n.mark
+$$) AS (k agtype, mark agtype);
+ k | mark 
+---+------
+ 1 | 1
+(1 row)
+
+-- Aggregating WITH clauses must not leak pre-aggregation ctid values.
+SELECT * FROM cypher('ctid_set', $$
+    CREATE (:aggregate {k: 1}), (:aggregate {k: 2})
+$$) AS (a agtype);
+ a 
+---
+(0 rows)
+
+SELECT * FROM cypher('ctid_set', $$
+    MATCH (n:aggregate)
+    WITH collect(n) AS nodes, count(*) AS total
+    UNWIND nodes AS n
+    SET n.total = total
+    RETURN n.k, n.total
+$$) AS (k agtype, total agtype);
+ k | total 
+---+-------
+ 1 | 2
+ 2 | 2
+(2 rows)
+
+-- DISTINCT is a row-shaping boundary and must preserve its semantics.
+SELECT * FROM cypher('ctid_set', $$
+    CREATE (:distinct_source), (:distinct_source),
+           (:distinct_target {hits: 0})
+$$) AS (a agtype);
+ a 
+---
+(0 rows)
+
+SELECT * FROM cypher('ctid_set', $$
+    MATCH (:distinct_source), (n:distinct_target)
+    WITH DISTINCT n
+    SET n.hits = n.hits + 1
+    RETURN n.hits
+$$) AS (hits agtype);
+ hits 
+------
+ 1
+(1 row)
+
+-- Edge labels have no inherited primary key. A user-created B-tree index on
+-- id must support fallback when DISTINCT intentionally suppresses the ctid.
+SELECT * FROM cypher('ctid_set', $$
+    CREATE ()-[:indexed_edge {k: 1}]->(),
+           ()-[:indexed_edge {k: 2}]->()
+$$) AS (a agtype);
+ a 
+---
+(0 rows)
+
+CREATE INDEX ctid_set_indexed_edge_id_idx
+    ON ctid_set.indexed_edge (id);
+SELECT * FROM cypher('ctid_set', $$
+    MATCH ()-[e:indexed_edge]->()
+    WITH DISTINCT e
+    SET e.indexed = true
+    RETURN e.k, e.indexed
+    ORDER BY e.k
+$$) AS (k agtype, indexed agtype);
+ k | indexed 
+---+---------
+ 1 | true
+ 2 | true
+(2 rows)
+
+-- WITH * and RETURN * must not expose hidden ctid target entries.
+SELECT * FROM cypher('ctid_set', $$
+    CREATE (:wildcard {k: 1})
+$$) AS (a agtype);
+ a 
+---
+(0 rows)
+
+SELECT * FROM cypher('ctid_set', $$
+    MATCH (n:wildcard)
+    WITH *
+    SET n.updated = true
+    RETURN *
+$$) AS (n agtype);
+                                               n                                                
+------------------------------------------------------------------------------------------------
+ {"id": 3377699720527873, "label": "wildcard", "properties": {"k": 1, "updated": true}}::vertex
+(1 row)
+
+SELECT * FROM cypher('ctid_set', $$
+    MATCH (n:wildcard)
+    RETURN n.updated
+$$) AS (updated agtype);
+ updated 
+---------
+ true
+(1 row)
+
+-- DISTINCT suppresses the ctid. Without the default vertex id index, lookup
+-- must fall back to a sequential scan and still update the intended rows.
+SELECT * FROM cypher('ctid_set', $$
+    CREATE (:seqscan_vertex {k: 1}), (:seqscan_vertex {k: 2})
+$$) AS (a agtype);
+ a 
+---
+(0 rows)
+
+ALTER TABLE ctid_set.seqscan_vertex
+    DROP CONSTRAINT seqscan_vertex_pkey;
+SELECT * FROM cypher('ctid_set', $$
+    MATCH (n:seqscan_vertex)
+    WITH DISTINCT n
+    SET n.fallback = true
+    RETURN n.k, n.fallback
+    ORDER BY n.k
+$$) AS (k agtype, fallback agtype);
+ k | fallback 
+---+----------
+ 1 | true
+ 2 | true
+(2 rows)
+
+-- ExtensibleNode metadata, including ctid_position, must survive generic-plan
+-- reuse. DDL invalidation between executions must rebuild a valid plan.
+SELECT * FROM cypher('ctid_set', $$
+    CREATE (:generic_plan {k: 1})
+$$) AS (a agtype);
+ a 
+---
+(0 rows)
+
+SET plan_cache_mode = force_generic_plan;
+PREPARE ctid_generic_plan(agtype) AS
+SELECT * FROM cypher('ctid_set', $$
+    MATCH (n:generic_plan)
+    WHERE n.k = $target
+    SET n.mark = $mark
+    RETURN n.mark
+$$, $1) AS (mark agtype);
+EXECUTE ctid_generic_plan('{"target": 1, "mark": 10}'::agtype);
+ mark 
+------
+ 10
+(1 row)
+
+ALTER TABLE ctid_set.generic_plan ADD COLUMN review_dummy integer;
+EXECUTE ctid_generic_plan('{"target": 1, "mark": 20}'::agtype);
+ mark 
+------
+ 20
+(1 row)
+
+DEALLOCATE ctid_generic_plan;
+RESET plan_cache_mode;
+SELECT * FROM cypher('ctid_set', $$
+    MATCH (n:generic_plan)
+    RETURN n.mark
+$$) AS (mark agtype);
+ mark 
+------
+ 20
+(1 row)
+
 --
 -- Clean up
 --
@@ -1299,6 +1612,28 @@ drop cascades to table issue_1884."TestE1"
 drop cascades to table issue_1884."TestE2"
 drop cascades to table issue_1884."E2REL"
 NOTICE:  graph "issue_1884" has been dropped
+ drop_graph 
+------------
+ 
+(1 row)
+
+SELECT drop_graph('ctid_set', true);
+NOTICE:  drop cascades to 14 other objects
+DETAIL:  drop cascades to table ctid_set._ag_label_vertex
+drop cascades to table ctid_set._ag_label_edge
+drop cascades to table ctid_set.v
+drop cascades to table ctid_set.alias_vertex
+drop cascades to table ctid_set.alias_edge
+drop cascades to table ctid_set.w
+drop cascades to table ctid_set.expr
+drop cascades to table ctid_set.aggregate
+drop cascades to table ctid_set.distinct_source
+drop cascades to table ctid_set.distinct_target
+drop cascades to table ctid_set.indexed_edge
+drop cascades to table ctid_set.wildcard
+drop cascades to table ctid_set.seqscan_vertex
+drop cascades to table ctid_set.generic_plan
+NOTICE:  graph "ctid_set" has been dropped
  drop_graph 
 ------------
  

--- a/regress/sql/agtype.sql
+++ b/regress/sql/agtype.sql
@@ -1064,6 +1064,12 @@ SELECT ag_catalog.agtype_volatile_wrapper(1::int2);
 SELECT ag_catalog.agtype_volatile_wrapper(32767::int2);
 SELECT ag_catalog.agtype_volatile_wrapper(-32767::int2);
 
+-- TID is packed as BlockNumber << 16 | OffsetNumber for hidden ctid transport.
+SELECT ag_catalog.agtype_volatile_wrapper('(0,1)'::tid);
+SELECT ag_catalog.agtype_volatile_wrapper('(42,7)'::tid);
+SELECT ag_catalog.agtype_volatile_wrapper('(65535,65535)'::tid);
+SELECT ag_catalog.agtype_volatile_wrapper('(4294967294,65535)'::tid);
+
 -- These should fail
 SELECT ag_catalog.agtype_volatile_wrapper(32768::int2);
 SELECT ag_catalog.agtype_volatile_wrapper(-32768::int2);

--- a/regress/sql/cypher_delete.sql
+++ b/regress/sql/cypher_delete.sql
@@ -299,6 +299,22 @@ SELECT * FROM cypher('setdelete', $$ MATCH (n)-[e]->(m) SET e.i = 1 DETACH DELET
 SELECT id as "expected: 2 rows (m vertices)" FROM setdelete._ag_label_vertex;
 SELECT id as "expected: 0 rows"              FROM setdelete._ag_label_edge;
 
+-- stale ctid fallback - SET one alias, then DELETE the same entity via another alias.
+SELECT * FROM cypher('setdelete', $$ CREATE (:B) $$) as ("CREATE" agtype);
+SELECT * FROM cypher('setdelete', $$ MATCH (n:B), (m:B) WHERE id(n) = id(m) SET n.flag = true DELETE m $$) as ("SET + DELETE alias" agtype);
+SELECT count(*) as "expected: 0 rows" FROM setdelete."B";
+
+-- hidden ctid propagation through WITH.
+SELECT * FROM cypher('setdelete', $$ CREATE (:C) $$) as ("CREATE" agtype);
+SELECT * FROM cypher('setdelete', $$ MATCH (n:C) WITH n DELETE n $$) as ("WITH DELETE" agtype);
+SELECT count(*) as "expected: 0 rows" FROM setdelete."C";
+
+-- stale edge ctid fallback with DETACH DELETE through another alias.
+SELECT * FROM cypher('setdelete', $$ CREATE (:D)-[:de]->(:D) $$) AS ("CREATE" agtype);
+SELECT * FROM cypher('setdelete', $$ MATCH (n)-[e:de]->(m), (x)-[f:de]->(y) WHERE id(e) = id(f) SET e.i = 1 DETACH DELETE x $$) AS ("SET + DETACH alias" agtype);
+SELECT count(*) as "expected: 1 row" FROM setdelete."D";
+SELECT count(*) as "expected: 0 rows" FROM setdelete.de;
+
 -- clean up
 SELECT drop_graph('setdelete', true);
 

--- a/regress/sql/cypher_remove.sql
+++ b/regress/sql/cypher_remove.sql
@@ -136,6 +136,29 @@ SELECT * FROM cypher('cypher_remove', $$CREATE ()-[:edge_multi_property { i: 5, 
 SELECT * FROM cypher('cypher_remove', $$MATCH ()-[e:edge_multi_property]-() RETURN e$$) AS (a agtype);
 SELECT * FROM cypher('cypher_remove', $$MATCH ()-[e:edge_multi_property]-() REMOVE e.i, e.j RETURN e$$) AS (a agtype);
 
+-- Hidden ctid columns must propagate through WITH for REMOVE.
+SELECT * FROM cypher('cypher_remove', $$
+    CREATE (:ctid_remove {drop_me: 1})
+$$) AS (a agtype);
+SELECT * FROM cypher('cypher_remove', $$
+    MATCH (n:ctid_remove)
+    WITH n
+    REMOVE n.drop_me
+    RETURN n
+$$) AS (a agtype);
+
+-- REMOVE must fall back from a stale ctid after an earlier SET moves the row.
+SELECT * FROM cypher('cypher_remove', $$
+    CREATE (:ctid_remove_stale {drop_me: 1})
+$$) AS (a agtype);
+SELECT * FROM cypher('cypher_remove', $$
+    MATCH (n:ctid_remove_stale), (m:ctid_remove_stale)
+    WHERE id(n) = id(m)
+    SET n.changed = true
+    REMOVE m.drop_me
+    RETURN m
+$$) AS (a agtype);
+
 --Errors
 SELECT * FROM cypher('cypher_remove', $$REMOVE n.i$$) AS (a agtype);
 

--- a/regress/sql/cypher_set.sql
+++ b/regress/sql/cypher_set.sql
@@ -542,6 +542,180 @@ SELECT * FROM cypher('issue_1884', $$
     RETURN a
 $$) AS (a agtype);
 
+-- ============================================================================
+-- ctid lookup fallback tests
+-- ============================================================================
+
+SELECT create_graph('ctid_set');
+
+-- Same entity referenced through two aliases: the second SET must fall back
+-- from the stale ctid to graphid lookup after the first SET moves the tuple.
+SELECT * FROM cypher('ctid_set', $$CREATE (:v {k: 1})$$) AS (a agtype);
+SELECT * FROM cypher('ctid_set', $$
+    MATCH (n:v), (m:v)
+    WHERE id(n) = id(m)
+    SET n.a = 1
+    SET m.a = 2
+    RETURN n.a, m.a
+$$) AS (n agtype, m agtype);
+SELECT * FROM cypher('ctid_set', $$MATCH (n:v) RETURN n.a$$) AS (a agtype);
+
+-- Updating the same entity through different aliases must preserve earlier
+-- changes, including when a later RHS depends on an earlier SET.
+SELECT * FROM cypher('ctid_set', $$
+    CREATE (:alias_vertex {k: 1})
+$$) AS (a agtype);
+SELECT * FROM cypher('ctid_set', $$
+    MATCH (n:alias_vertex), (m:alias_vertex)
+    WHERE id(n) = id(m)
+    SET n.a = 1
+    SET m.b = n.a + 1
+    RETURN n.a, m.a, m.b
+$$) AS (na agtype, ma agtype, mb agtype);
+SELECT * FROM cypher('ctid_set', $$
+    MATCH (n:alias_vertex)
+    RETURN n.a, n.b
+$$) AS (a agtype, b agtype);
+
+-- The same alias synchronization is required for edges.
+SELECT * FROM cypher('ctid_set', $$
+    CREATE ()-[:alias_edge {k: 1}]->()
+$$) AS (a agtype);
+SELECT * FROM cypher('ctid_set', $$
+    MATCH ()-[n:alias_edge]->(), ()-[m:alias_edge]->()
+    WHERE id(n) = id(m)
+    SET n.a = 1
+    SET m.b = n.a + 1
+    RETURN n.a, m.a, m.b
+$$) AS (na agtype, ma agtype, mb agtype);
+SELECT * FROM cypher('ctid_set', $$
+    MATCH ()-[n:alias_edge]->()
+    RETURN n.a, n.b
+$$) AS (a agtype, b agtype);
+
+-- Hidden ctid columns must propagate through WITH.
+SELECT * FROM cypher('ctid_set', $$CREATE (:w {k: 1})$$) AS (a agtype);
+SELECT * FROM cypher('ctid_set', $$
+    MATCH (n:w)
+    WITH n
+    SET n.k = 2
+    RETURN n.k
+$$) AS (a agtype);
+SELECT * FROM cypher('ctid_set', $$MATCH (n:w) RETURN n.k$$) AS (a agtype);
+
+-- Hidden ctid columns must follow simple WITH aliases too.
+SELECT * FROM cypher('ctid_set', $$
+    MATCH (n:w)
+    WITH n AS m
+    SET m.k = 3
+    RETURN m.k
+$$) AS (a agtype);
+SELECT * FROM cypher('ctid_set', $$MATCH (n:w) RETURN n.k$$) AS (a agtype);
+
+-- Computed WITH expressions must not inherit a ctid from one of their inputs.
+SELECT * FROM cypher('ctid_set', $$
+    CREATE (:expr {k: 1}), (:expr {k: 2})
+$$) AS (a agtype);
+SELECT * FROM cypher('ctid_set', $$
+    MATCH (a:expr {k: 1}), (b:expr {k: 2})
+    WITH CASE WHEN a.k = 1 THEN a ELSE b END AS n
+    SET n.mark = 1
+    RETURN n.k, n.mark
+$$) AS (k agtype, mark agtype);
+
+-- Aggregating WITH clauses must not leak pre-aggregation ctid values.
+SELECT * FROM cypher('ctid_set', $$
+    CREATE (:aggregate {k: 1}), (:aggregate {k: 2})
+$$) AS (a agtype);
+SELECT * FROM cypher('ctid_set', $$
+    MATCH (n:aggregate)
+    WITH collect(n) AS nodes, count(*) AS total
+    UNWIND nodes AS n
+    SET n.total = total
+    RETURN n.k, n.total
+$$) AS (k agtype, total agtype);
+
+-- DISTINCT is a row-shaping boundary and must preserve its semantics.
+SELECT * FROM cypher('ctid_set', $$
+    CREATE (:distinct_source), (:distinct_source),
+           (:distinct_target {hits: 0})
+$$) AS (a agtype);
+SELECT * FROM cypher('ctid_set', $$
+    MATCH (:distinct_source), (n:distinct_target)
+    WITH DISTINCT n
+    SET n.hits = n.hits + 1
+    RETURN n.hits
+$$) AS (hits agtype);
+
+-- Edge labels have no inherited primary key. A user-created B-tree index on
+-- id must support fallback when DISTINCT intentionally suppresses the ctid.
+SELECT * FROM cypher('ctid_set', $$
+    CREATE ()-[:indexed_edge {k: 1}]->(),
+           ()-[:indexed_edge {k: 2}]->()
+$$) AS (a agtype);
+CREATE INDEX ctid_set_indexed_edge_id_idx
+    ON ctid_set.indexed_edge (id);
+SELECT * FROM cypher('ctid_set', $$
+    MATCH ()-[e:indexed_edge]->()
+    WITH DISTINCT e
+    SET e.indexed = true
+    RETURN e.k, e.indexed
+    ORDER BY e.k
+$$) AS (k agtype, indexed agtype);
+
+-- WITH * and RETURN * must not expose hidden ctid target entries.
+SELECT * FROM cypher('ctid_set', $$
+    CREATE (:wildcard {k: 1})
+$$) AS (a agtype);
+SELECT * FROM cypher('ctid_set', $$
+    MATCH (n:wildcard)
+    WITH *
+    SET n.updated = true
+    RETURN *
+$$) AS (n agtype);
+SELECT * FROM cypher('ctid_set', $$
+    MATCH (n:wildcard)
+    RETURN n.updated
+$$) AS (updated agtype);
+
+-- DISTINCT suppresses the ctid. Without the default vertex id index, lookup
+-- must fall back to a sequential scan and still update the intended rows.
+SELECT * FROM cypher('ctid_set', $$
+    CREATE (:seqscan_vertex {k: 1}), (:seqscan_vertex {k: 2})
+$$) AS (a agtype);
+ALTER TABLE ctid_set.seqscan_vertex
+    DROP CONSTRAINT seqscan_vertex_pkey;
+SELECT * FROM cypher('ctid_set', $$
+    MATCH (n:seqscan_vertex)
+    WITH DISTINCT n
+    SET n.fallback = true
+    RETURN n.k, n.fallback
+    ORDER BY n.k
+$$) AS (k agtype, fallback agtype);
+
+-- ExtensibleNode metadata, including ctid_position, must survive generic-plan
+-- reuse. DDL invalidation between executions must rebuild a valid plan.
+SELECT * FROM cypher('ctid_set', $$
+    CREATE (:generic_plan {k: 1})
+$$) AS (a agtype);
+SET plan_cache_mode = force_generic_plan;
+PREPARE ctid_generic_plan(agtype) AS
+SELECT * FROM cypher('ctid_set', $$
+    MATCH (n:generic_plan)
+    WHERE n.k = $target
+    SET n.mark = $mark
+    RETURN n.mark
+$$, $1) AS (mark agtype);
+EXECUTE ctid_generic_plan('{"target": 1, "mark": 10}'::agtype);
+ALTER TABLE ctid_set.generic_plan ADD COLUMN review_dummy integer;
+EXECUTE ctid_generic_plan('{"target": 1, "mark": 20}'::agtype);
+DEALLOCATE ctid_generic_plan;
+RESET plan_cache_mode;
+SELECT * FROM cypher('ctid_set', $$
+    MATCH (n:generic_plan)
+    RETURN n.mark
+$$) AS (mark agtype);
+
 --
 -- Clean up
 --
@@ -551,6 +725,7 @@ SELECT drop_graph('cypher_set', true);
 SELECT drop_graph('cypher_set_1', true);
 SELECT drop_graph('issue_1634', true);
 SELECT drop_graph('issue_1884', true);
+SELECT drop_graph('ctid_set', true);
 
 --
 -- End

--- a/src/backend/executor/cypher_delete.c
+++ b/src/backend/executor/cypher_delete.c
@@ -123,6 +123,9 @@ static void begin_cypher_delete(CustomScanState *node, EState *estate,
     if (estate->es_output_cid == 0)
         estate->es_output_cid = estate->es_snapshot->curcid;
 
+    /* Build the per-statement index and fetch-slot lookup cache. */
+    css->entity_lookup_cache = create_entity_lookup_cache();
+
     Increment_Estate_CommandId(estate);
 }
 
@@ -204,6 +207,10 @@ static void end_cypher_delete(CustomScanState *node)
     increment_graph_version(css->delete_data->graph_oid);
 
     hash_destroy(((cypher_delete_custom_scan_state *)node)->vertex_id_htab);
+
+    /* Release cached index handles and fetch slots. */
+    destroy_entity_lookup_cache(
+        ((cypher_delete_custom_scan_state *)node)->entity_lookup_cache);
 
     ExecEndNode(node->ss.ps.lefttree);
 }
@@ -384,8 +391,6 @@ static void process_delete_list(CustomScanState *node)
     EState *estate = node->ss.ps.state;
     HTAB *qual_cache = NULL;
     HASHCTL hashctl;
-    HTAB *index_cache = NULL;
-    HASHCTL idx_hashctl;
 
     /* Hash table for caching compiled security quals per label */
     MemSet(&hashctl, 0, sizeof(hashctl));
@@ -395,19 +400,10 @@ static void process_delete_list(CustomScanState *node)
     qual_cache = hash_create("delete_qual_cache", 8, &hashctl,
                              HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
 
-    MemSet(&idx_hashctl, 0, sizeof(idx_hashctl));
-    idx_hashctl.keysize = sizeof(Oid);
-    idx_hashctl.entrysize = sizeof(IndexCacheEntry);
-    idx_hashctl.hcxt = CurrentMemoryContext;
-    index_cache = hash_create("delete_index_cache", 8, &idx_hashctl,
-                              HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
-
     foreach(lc, css->delete_data->delete_items)
     {
         cypher_delete_item *item;
         agtype_value *original_entity_value, *id, *label;
-        ScanKeyData scan_keys[1];
-        TableScanDesc scan_desc = NULL;
         ResultRelInfo *resultRelInfo;
         HeapTuple heap_tuple = NULL;
         char *label_name;
@@ -415,14 +411,6 @@ static void process_delete_list(CustomScanState *node)
         int entity_position;
         Oid relid;
         Relation rel;
-        int id_attr_num;
-        Oid index_oid = InvalidOid;
-        TupleTableSlot *slot = NULL;
-        Relation index_rel = NULL;
-        IndexScanDesc index_scan_desc = NULL;
-        bool shouldFree = false;
-        IndexCacheEntry *idx_entry;
-        bool found_idx_entry;     
 
         item = lfirst(lc);
 
@@ -448,34 +436,12 @@ static void process_delete_list(CustomScanState *node)
          * Setup the scan key to require the id field on-disc to match the
          * entity's graphid.
          */
-        if (original_entity_value->type == AGTV_VERTEX)
-        {
-            id_attr_num = Anum_ag_label_vertex_table_id;
-            ScanKeyInit(&scan_keys[0], Anum_ag_label_vertex_table_id,
-                        BTEqualStrategyNumber, F_GRAPHIDEQ,
-                        GRAPHID_GET_DATUM(id->val.int_value));
-        }
-        else if (original_entity_value->type == AGTV_EDGE)
-        {
-            id_attr_num = Anum_ag_label_edge_table_id;
-            ScanKeyInit(&scan_keys[0], Anum_ag_label_edge_table_id,
-                        BTEqualStrategyNumber, F_GRAPHIDEQ,
-                        GRAPHID_GET_DATUM(id->val.int_value));
-        }
-        else
+        if (original_entity_value->type != AGTV_VERTEX &&
+            original_entity_value->type != AGTV_EDGE)
         {
             ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
                     errmsg("DELETE clause can only delete vertices and edges")));
         }
-
-        idx_entry = hash_search(index_cache, &relid, HASH_ENTER, &found_idx_entry);
-
-        if (!found_idx_entry)
-        {
-            idx_entry->index_oid = find_usable_btree_index_for_attr(rel, id_attr_num);
-        }
-
-        index_oid = idx_entry->index_oid;
 
         /*
          * Setup the scan description, with the correct snapshot and scan keys.
@@ -483,84 +449,49 @@ static void process_delete_list(CustomScanState *node)
         estate->es_snapshot->curcid = GetCurrentCommandId(false);
         estate->es_output_cid = GetCurrentCommandId(false);
 
-        if (OidIsValid(index_oid))
-        {
-            slot = table_slot_create(rel, NULL);
-
-            index_rel = index_open(index_oid, RowExclusiveLock);
-            index_scan_desc = index_beginscan(rel, index_rel, estate->es_snapshot, NULL, 1, 0);
-            index_rescan(index_scan_desc, scan_keys, 1, NULL, 0);
-
-            if (index_getnext_slot(index_scan_desc, ForwardScanDirection, slot))
-            {
-                heap_tuple = ExecFetchSlotHeapTuple(slot, true, &shouldFree);
-            }
-        }
-        else
-        {
-            scan_desc = table_beginscan(rel, estate->es_snapshot, 1, scan_keys);
-            /* Retrieve the tuple. */
-            heap_tuple = heap_getnext(scan_desc, ForwardScanDirection);
-        }
-
+        heap_tuple = find_entity_tuple(
+            rel, estate->es_snapshot, id->val.int_value, scanTupleSlot,
+            item->ctid_position, css->entity_lookup_cache);
         if (HeapTupleIsValid(heap_tuple))
         {
             bool passed_rls = true;
 
-            /* Check RLS security quals (USING policy) before delete */
             if (check_enable_rls(relid, InvalidOid, true) == RLS_ENABLED)
             {
                 RLSCacheEntry *entry;
                 bool found_rls;
 
-                entry = hash_search(qual_cache, &relid, HASH_ENTER, &found_rls);
+                entry = hash_search(qual_cache, &relid, HASH_ENTER,
+                                    &found_rls);
                 if (!found_rls)
                 {
-                    entry->qualExprs = setup_security_quals(resultRelInfo, estate, node, CMD_DELETE);
-                    entry->slot = ExecInitExtraTupleSlot(estate, RelationGetDescr(rel), &TTSOpsHeapTuple);
+                    entry->qualExprs = setup_security_quals(
+                        resultRelInfo, estate, node, CMD_DELETE);
+                    entry->slot = ExecInitExtraTupleSlot(
+                        estate, RelationGetDescr(rel), &TTSOpsHeapTuple);
                 }
-
                 ExecStoreHeapTuple(heap_tuple, entry->slot, false);
-
-                if (!check_security_quals(entry->qualExprs, entry->slot, econtext))
-                {
-                    passed_rls = false;
-                }
+                passed_rls = check_security_quals(entry->qualExprs,
+                                                  entry->slot, econtext);
             }
-
             if (passed_rls)
             {
                 /*
-                 * For vertices, we insert the vertex ID in the hashtable
-                 * vertex_id_htab. This hashtable is used later to process
-                 * connected edges.
+                 * Save deleted vertex IDs for the later connected-edge check.
+                 * DETACH DELETE removes those edges; plain DELETE reports an
+                 * error if any remain.
                  */
                 if (original_entity_value->type == AGTV_VERTEX)
                 {
                     bool found;
-                    hash_search(css->vertex_id_htab, (void *)&(id->val.int_value),
+
+                    hash_search(css->vertex_id_htab,
+                                (void *)&id->val.int_value,
                                 HASH_ENTER, &found);
                 }
-
-                /* At this point, we are ready to delete the node/vertex. */
                 delete_entity(estate, resultRelInfo, heap_tuple);
             }
-
-            if (shouldFree)
-            {
-                heap_freetuple(heap_tuple);
-            }
-        }
-
-        if (OidIsValid(index_oid))
-        {
-            ExecDropSingleTupleTableSlot(slot);
-            index_endscan(index_scan_desc);
-            index_close(index_rel, RowExclusiveLock);
-        }
-        else
-        {
-            table_endscan(scan_desc);
+            heap_freetuple(heap_tuple);
         }
 
         destroy_entity_result_rel_info(resultRelInfo);
@@ -568,7 +499,6 @@ static void process_delete_list(CustomScanState *node)
 
     /* Clean up the cache */
     hash_destroy(qual_cache);
-    hash_destroy(index_cache);
 }
 
 /*

--- a/src/backend/executor/cypher_merge.c
+++ b/src/backend/executor/cypher_merge.c
@@ -120,6 +120,10 @@ static void begin_cypher_merge(CustomScanState *node, EState *estate,
     /* TODO is this necessary? Removing it seems to not have an impact */
     ExecAssignExprContext(estate, &node->ss.ps);
 
+    /* Build the lookup cache only when MERGE can execute SET items. */
+    if (css->on_match_set_info != NULL || css->on_create_set_info != NULL)
+        css->entity_lookup_cache = create_entity_lookup_cache();
+
     ExecInitScanTupleSlot(estate, &node->ss,
                           ExecGetResultType(node->ss.ps.lefttree),
                           &TTSOpsVirtual);
@@ -1055,6 +1059,9 @@ static void end_cypher_merge(CustomScanState *node)
     {
         increment_graph_version(css->graph_oid);
     }
+
+    /* Release cached index handles and fetch slots. */
+    destroy_entity_lookup_cache(css->entity_lookup_cache);
 
     ExecEndNode(node->ss.ps.lefttree);
 

--- a/src/backend/executor/cypher_set.c
+++ b/src/backend/executor/cypher_set.c
@@ -25,10 +25,11 @@
 #include "storage/bufmgr.h"
 #include "utils/rls.h"
 
+#include "catalog/ag_graph.h"
+#include "catalog/ag_label.h"
 #include "executor/cypher_executor.h"
 #include "executor/cypher_utils.h"
 #include "utils/age_global_graph.h"
-#include "catalog/ag_graph.h"
 #include "utils/agtype.h"
 
 static void begin_cypher_set(CustomScanState *node, EState *estate,
@@ -92,6 +93,9 @@ static void begin_cypher_set(CustomScanState *node, EState *estate,
     {
         estate->es_output_cid = estate->es_snapshot->curcid;
     }
+
+    /* Build the per-statement index and fetch-slot lookup cache. */
+    css->entity_lookup_cache = create_entity_lookup_cache();
 
     Increment_Estate_CommandId(estate);
 }
@@ -237,17 +241,23 @@ static HeapTuple update_entity_tuple(ResultRelInfo *resultRelInfo,
 }
 
 /*
- * When the CREATE clause is the last cypher clause, consume all input from the
- * previous clause(s) in the first call of exec_cypher_create.
+ * When SET or REMOVE is the last cypher clause, consume all input from the
+ * previous clause(s) in the first call.
  */
 static void process_all_tuples(CustomScanState *node)
 {
     cypher_set_custom_scan_state *css = (cypher_set_custom_scan_state *)node;
     TupleTableSlot *slot;
     EState *estate = css->css.ss.ps.state;
+    ExprContext *econtext = css->css.ss.ps.ps_ExprContext;
 
     do
     {
+        /*
+         * The left child owns the current scan tuple and its Datums. Resetting
+         * this node's context only releases scratch from the previous update.
+         */
+        ResetExprContext(econtext);
         process_update_list(node);
         Decrement_Estate_CommandId(estate)
         slot = ExecProcNode(node->ss.ps.lefttree);
@@ -344,15 +354,12 @@ static agtype_value *replace_entity_in_path(agtype_value *path,
 }
 
 /*
- * When a vertex or edge is updated, we need to update the vertex
- * or edge if it is contained within a path. Scan through scanTupleSlot
- * to find all paths and check if they need to be updated.
+ * Keep every reference to an updated entity in the current row consistent.
+ * An entity can appear directly under another variable or within a path.
  */
-static void update_all_paths(CustomScanState *node, graphid id,
-                             agtype *updated_entity)
+static void update_entity_references(TupleTableSlot *scanTupleSlot, graphid id,
+                                     agtype *updated_entity)
 {
-    ExprContext *econtext = node->ss.ps.ps_ExprContext;
-    TupleTableSlot *scanTupleSlot = econtext->ecxt_scantuple;
     int i;
 
     for (i = 0; i < scanTupleSlot->tts_tupleDescriptor->natts; i++)
@@ -374,7 +381,7 @@ static void update_all_paths(CustomScanState *node, graphid id,
 
         original_entity = DATUM_GET_AGTYPE_P(scanTupleSlot->tts_values[i]);
 
-        /* if the value is not a scalar type, its not a path */
+        /* Vertices, edges, and paths are represented as scalar agtype values. */
         if (!AGTYPE_CONTAINER_IS_SCALAR(&original_entity->root))
         {
             continue;
@@ -382,8 +389,19 @@ static void update_all_paths(CustomScanState *node, graphid id,
 
         original_entity_value = get_ith_agtype_value_from_container(&original_entity->root, 0);
 
-        /* we found a path */
-        if (original_entity_value->type == AGTV_PATH)
+        if (original_entity_value->type == AGTV_VERTEX ||
+            original_entity_value->type == AGTV_EDGE)
+        {
+            agtype_value *original_id = GET_AGTYPE_VALUE_OBJECT_VALUE(
+                original_entity_value, "id");
+
+            if (original_id->val.int_value == id)
+            {
+                scanTupleSlot->tts_values[i] =
+                    AGTYPE_P_GET_DATUM(updated_entity);
+            }
+        }
+        else if (original_entity_value->type == AGTV_PATH)
         {
             /* check if the path contains the entity. */
             if (check_path(original_entity_value, id))
@@ -397,6 +415,54 @@ static void update_all_paths(CustomScanState *node, graphid id,
     }
 }
 
+static agtype_value *get_tuple_properties(Relation rel, HeapTuple tuple,
+                                          bool is_vertex)
+{
+    AttrNumber properties_attribute;
+    agtype_iterator *iterator;
+    agtype_iterator_token token;
+    agtype_parse_state *parse_state = NULL;
+    agtype_value value;
+    agtype_value *properties = NULL;
+    agtype *properties_agtype;
+    Datum properties_datum;
+    bool isnull;
+
+    properties_attribute = is_vertex
+        ? Anum_ag_label_vertex_table_properties
+        : Anum_ag_label_edge_table_properties;
+    properties_datum = heap_getattr(tuple, properties_attribute,
+                                    RelationGetDescr(rel), &isnull);
+    if (isnull)
+    {
+        return NULL;
+    }
+
+    properties_agtype = DATUM_GET_AGTYPE_P(properties_datum);
+
+    /*
+     * AGE has no general agtype-to-agtype_value conversion helper. Rebuild the
+     * container through its iterator to obtain a mutable AGTV_OBJECT.
+     */
+    iterator = agtype_iterator_init(&properties_agtype->root);
+    while ((token = agtype_iterator_next(&iterator, &value, true)) !=
+           WAGT_DONE)
+    {
+        properties = push_agtype_value(
+            &parse_state, token,
+            token < WAGT_BEGIN_ARRAY ? &value : NULL);
+    }
+
+    if (properties == NULL || properties->type != AGTV_OBJECT)
+    {
+        ereport(ERROR,
+                (errcode(ERRCODE_DATA_EXCEPTION),
+                 errmsg("entity properties must be an agtype object")));
+    }
+
+    return properties;
+}
+
 /*
  * Core SET logic that can be called from any executor (SET, MERGE, etc.).
  * Takes the CustomScanState for expression context and a
@@ -405,19 +471,36 @@ static void update_all_paths(CustomScanState *node, graphid id,
 void apply_update_list(CustomScanState *node,
                        cypher_update_information *set_info)
 {
+    EntityLookupCache *entity_lookup_cache = NULL;
     ExprContext *econtext = node->ss.ps.ps_ExprContext;
     TupleTableSlot *scanTupleSlot = econtext->ecxt_scantuple;
     ListCell *lc;
     EState *estate = node->ss.ps.state;
     int *luindex = NULL;
+    bool *seen_entity_positions = NULL;
     int lidx = 0;
     HTAB *qual_cache = NULL;
     HASHCTL hashctl;
-    HTAB *index_cache = NULL;
-    HASHCTL idx_hashctl;
+
+    if (node->methods == &cypher_set_exec_methods)
+    {
+        cypher_set_custom_scan_state *css =
+            (cypher_set_custom_scan_state *)node;
+
+        entity_lookup_cache = css->entity_lookup_cache;
+    }
+    else if (node->methods == &cypher_merge_exec_methods)
+    {
+        cypher_merge_custom_scan_state *css =
+            (cypher_merge_custom_scan_state *)node;
+
+        entity_lookup_cache = css->entity_lookup_cache;
+    }
 
     /* allocate an array to hold the last update index of each 'entity' */
     luindex = palloc0(sizeof(int) * scanTupleSlot->tts_nvalid);
+    seen_entity_positions =
+        palloc0(sizeof(bool) * scanTupleSlot->tts_nvalid);
 
     /* Hash table for caching compiled security quals per label */
     MemSet(&hashctl, 0, sizeof(hashctl));
@@ -426,13 +509,6 @@ void apply_update_list(CustomScanState *node,
     hashctl.hcxt = CurrentMemoryContext;
     qual_cache = hash_create("update_qual_cache", 8, &hashctl,
                              HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
-
-    MemSet(&idx_hashctl, 0, sizeof(idx_hashctl));
-    idx_hashctl.keysize = sizeof(Oid);
-    idx_hashctl.entrysize = sizeof(IndexCacheEntry);
-    idx_hashctl.hcxt = CurrentMemoryContext;
-    index_cache = hash_create("update_index_cache", 8, &idx_hashctl,
-                              HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
 
     /*
      * Iterate through the SET items list and store the loop index of each
@@ -469,20 +545,18 @@ void apply_update_list(CustomScanState *node,
         agtype *new_property_value = NULL;
         TupleTableSlot *slot;
         ResultRelInfo *resultRelInfo;
-        ScanKeyData scan_keys[1];
-        TableScanDesc scan_desc;
         bool remove_property;
         char *label_name;
         cypher_update_item *update_item;
         Datum new_entity;
         HeapTuple heap_tuple;
+        HeapTuple found_tuple = NULL;
         char *clause_name = set_info->clause_name;
         int cid;
-        Oid index_oid = InvalidOid;
         Relation rel;
         Oid relid;
-        IndexCacheEntry *idx_entry;
-        bool found_idx_entry;
+        bool first_update;
+        bool last_update;
 
         update_item = (cypher_update_item *)lfirst(lc);
 
@@ -584,46 +658,11 @@ void apply_update_list(CustomScanState *node,
             new_property_value = DATUM_GET_AGTYPE_P(scanTupleSlot->tts_values[update_item->prop_position - 1]);
         }
 
-        /* Alter the properties Agtype value. */
-        if (update_item->prop_name != NULL &&
-            strcmp(update_item->prop_name, "") != 0)
-        {
-            altered_properties = alter_property_value(original_properties,
-                                                      update_item->prop_name,
-                                                      new_property_value,
-                                                      remove_property);
-        }
-        else
-        {
-            altered_properties = alter_properties(
-                update_item->is_add ? original_properties : NULL,
-                new_property_value);
-
-            /*
-             * For SET clause with plus-equal operator, nulls are not removed
-             * from the map during transformation because they are required in
-             * the executor to alter (merge) properties correctly. Only after
-             * that step, they can be removed.
-             */
-            if (update_item->is_add)
-            {
-                remove_null_from_agtype_object(altered_properties);
-            }
-        }
-
         resultRelInfo = create_entity_result_rel_info(
             estate, set_info->graph_name, label_name);
 
         rel = resultRelInfo->ri_RelationDesc;
         relid = RelationGetRelid(rel);
-
-        idx_entry = hash_search(index_cache, &relid, HASH_ENTER, &found_idx_entry);
-        if (!found_idx_entry)
-        {
-            /*  Check if there is a valid  index on the 'id' column */
-            idx_entry->index_oid = find_usable_btree_index_for_attr(rel, 1);
-        }
-        index_oid = idx_entry->index_oid;
 
         slot = ExecInitExtraTupleSlot(
             estate, RelationGetDescr(resultRelInfo->ri_RelationDesc),
@@ -657,6 +696,73 @@ void apply_update_list(CustomScanState *node,
                 /* Use cached WCOs */
                 resultRelInfo->ri_WithCheckOptions = entry->withCheckOptions;
                 resultRelInfo->ri_WithCheckOptionExprs = entry->withCheckOptionExprs;
+            }
+        }
+
+        first_update =
+            !seen_entity_positions[update_item->entity_position - 1];
+        last_update =
+            luindex[update_item->entity_position - 1] == lidx;
+
+        cid = estate->es_snapshot->curcid;
+        estate->es_snapshot->curcid = GetCurrentCommandId(false);
+
+        /*
+         * The entity value carried by an alias may predate an earlier SET
+         * clause in the same query. Use the current heap tuple as the base for
+         * the first update of each entity position. The last update also needs
+         * the tuple for the physical write, so reuse that lookup below.
+         */
+        if (first_update || last_update)
+        {
+            found_tuple = find_entity_tuple(
+                rel, estate->es_snapshot, id->val.int_value, scanTupleSlot,
+                update_item->ctid_position, entity_lookup_cache);
+        }
+        if (first_update && HeapTupleIsValid(found_tuple))
+        {
+            ItemPointerData ctid_hint;
+
+            /* Compare both CTID components to detect a moved tuple version. */
+            if (!get_entity_ctid_hint(scanTupleSlot,
+                                      update_item->ctid_position,
+                                      &ctid_hint) ||
+                ItemPointerGetBlockNumberNoCheck(&ctid_hint) !=
+                    ItemPointerGetBlockNumberNoCheck(&found_tuple->t_self) ||
+                ItemPointerGetOffsetNumberNoCheck(&ctid_hint) !=
+                    ItemPointerGetOffsetNumberNoCheck(&found_tuple->t_self))
+            {
+                original_properties = get_tuple_properties(
+                    rel, found_tuple,
+                    original_entity_value->type == AGTV_VERTEX);
+            }
+        }
+        seen_entity_positions[update_item->entity_position - 1] = true;
+
+        /* Alter the properties Agtype value. */
+        if (update_item->prop_name != NULL &&
+            strcmp(update_item->prop_name, "") != 0)
+        {
+            altered_properties = alter_property_value(original_properties,
+                                                      update_item->prop_name,
+                                                      new_property_value,
+                                                      remove_property);
+        }
+        else
+        {
+            altered_properties = alter_properties(
+                update_item->is_add ? original_properties : NULL,
+                new_property_value);
+
+            /*
+             * For SET clause with plus-equal operator, nulls are not removed
+             * from the map during transformation because they are required in
+             * the executor to alter (merge) properties correctly. Only after
+             * that step, they can be removed.
+             */
+            if (update_item->is_add)
+            {
+                remove_null_from_agtype_object(altered_properties);
             }
         }
 
@@ -697,153 +803,76 @@ void apply_update_list(CustomScanState *node,
         /* place the datum in its tuple table slot position. */
         scanTupleSlot->tts_values[update_item->entity_position - 1] = new_entity;
 
-        /*
-         * If the tuple table slot has paths, we need to inspect them to see if
-         * the updated entity is contained within them and replace the entity
-         * if it is.
-         */
-        update_all_paths(node,
-                         id->val.int_value, DATUM_GET_AGTYPE_P(new_entity));
+        /* Keep aliases and paths in the current row in sync. */
+        update_entity_references(scanTupleSlot, id->val.int_value,
+                                 DATUM_GET_AGTYPE_P(new_entity));
 
         /*
          * If the last update index for the entity is equal to the current loop
          * index, then update this tuple.
          */
-        cid = estate->es_snapshot->curcid;
-        estate->es_snapshot->curcid = GetCurrentCommandId(false);
-
-        if (luindex[update_item->entity_position - 1] == lidx)
+        if (last_update)
         {
-            if (OidIsValid(index_oid))
-             {
-                Relation index_rel;
-                IndexScanDesc idx_scan_desc;
-                TupleTableSlot *index_slot;
-
-                index_rel = index_open(index_oid, RowExclusiveLock);
-                
-                /*
-                 * Setup the scan key to require the id field on-disc to match the
-                 * entity's graphid.
-                 */
-                ScanKeyInit(&scan_keys[0], 1, BTEqualStrategyNumber, F_GRAPHIDEQ,
-                            GRAPHID_GET_DATUM(id->val.int_value));
-
-                index_slot = table_slot_create(rel, NULL);
-                idx_scan_desc = index_beginscan(rel, index_rel, estate->es_snapshot, NULL, 1, 0);
-                index_rescan(idx_scan_desc, scan_keys, 1, NULL, 0);
-
-                if (index_getnext_slot(idx_scan_desc, ForwardScanDirection, index_slot))
-                {
-                    bool shouldFree;
-                    
-                    /* Retrieve the tuple from the slot */
-                    heap_tuple = ExecFetchSlotHeapTuple(index_slot, true, &shouldFree);
-
-                    if (HeapTupleIsValid(heap_tuple))
-                    {
-                        bool should_update = true;
-                        HeapTuple original_tuple = heap_tuple;
-                        
-                        /* Check RLS security quals (USING policy) before update */
-                        if (check_enable_rls(relid, InvalidOid, true) == RLS_ENABLED)
-                        {
-                            RLSCacheEntry *entry;
-
-                            /* Entry was already created earlier when setting up WCOs */
-                            entry = hash_search(qual_cache, &relid, HASH_FIND, NULL);
-                            if (!entry)
-                            {
-                                ereport(ERROR,
-                                        (errcode(ERRCODE_INTERNAL_ERROR),
-                                        errmsg("missing RLS cache entry for relation %u",
-                                                relid)));
-                            }
-
-                            ExecStoreHeapTuple(heap_tuple, entry->slot, false);
-                            should_update = check_security_quals(entry->qualExprs,
-                                                                entry->slot,
-                                                                econtext);
-                        }
-
-                        /* Silently skip if USING policy filters out this row */
-                        if (should_update)
-                        {
-                            heap_tuple = update_entity_tuple(resultRelInfo, slot, estate,
-                                                            original_tuple);
-                        }
-
-                        if (shouldFree)
-                        {
-                            heap_freetuple(original_tuple);
-                        }
-                    }
-                }
-
-                ExecDropSingleTupleTableSlot(index_slot);
-                index_endscan(idx_scan_desc);
-                index_close(index_rel, RowExclusiveLock);
-            } 
-            else 
+            if (HeapTupleIsValid(found_tuple))
             {
-                /*
-                * Setup the scan key to require the id field on-disc to match the
-                * entity's graphid.
-                */
-               ScanKeyInit(&scan_keys[0], 1, BTEqualStrategyNumber, F_GRAPHIDEQ,
-                            GRAPHID_GET_DATUM(id->val.int_value));
-                /*
-                 * Setup the scan description, with the correct snapshot and scan
-                 * keys.
-                 */
-                scan_desc = table_beginscan(resultRelInfo->ri_RelationDesc,
-                                            estate->es_snapshot, 1, scan_keys);
-                /* Retrieve the tuple. */
-                heap_tuple = heap_getnext(scan_desc, ForwardScanDirection);
+                bool should_update = true;
 
-                /*
-                * If the heap tuple still exists (It wasn't deleted between the
-                * match and this SET/REMOVE) update the heap_tuple.
-                */
-                if (HeapTupleIsValid(heap_tuple))
+                if (check_enable_rls(relid, InvalidOid, true) == RLS_ENABLED)
                 {
-                    bool should_update = true;
+                    RLSCacheEntry *entry;
 
-                    /* Check RLS security quals (USING policy) before update */
-                    if (check_enable_rls(relid, InvalidOid, true) == RLS_ENABLED)
+                    entry = hash_search(qual_cache, &relid, HASH_FIND, NULL);
+                    if (entry == NULL)
+                        elog(ERROR, "missing RLS cache entry for relation %u",
+                             relid);
+                    ExecStoreHeapTuple(found_tuple, entry->slot, false);
+                    should_update = check_security_quals(entry->qualExprs,
+                                                         entry->slot, econtext);
+                }
+                if (should_update)
+                {
+                    heap_tuple = update_entity_tuple(resultRelInfo, slot, estate,
+                                                     found_tuple);
+                    if (heap_tuple != NULL &&
+                        update_item->ctid_position > 0 &&
+                        update_item->ctid_position <=
+                            scanTupleSlot->tts_tupleDescriptor->natts)
                     {
-                        RLSCacheEntry *entry;
+                        agtype *ctid_agtype;
+                        agtype_value ctid_value;
+                        MemoryContext old;
 
-                        /* Entry was already created earlier when setting up WCOs */
-                        entry = hash_search(qual_cache, &relid, HASH_FIND, NULL);
-                        if (!entry)
-                        {
-                            ereport(ERROR,
-                                    (errcode(ERRCODE_INTERNAL_ERROR),
-                                    errmsg("missing RLS cache entry for relation %u",
-                                            relid)));
-                        }
+                        ctid_value.type = AGTV_INTEGER;
+                        ctid_value.val.int_value = AGE_CTID_PACK(
+                            ItemPointerGetBlockNumber(&heap_tuple->t_self),
+                            ItemPointerGetOffsetNumber(&heap_tuple->t_self));
+                        old = MemoryContextSwitchTo(
+                            econtext->ecxt_per_tuple_memory);
+                        ctid_agtype = agtype_value_to_agtype(&ctid_value);
+                        MemoryContextSwitchTo(old);
 
-                        ExecStoreHeapTuple(heap_tuple, entry->slot, false);
-                        should_update = check_security_quals(entry->qualExprs,
-                                                            entry->slot,
-                                                            econtext);
-                    }
-
-                    /* Silently skip if USING policy filters out this row */
-                    if (should_update)
-                    {
-                        heap_tuple = update_entity_tuple(resultRelInfo, slot, estate,
-                                                        heap_tuple);
+                        /*
+                         * Refresh this variable's hint only. Other aliases of
+                         * the graphid may retain a stale hint, which is safe:
+                         * find_entity_tuple() validates it and falls back to
+                         * graphid lookup.
+                         */
+                        scanTupleSlot->tts_values[
+                            update_item->ctid_position - 1] =
+                            AGTYPE_P_GET_DATUM(ctid_agtype);
+                        scanTupleSlot->tts_isnull[
+                            update_item->ctid_position - 1] = false;
                     }
                 }
-                /* close the ScanDescription */
-                table_endscan(scan_desc);
             }
         }
 
+        if (HeapTupleIsValid(found_tuple))
+        {
+            heap_freetuple(found_tuple);
+        }
         estate->es_snapshot->curcid = cid;
-        /* close relation */        
+        /* close relation */
         ExecCloseIndices(resultRelInfo);
         table_close(resultRelInfo->ri_RelationDesc, RowExclusiveLock);
 
@@ -853,10 +882,10 @@ void apply_update_list(CustomScanState *node,
 
     /* Clean up the cache */
     hash_destroy(qual_cache);
-    hash_destroy(index_cache);
 
     /* free our lookup array */
     pfree_if_not_null(luindex);
+    pfree_if_not_null(seen_entity_positions);
 }
 
 static void process_update_list(CustomScanState *node)
@@ -904,6 +933,11 @@ static TupleTableSlot *exec_cypher_set(CustomScanState *node)
         return NULL;
     }
 
+    /*
+     * The left child owns scanTupleSlot and its Datums. This reset only frees
+     * per-row scratch allocated by this CustomScan on the preceding call.
+     */
+    ResetExprContext(econtext);
     process_update_list(node);
 
     /* increment the command counter to reflect the updates */
@@ -921,6 +955,10 @@ static TupleTableSlot *exec_cypher_set(CustomScanState *node)
 
 static void end_cypher_set(CustomScanState *node)
 {
+    /* Release cached index handles and fetch slots. */
+    destroy_entity_lookup_cache(
+        ((cypher_set_custom_scan_state *)node)->entity_lookup_cache);
+
     ExecEndNode(node->ss.ps.lefttree);
 }
 

--- a/src/backend/executor/cypher_utils.c
+++ b/src/backend/executor/cypher_utils.c
@@ -24,6 +24,8 @@
 
 #include "postgres.h"
 
+#include "access/genam.h"
+#include "access/tableam.h"
 #include "executor/executor.h"
 #include "executor/nodeModifyTable.h"
 #include "miscadmin.h"
@@ -32,12 +34,20 @@
 #include "rewrite/rewriteManip.h"
 #include "rewrite/rowsecurity.h"
 #include "utils/acl.h"
+#include "utils/hsearch.h"
+#include "utils/memutils.h"
+#include "utils/relcache.h"
 #include "utils/rls.h"
 
 #include "catalog/ag_label.h"
 #include "commands/label_commands.h"
 #include "executor/cypher_utils.h"
 #include "utils/ag_cache.h"
+
+StaticAssertDecl(Anum_ag_label_vertex_table_id ==
+                     Anum_ag_label_edge_table_id,
+                 "vertex and edge id columns must have the same attribute "
+                 "number");
 
 /* RLS helper function declarations */
 static void get_policies_for_relation(Relation relation, CmdType cmd,
@@ -218,6 +228,357 @@ TupleTableSlot *populate_edge_tts(
     return elemTupleSlot;
 }
 
+/* Create the per-statement lookup cache in its own memory context. */
+EntityLookupCache *create_entity_lookup_cache(void)
+{
+    EntityLookupCache *cache;
+    MemoryContext mcxt;
+    MemoryContext old;
+    HASHCTL hashctl;
+
+    mcxt = AllocSetContextCreate(CurrentMemoryContext,
+                                 "AGE entity lookup cache",
+                                 ALLOCSET_SMALL_SIZES);
+    old = MemoryContextSwitchTo(mcxt);
+
+    cache = palloc0(sizeof(EntityLookupCache));
+    cache->mcxt = mcxt;
+
+    MemSet(&hashctl, 0, sizeof(hashctl));
+    hashctl.keysize = sizeof(Oid);
+    hashctl.entrysize = sizeof(EntityLookupCacheEntry);
+    hashctl.hcxt = mcxt;
+    cache->htab = hash_create("AGE entity lookup htab", 8, &hashctl,
+                              HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
+
+    MemoryContextSwitchTo(old);
+    return cache;
+}
+
+/* Release slots and index handles before deleting the memory context. */
+void destroy_entity_lookup_cache(EntityLookupCache *cache)
+{
+    HASH_SEQ_STATUS seq;
+    EntityLookupCacheEntry *entry;
+    MemoryContext mcxt;
+
+    if (cache == NULL)
+        return;
+
+    mcxt = cache->mcxt;
+    hash_seq_init(&seq, cache->htab);
+    while ((entry = (EntityLookupCacheEntry *) hash_seq_search(&seq)) != NULL)
+    {
+        if (entry->fetch_slot != NULL)
+            ExecDropSingleTupleTableSlot(entry->fetch_slot);
+        if (entry->id_index != NULL)
+            index_close(entry->id_index, AccessShareLock);
+    }
+
+    MemoryContextDelete(mcxt);
+}
+
+static EntityLookupCacheEntry *get_entity_lookup_cache_entry(
+    EntityLookupCache *cache, Relation rel)
+{
+    Oid relid = RelationGetRelid(rel);
+    bool found;
+    EntityLookupCacheEntry *entry;
+
+    entry = hash_search(cache->htab, &relid, HASH_ENTER, &found);
+    if (!found)
+    {
+        entry->relid = relid;
+        entry->index_initialized = false;
+        entry->fetch_slot = NULL;
+        entry->id_index = NULL;
+    }
+
+    return entry;
+}
+
+bool get_entity_ctid_hint(TupleTableSlot *scanTupleSlot,
+                          AttrNumber ctid_position, ItemPointer ctid)
+{
+    agtype *ctid_agt;
+    agtype_value *ctid_val;
+    OffsetNumber ctid_offset;
+    bool ctid_isnull;
+    Datum ctid_datum;
+    int64 packed;
+
+    if (ctid_position <= 0 || scanTupleSlot == NULL ||
+        ctid_position > scanTupleSlot->tts_tupleDescriptor->natts)
+        return false;
+
+    ctid_datum = slot_getattr(scanTupleSlot, ctid_position, &ctid_isnull);
+    if (ctid_isnull)
+        return false;
+
+    /*
+     * These checks validate the internal ctid transport format. A
+     * mismatch here means parser/targetlist metadata is broken, not that the
+     * hint merely went stale, so fail the statement instead of falling back.
+     */
+    if (TupleDescAttr(scanTupleSlot->tts_tupleDescriptor,
+                      ctid_position - 1)->atttypid != AGTYPEOID)
+        elog(ERROR, "unexpected ctid hint type");
+
+    ctid_agt = DATUM_GET_AGTYPE_P(ctid_datum);
+    if (!AGTYPE_CONTAINER_IS_SCALAR(&ctid_agt->root))
+        elog(ERROR, "unexpected non-scalar ctid hint");
+
+    ctid_val = get_ith_agtype_value_from_container(&ctid_agt->root, 0);
+    if (ctid_val == NULL || ctid_val->type != AGTV_INTEGER)
+        elog(ERROR, "unexpected non-integer ctid hint");
+
+    packed = ctid_val->val.int_value;
+    ctid_offset = AGE_CTID_UNPACK_OFFSET(packed);
+    if (ctid_offset == InvalidOffsetNumber)
+        elog(ERROR, "unexpected invalid ctid hint offset");
+
+    ItemPointerSetBlockNumber(ctid, AGE_CTID_UNPACK_BLOCK(packed));
+    ItemPointerSetOffsetNumber(ctid, ctid_offset);
+
+    return true;
+}
+
+/* Try a tuple lookup using the hidden packed ctid hint. */
+static HeapTuple try_ctid_fetch_tuple(Relation rel, Snapshot snapshot,
+                                      graphid entity_id,
+                                      TupleTableSlot *scanTupleSlot,
+                                      AttrNumber ctid_position,
+                                      EntityLookupCache *cache)
+{
+    HeapTuple result = NULL;
+    ItemPointerData ctid_data;
+    EntityLookupCacheEntry *entry = NULL;
+    TupleTableSlot *fetch_slot = NULL;
+    TupleTableSlot *slot;
+    bool id_isnull;
+    Datum id_datum;
+
+    if (!get_entity_ctid_hint(scanTupleSlot, ctid_position, &ctid_data))
+        return NULL;
+
+    if (cache != NULL)
+    {
+        entry = get_entity_lookup_cache_entry(cache, rel);
+        if (entry->fetch_slot == NULL)
+        {
+            MemoryContext old = MemoryContextSwitchTo(cache->mcxt);
+
+            entry->fetch_slot = MakeSingleTupleTableSlot(
+                RelationGetDescr(rel), &TTSOpsBufferHeapTuple);
+            MemoryContextSwitchTo(old);
+        }
+        fetch_slot = entry->fetch_slot;
+    }
+
+    slot = fetch_slot;
+    if (slot == NULL)
+        slot = MakeSingleTupleTableSlot(RelationGetDescr(rel),
+                                        &TTSOpsBufferHeapTuple);
+    else
+        ExecClearTuple(slot);
+
+    if (table_tuple_fetch_row_version(rel, &ctid_data, snapshot, slot))
+    {
+        id_datum = slot_getattr(slot, Anum_ag_label_vertex_table_id,
+                                &id_isnull);
+
+        /*
+         * table_tuple_fetch_row_version() only proves that the tuple at
+         * this TID is visible to the current snapshot. AGE writable clauses do
+         * not run the full PG UPDATE/DELETE recheck chain here, so Tier-1 must
+         * still verify logical identity itself. The ctid hint can be unreliable
+         * when an earlier writable clause in the same statement has already
+         * moved the tuple version, or when parser/alias propagation paired a
+         * well-formed but wrong ctid with this entity. Since ctid is only a
+         * physical locator, a visible tuple fetched here must still match
+         * entity_id before Tier-1 can use it.
+         */
+        if (id_isnull || DATUM_GET_GRAPHID(id_datum) != entity_id)
+            result = NULL;
+        else
+            result = ExecCopySlotHeapTuple(slot);
+    }
+
+    if (fetch_slot == NULL)
+        ExecDropSingleTupleTableSlot(slot);
+    else
+        ExecClearTuple(slot);
+
+    return result;
+}
+
+/*
+ * Try ctid lookup first, then a usable B-tree index on id. Use SeqScan only
+ * when the relation has no such index.
+ *
+ * The ctid hint must come from the same statement. If the tuple at that ctid
+ * is no longer visible, fall back to graphid lookup. A visible tuple fetched
+ * by ctid must still match entity_id.
+ *
+ * Returns a copied tuple, or NULL if not found.
+ * The caller must heap_freetuple() the result when done.
+ */
+HeapTuple find_entity_tuple(Relation rel, Snapshot snapshot,
+                            graphid entity_id,
+                            TupleTableSlot *scanTupleSlot,
+                            AttrNumber ctid_position,
+                            EntityLookupCache *cache)
+{
+    HeapTuple result = NULL;
+    EntityLookupCacheEntry *entry = NULL;
+    TupleTableSlot *fetch_slot = NULL;
+    Relation id_index = NULL;
+    bool own_index = false;
+
+    /* Tier 1: ctid direct fetch */
+    if (ctid_position > 0 && scanTupleSlot != NULL &&
+        ctid_position <= scanTupleSlot->tts_tupleDescriptor->natts)
+    {
+        result = try_ctid_fetch_tuple(rel, snapshot, entity_id,
+                                      scanTupleSlot, ctid_position, cache);
+        if (result != NULL)
+            return result;
+    }
+
+    /*
+     * Tier 2: use any valid, non-partial B-tree index whose first key is id.
+     * Edge labels do not inherit a primary key, but users can create an id
+     * index explicitly.
+     */
+    if (cache != NULL)
+    {
+        entry = get_entity_lookup_cache_entry(cache, rel);
+        if (!entry->index_initialized)
+        {
+            Oid index_oid;
+
+            index_oid = find_usable_btree_index_for_attr(
+                rel, Anum_ag_label_vertex_table_id);
+            if (OidIsValid(index_oid))
+            {
+                /*
+                 * This handle is only scanned. ExecOpenIndices() separately
+                 * opens indexes that may be changed by UPDATE or DELETE.
+                 */
+                entry->id_index = index_open(index_oid, AccessShareLock);
+            }
+            entry->index_initialized = true;
+        }
+        id_index = entry->id_index;
+    }
+    else
+    {
+        Oid index_oid;
+
+        index_oid = find_usable_btree_index_for_attr(
+            rel, Anum_ag_label_vertex_table_id);
+        if (OidIsValid(index_oid))
+        {
+            /* The lookup scan itself does not modify the index. */
+            id_index = index_open(index_oid, AccessShareLock);
+            own_index = true;
+        }
+    }
+
+    if (id_index != NULL)
+    {
+        ScanKeyData index_keys[1];
+        IndexScanDesc index_scan;
+        TupleTableSlot *slot;
+
+        /* Attribute 1 is the first key of the selected id index. */
+        ScanKeyInit(&index_keys[0], 1, BTEqualStrategyNumber, F_GRAPHIDEQ,
+                    GRAPHID_GET_DATUM(entity_id));
+
+        if (cache != NULL)
+        {
+            if (entry->fetch_slot == NULL)
+            {
+                MemoryContext old = MemoryContextSwitchTo(cache->mcxt);
+
+                entry->fetch_slot = MakeSingleTupleTableSlot(
+                    RelationGetDescr(rel), &TTSOpsBufferHeapTuple);
+                MemoryContextSwitchTo(old);
+            }
+            fetch_slot = entry->fetch_slot;
+        }
+
+        slot = fetch_slot;
+        if (slot == NULL)
+            slot = MakeSingleTupleTableSlot(RelationGetDescr(rel),
+                                            &TTSOpsBufferHeapTuple);
+        else
+            ExecClearTuple(slot);
+
+        index_scan = index_beginscan(rel, id_index, snapshot, NULL, 1, 0);
+        index_rescan(index_scan, index_keys, 1, NULL, 0);
+
+        if (index_getnext_slot(index_scan, ForwardScanDirection, slot))
+            result = ExecCopySlotHeapTuple(slot);
+
+        index_endscan(index_scan);
+
+        if (fetch_slot == NULL)
+            ExecDropSingleTupleTableSlot(slot);
+        else
+            ExecClearTuple(slot);
+        if (own_index)
+            index_close(id_index, AccessShareLock);
+
+        return result;
+    }
+
+    /* Tier 3: SeqScan fallback for relations without a usable id index. */
+    {
+        ScanKeyData heap_keys[1];
+        TableScanDesc scan_desc;
+        TupleTableSlot *slot;
+
+        /* attno here is the table column number of the id column */
+        ScanKeyInit(&heap_keys[0], Anum_ag_label_vertex_table_id,
+                    BTEqualStrategyNumber, F_GRAPHIDEQ,
+                    GRAPHID_GET_DATUM(entity_id));
+
+        if (cache != NULL)
+        {
+            if (entry->fetch_slot == NULL)
+            {
+                MemoryContext old = MemoryContextSwitchTo(cache->mcxt);
+
+                entry->fetch_slot = MakeSingleTupleTableSlot(
+                    RelationGetDescr(rel), &TTSOpsBufferHeapTuple);
+                MemoryContextSwitchTo(old);
+            }
+            fetch_slot = entry->fetch_slot;
+        }
+
+        slot = fetch_slot;
+        if (slot == NULL)
+            slot = MakeSingleTupleTableSlot(RelationGetDescr(rel),
+                                            &TTSOpsBufferHeapTuple);
+        else
+            ExecClearTuple(slot);
+
+        scan_desc = table_beginscan(rel, snapshot, 1, heap_keys);
+
+        if (table_scan_getnextslot(scan_desc, ForwardScanDirection, slot))
+            result = ExecCopySlotHeapTuple(slot);
+
+        table_endscan(scan_desc);
+
+        if (fetch_slot == NULL)
+            ExecDropSingleTupleTableSlot(slot);
+        else
+            ExecClearTuple(slot);
+    }
+
+    return result;
+}
 
 /*
  * Find out if the entity still exists. This is for 'implicit' deletion

--- a/src/backend/nodes/cypher_copyfuncs.c
+++ b/src/backend/nodes/cypher_copyfuncs.c
@@ -131,6 +131,9 @@ void copy_cypher_update_item(ExtensibleNode *newnode, const ExtensibleNode *from
 
     COPY_SCALAR_FIELD(prop_position);
     COPY_SCALAR_FIELD(entity_position);
+
+    /* copy ctid position for direct tuple fetch */
+    COPY_SCALAR_FIELD(ctid_position);
     COPY_STRING_FIELD(var_name);
     COPY_STRING_FIELD(prop_name);
     COPY_NODE_FIELD(qualified_name);
@@ -159,6 +162,9 @@ void copy_cypher_delete_item(ExtensibleNode *newnode, const ExtensibleNode *from
 
     COPY_NODE_FIELD(entity_position);
     COPY_STRING_FIELD(var_name);
+
+    /* copy ctid position for direct tuple fetch */
+    COPY_SCALAR_FIELD(ctid_position);
 }
 
 /* copy function for cypher_merge_information */

--- a/src/backend/nodes/cypher_outfuncs.c
+++ b/src/backend/nodes/cypher_outfuncs.c
@@ -109,6 +109,9 @@ void out_cypher_return(StringInfo str, const ExtensibleNode *node)
     WRITE_ENUM_FIELD(op, SetOperation);
     WRITE_NODE_FIELD(larg);
     WRITE_NODE_FIELD(rarg);
+
+    /* serialize is-WITH flag for ctid propagation through WITH */
+    WRITE_BOOL_FIELD(is_with);
 }
 
 /* serialization function for the cypher_with ExtensibleNode. */
@@ -447,6 +450,9 @@ void out_cypher_update_item(StringInfo str, const ExtensibleNode *node)
 
     WRITE_INT32_FIELD(prop_position);
     WRITE_INT32_FIELD(entity_position);
+
+    /* serialize ctid position for direct tuple fetch */
+    WRITE_INT32_FIELD(ctid_position);
     WRITE_STRING_FIELD(var_name);
     WRITE_STRING_FIELD(prop_name);
     WRITE_NODE_FIELD(qualified_name);
@@ -475,6 +481,9 @@ void out_cypher_delete_item(StringInfo str, const ExtensibleNode *node)
 
     WRITE_NODE_FIELD(entity_position);
     WRITE_STRING_FIELD(var_name);
+
+    /* serialize ctid position for direct tuple fetch */
+    WRITE_INT32_FIELD(ctid_position);
 }
 
 /* serialization function for the cypher_merge_information ExtensibleNode. */

--- a/src/backend/nodes/cypher_readfuncs.c
+++ b/src/backend/nodes/cypher_readfuncs.c
@@ -264,6 +264,9 @@ void read_cypher_update_item(struct ExtensibleNode *node)
 
     READ_INT_FIELD(prop_position);
     READ_INT_FIELD(entity_position);
+
+    /* deserialize ctid position for direct tuple fetch */
+    READ_INT_FIELD(ctid_position);
     READ_STRING_FIELD(var_name);
     READ_STRING_FIELD(prop_name);
     READ_NODE_FIELD(qualified_name);
@@ -298,6 +301,9 @@ void read_cypher_delete_item(struct ExtensibleNode *node)
 
     READ_NODE_FIELD(entity_position);
     READ_STRING_FIELD(var_name);
+
+    /* deserialize ctid position for direct tuple fetch */
+    READ_INT_FIELD(ctid_position);
 }
 
 /*

--- a/src/backend/parser/cypher_analyze.c
+++ b/src/backend/parser/cypher_analyze.c
@@ -1009,6 +1009,25 @@ static Query *analyze_cypher(List *stmt, ParseState *parent_pstate,
     cpstate->default_alias_num = 0;
     cpstate->entities = NIL;
     cpstate->subquery_where_flag = false;
+
+    /*
+     * Inject hidden ctid columns during MATCH only when the statement contains
+     * a clause that needs to relocate entity tuples. Read-only statements skip
+     * the extra columns entirely.
+     */
+    cpstate->has_writable_clause = false;
+    foreach (lc, stmt)
+    {
+        Node *clause_node = lfirst(lc);
+
+        if (is_ag_node(clause_node, cypher_set) ||
+            is_ag_node(clause_node, cypher_delete))
+        {
+            cpstate->has_writable_clause = true;
+            break;
+        }
+    }
+
     /*
      * install error context callback to adjust an error position since
      * locations in stmt are 0 based

--- a/src/backend/parser/cypher_clause.c
+++ b/src/backend/parser/cypher_clause.c
@@ -80,6 +80,7 @@
 #define AGE_VARNAME_ID AGE_DEFAULT_VARNAME_PREFIX"id"
 #define AGE_VARNAME_SET_CLAUSE AGE_DEFAULT_VARNAME_PREFIX"set_clause"
 #define AGE_VARNAME_SET_VALUE AGE_DEFAULT_VARNAME_PREFIX"set_value"
+#define AGE_VARNAME_CTID_FORMAT AGE_DEFAULT_VARNAME_PREFIX"ctid_%s"
 
 /*
  * In the transformation stage, we need to track
@@ -266,6 +267,18 @@ static Expr *add_volatile_wrapper(Expr *node);
 static bool variable_exists(cypher_parsestate *cpstate, char *name);
 static void add_volatile_wrapper_to_target_entry(List *target_list, int resno);
 static int get_target_entry_resno(List *target_list, char *name);
+
+/* Helpers for injecting and resolving ctid columns for direct tuple fetch. */
+static AttrNumber resolve_ctid_position(List *target_list,
+                                        const char *var_name);
+static bool is_internal_name(const char *name);
+static char *get_ctid_source_name(ParseState *pstate, TargetEntry *te);
+static void inject_ctid_target_entry(ParseState *pstate,
+                                     ParseNamespaceItem *pnsi,
+                                     const char *entity_name,
+                                     List **target_list);
+static void inject_ctid_columns_for_with(ParseState *pstate, Query *query);
+
 static void handle_prev_clause(cypher_parsestate *cpstate, Query *query,
                                cypher_clause *clause, bool first_rte);
 static TargetEntry *placeholder_target_entry(cypher_parsestate *cpstate,
@@ -2853,6 +2866,9 @@ static List *transform_cypher_delete_item_list(cypher_parsestate *cpstate,
         item->var_name = val->sval;
         item->entity_position = pos;
 
+        /* Resolve the ctid attribute position for direct tuple fetch. */
+        item->ctid_position = resolve_ctid_position(query->targetList,
+                                                    val->sval);
         items = lappend(items, item);
     }
 
@@ -3038,6 +3054,9 @@ cypher_update_information *transform_cypher_remove_item_list(
         property_name = property_node->sval;
         item->prop_name = property_name;
 
+        /* Resolve the ctid attribute position for direct tuple fetch. */
+        item->ctid_position = resolve_ctid_position(query->targetList,
+                                                    variable_name);
         info->set_items = lappend(info->set_items, item);
     }
 
@@ -3235,6 +3254,10 @@ cypher_update_information *transform_cypher_set_item_list(
         target_item->expr = add_volatile_wrapper(target_item->expr);
 
         query->targetList = lappend(query->targetList, target_item);
+
+        /* Resolve the ctid attribute position for direct tuple fetch. */
+        item->ctid_position = resolve_ctid_position(query->targetList,
+                                                    variable_name);
         info->set_items = lappend(info->set_items, item);
     }
 
@@ -3520,6 +3543,15 @@ static Query *transform_cypher_return(cypher_parsestate *cpstate,
                                                    &groupClause,
                                                    EXPR_KIND_SELECT_TARGET);
 
+    /*
+     * Propagate ctid columns through WITH only when the statement contains SET
+     * or DELETE. Skip aggregation and DISTINCT because hidden ctid must not
+     * affect grouping or deduplication semantics.
+     */
+    if (self->is_with && cpstate->has_writable_clause &&
+        !pstate->p_hasAggs && groupClause == NIL && !self->distinct)
+        inject_ctid_columns_for_with(pstate, query);
+
     markTargetListOrigins(pstate, query->targetList);
 
     /* ORDER BY */
@@ -3700,6 +3732,8 @@ static Query *transform_cypher_with(cypher_parsestate *cpstate,
     return_clause->skip = self->skip;
     return_clause->limit = self->limit;
 
+    /* Mark as WITH so ctid columns propagate to downstream clauses. */
+    return_clause->is_with = true;
     wrapper = palloc(sizeof(*wrapper));
     wrapper->self = (Node *)return_clause;
     wrapper->prev = clause->prev;
@@ -6875,6 +6909,14 @@ static Expr *transform_cypher_edge(cypher_parsestate *cpstate,
     {
         te = makeTargetEntry((Expr *)expr, resno, rel->name, false);
         *target_list = lappend(*target_list, te);
+
+        /*
+         * Add a hidden ctid column for direct tuple fetch. This is only useful
+         * when the statement contains SET, REMOVE, or DELETE.
+         */
+        if (valid_label && cpstate->has_writable_clause &&
+            !is_internal_name(rel->name))
+            inject_ctid_target_entry(pstate, pnsi, rel->name, target_list);
     }
 
     return (Expr *)expr;
@@ -7163,6 +7205,13 @@ static Expr *transform_cypher_node(cypher_parsestate *cpstate,
     te = makeTargetEntry(expr, resno, node->name, false);
     *target_list = lappend(*target_list, te);
 
+    /*
+     * Add a hidden ctid column for direct tuple fetch. This is only useful
+     * when the statement contains SET, REMOVE, or DELETE.
+     */
+    if (valid_label && cpstate->has_writable_clause &&
+        !is_internal_name(node->name))
+        inject_ctid_target_entry(pstate, pnsi, node->name, target_list);
     return expr;
 }
 
@@ -7737,6 +7786,136 @@ static void add_volatile_wrapper_to_target_entry(List *target_list, int resno)
     ereport(ERROR,
             (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
              errmsg("add_volatile_wrapper_to_target_entry: resno not found")));
+}
+
+/* Find the ctid target entry for a variable and return its resno. */
+static AttrNumber resolve_ctid_position(List *target_list,
+                                        const char *var_name)
+{
+    char *ctid_name;
+    AttrNumber pos;
+
+    ctid_name = psprintf(AGE_VARNAME_CTID_FORMAT, var_name);
+
+    pos = get_target_entry_resno(target_list, ctid_name);
+    pfree(ctid_name);
+
+    if (pos == -1)
+        return 0;
+
+    add_volatile_wrapper_to_target_entry(target_list, pos);
+    return pos;
+}
+
+/* Return true when name was generated for an internal pattern entity. */
+static bool is_internal_name(const char *name)
+{
+    return strncmp(name, AGE_DEFAULT_PREFIX,
+                   strlen(AGE_DEFAULT_PREFIX)) == 0;
+}
+
+/* Resolve the source column name for hidden ctid propagation. */
+static char *get_ctid_source_name(ParseState *pstate, TargetEntry *te)
+{
+    /*
+     * Resolve the source ctid from the underlying variable rather than the
+     * WITH alias.
+     */
+    if (te->expr != NULL && IsA(te->expr, Var))
+    {
+        Var *var = (Var *)te->expr;
+
+        if (var->varattno > 0 && var->varlevelsup == 0)
+        {
+            RangeTblEntry *rte = rt_fetch(var->varno, pstate->p_rtable);
+
+            return get_rte_attribute_name(rte, var->varattno);
+        }
+    }
+
+    return NULL;
+}
+
+/*
+ * Add a hidden CTID target entry for a vertex or edge.
+ *
+ * It must remain a non-junk output of this clause query. AGE represents
+ * successive clauses as subqueries, and a resjunk entry is not addressable by
+ * the downstream clause, leaving ctid_position unresolved.
+ */
+static void inject_ctid_target_entry(ParseState *pstate,
+                                     ParseNamespaceItem *pnsi,
+                                     const char *entity_name,
+                                     List **target_list)
+{
+    Node *ctid_var;
+
+    ctid_var = scanNSItemForColumn(pstate, pnsi, 0, "ctid", -1);
+    if (ctid_var != NULL)
+    {
+        char *ctid_name = psprintf(AGE_VARNAME_CTID_FORMAT, entity_name);
+        TargetEntry *ctid_te = makeTargetEntry((Expr *)ctid_var,
+                                               pstate->p_next_resno++,
+                                               ctid_name, false);
+        *target_list = lappend(*target_list, ctid_te);
+    }
+}
+
+/* Preserve hidden ctid columns across WITH for writable clauses. */
+static void inject_ctid_columns_for_with(ParseState *pstate, Query *query)
+{
+    List *new_entries = NIL;
+    ListCell *lc;
+    int var_prefix_len = strlen(AGE_DEFAULT_VARNAME_PREFIX);
+
+    foreach (lc, query->targetList)
+    {
+        TargetEntry *te = (TargetEntry *)lfirst(lc);
+        char *source_ctid_name;
+        char *source_name;
+        char *ctid_name;
+        Node *ctid_var;
+
+        if (te->resjunk || te->resname == NULL)
+            continue;
+
+        if (strncmp(te->resname, AGE_DEFAULT_VARNAME_PREFIX,
+                    var_prefix_len) == 0)
+            continue;
+
+        /*
+         * Keep the output hidden ctid column named after te->resname,
+         * but resolve its value from the source variable.
+         */
+        source_name = get_ctid_source_name(pstate, te);
+        if (source_name == NULL)
+            continue;
+
+        ctid_name = psprintf(AGE_VARNAME_CTID_FORMAT, te->resname);
+
+        if (get_target_entry_resno(query->targetList, ctid_name) != -1)
+        {
+            pfree(ctid_name);
+            continue;
+        }
+
+        source_ctid_name = psprintf(AGE_VARNAME_CTID_FORMAT, source_name);
+        ctid_var = colNameToVar(pstate, source_ctid_name, false, -1);
+        pfree(source_ctid_name);
+        if (ctid_var != NULL)
+        {
+            TargetEntry *ctid_te = makeTargetEntry(
+                (Expr *)ctid_var, (AttrNumber)pstate->p_next_resno++,
+                ctid_name, false);
+            new_entries = lappend(new_entries, ctid_te);
+        }
+        else
+        {
+            pfree(ctid_name);
+        }
+    }
+
+    query->targetList = list_concat(query->targetList, new_entries);
 }
 
 /*

--- a/src/backend/parser/cypher_parse_node.c
+++ b/src/backend/parser/cypher_parse_node.c
@@ -60,6 +60,12 @@ cypher_parsestate *make_cypher_parsestate(cypher_parsestate *parent_cpstate)
         cpstate->graph_oid = parent_cpstate->graph_oid;
         cpstate->params = parent_cpstate->params;
         cpstate->subquery_where_flag = parent_cpstate->subquery_where_flag;
+
+        /*
+         * Keep the ctid injection decision consistent across the whole
+         * statement, including subquery parse states.
+         */
+        cpstate->has_writable_clause = parent_cpstate->has_writable_clause;
     }
 
     return cpstate;

--- a/src/backend/utils/adt/agtype.c
+++ b/src/backend/utils/adt/agtype.c
@@ -13236,6 +13236,15 @@ Datum agtype_volatile_wrapper(PG_FUNCTION_ARGS)
             agtv_result.val.string.val = text_to_cstring(DatumGetTextPP(arg));
             agtv_result.val.string.len = strlen(agtv_result.val.string.val);
         }
+        else if (type == TIDOID)
+        {
+            ItemPointer tid = (ItemPointer) DatumGetPointer(arg);
+
+            agtv_result.type = AGTV_INTEGER;
+            agtv_result.val.int_value =
+                AGE_CTID_PACK(ItemPointerGetBlockNumberNoCheck(tid),
+                              ItemPointerGetOffsetNumberNoCheck(tid));
+        }
         else if (type == VERTEXOID)
         {
             PG_RETURN_DATUM(DirectFunctionCall1(vertex_to_agtype, arg));

--- a/src/include/executor/cypher_utils.h
+++ b/src/include/executor/cypher_utils.h
@@ -59,12 +59,33 @@ typedef struct cypher_create_custom_scan_state
     Oid graph_oid;
 } cypher_create_custom_scan_state;
 
+/*
+ * Per-statement lookup cache keyed by table relid. The fetch slot and usable
+ * B-tree index on id are initialized lazily.
+ */
+typedef struct EntityLookupCacheEntry
+{
+    Oid relid;                  /* hash key */
+    bool index_initialized;     /* includes a negative lookup result */
+    Relation id_index;          /* usable id index opened once */
+    TupleTableSlot *fetch_slot; /* reusable TTSOpsBufferHeapTuple slot */
+} EntityLookupCacheEntry;
+
+typedef struct EntityLookupCache
+{
+    HTAB *htab;                 /* relid -> EntityLookupCacheEntry */
+    MemoryContext mcxt;         /* context for cached handles and slots */
+} EntityLookupCache;
+
 typedef struct cypher_set_custom_scan_state
 {
     CustomScanState css;
     CustomScan *cs;
     cypher_update_information *set_list;
     int flags;
+
+    /* Per-statement index and fetch-slot cache for tuple lookup. */
+    EntityLookupCache *entity_lookup_cache;
 } cypher_set_custom_scan_state;
 
 typedef struct cypher_delete_custom_scan_state
@@ -92,6 +113,9 @@ typedef struct cypher_delete_custom_scan_state
      * and end_id column.
      */
     HTAB *vertex_id_htab;
+
+    /* Per-statement index and fetch-slot cache for tuple lookup. */
+    EntityLookupCache *entity_lookup_cache;
 } cypher_delete_custom_scan_state;
 
 typedef struct cypher_merge_custom_scan_state
@@ -113,6 +137,9 @@ typedef struct cypher_merge_custom_scan_state
     bool eager_buffer_filled;
     cypher_update_information *on_match_set_info;   /* NULL if not specified */
     cypher_update_information *on_create_set_info;   /* NULL if not specified */
+
+    /* Per-statement index and fetch-slot cache for ON MATCH/CREATE SET. */
+    EntityLookupCache *entity_lookup_cache;
 } cypher_merge_custom_scan_state;
 
 /* Reusable SET logic callable from MERGE executor */
@@ -129,6 +156,24 @@ TupleTableSlot *populate_edge_tts(
 ResultRelInfo *create_entity_result_rel_info(EState *estate, char *graph_name,
                                              char *label_name);
 void destroy_entity_result_rel_info(ResultRelInfo *result_rel_info);
+
+EntityLookupCache *create_entity_lookup_cache(void);
+void destroy_entity_lookup_cache(EntityLookupCache *cache);
+
+/* Decode a hidden packed ctid hint. Return false when no hint is available. */
+bool get_entity_ctid_hint(TupleTableSlot *scanTupleSlot,
+                          AttrNumber ctid_position, ItemPointer ctid);
+
+/*
+ * Look up an entity by ctid, then by a usable B-tree index on id. Use a
+ * sequential scan only when no such index exists. cache may be NULL for
+ * one-shot use.
+ */
+HeapTuple find_entity_tuple(Relation rel, Snapshot snapshot,
+                            graphid entity_id,
+                            TupleTableSlot *scanTupleSlot,
+                            AttrNumber ctid_position,
+                            EntityLookupCache *cache);
 
 bool entity_exists(EState *estate, Oid graph_oid, graphid id);
 HeapTuple insert_entity_tuple(ResultRelInfo *resultRelInfo,

--- a/src/include/nodes/cypher_nodes.h
+++ b/src/include/nodes/cypher_nodes.h
@@ -62,6 +62,10 @@ typedef struct cypher_return
     SetOperation op;
     List *larg; /* lefthand argument of the unions */
     List *rarg; /*righthand argument of the unions */
+
+    /* Distinguish WITH from RETURN for hidden ctid propagation. */
+    bool is_with;
+
 } cypher_return;
 
 typedef struct cypher_with
@@ -487,6 +491,10 @@ typedef struct cypher_update_item
     ExtensibleNode extensible;
     AttrNumber prop_position;
     AttrNumber entity_position;
+
+    /* Attribute number of the packed ctid column in the scan tuple. */
+    AttrNumber ctid_position;
+
     char *var_name;
     char *prop_name;
     List *qualified_name;
@@ -512,6 +520,9 @@ typedef struct cypher_delete_item
     ExtensibleNode extensible;
     Integer *entity_position;
     char *var_name;
+
+    /* Attribute number of the packed ctid column in the scan tuple. */
+    AttrNumber ctid_position;
 } cypher_delete_item;
 
 typedef struct cypher_merge_information

--- a/src/include/parser/cypher_parse_node.h
+++ b/src/include/parser/cypher_parse_node.h
@@ -50,6 +50,13 @@ typedef struct cypher_parsestate
      */
     bool exprHasAgg;
     bool p_opt_match;
+
+    /*
+     * True if the Cypher statement contains SET, REMOVE, or DELETE, making
+     * hidden ctid columns useful during MATCH transforms.
+     */
+    bool has_writable_clause;
+
 } cypher_parsestate;
 
 typedef struct errpos_ecb_state

--- a/src/include/utils/agtype.h
+++ b/src/include/utils/agtype.h
@@ -37,6 +37,20 @@
 
 #include "utils/graphid.h"
 
+/*
+ * Pack and unpack a TID into an int64 for agtype transport.
+ * Layout: BlockNumber (32 bits) << 16 | OffsetNumber (16 bits).
+ */
+StaticAssertDecl(sizeof(OffsetNumber) == 2 && sizeof(BlockNumber) == 4,
+                 "AGE_CTID_PACK assumes 16-bit OffsetNumber and "
+                 "32-bit BlockNumber");
+#define AGE_CTID_PACK(blk, off) \
+    (((int64)(blk) << 16) | (int64)(off))
+#define AGE_CTID_UNPACK_BLOCK(packed) \
+    ((BlockNumber)((packed) >> 16))
+#define AGE_CTID_UNPACK_OFFSET(packed) \
+    ((OffsetNumber)((packed) & 0xFFFF))
+
 /* Tokens used when sequentially processing an agtype value */
 typedef enum
 {


### PR DESCRIPTION
## Summary

This change avoids redundant graphid lookups when `SET`, `REMOVE`, or
`DELETE` writes an entity already read by `MATCH`.

For writable statements, AGE now carries the matched tuple's `ctid` as a
hidden internal lookup hint. The executor validates the tuple's snapshot
visibility and graphid before using it, and falls back to the existing
graphid lookup when the hint is missing or stale. Graphid remains the logical
entity identity.

The same executor path also contained a correctness issue: when two aliases
in one result row represented the same entity, a later `SET` or `REMOVE`
could rebuild the entity from stale alias-local properties and overwrite an
earlier change. This change refreshes the current properties and keeps
same-graphid aliases and paths synchronized.

The resulting lookup order is:

```text
validated CTID fetch
    -> usable non-partial B-tree index whose first key is entity id
    -> sequential scan when no suitable id index exists
```

No Cypher syntax or user-visible result columns are added.

## Implementation

### Hidden CTID propagation

- Add a hidden CTID target entry for named vertices and edges read by
  `MATCH`, but only when the statement contains `SET`, `REMOVE`, or `DELETE`.
- Carry the hint through simple `WITH n` and `WITH n AS alias` projections.
- Stop propagation at aggregation, `DISTINCT`, computed expressions, and
  parser-generated variables, where a hidden value could change row-shaping
  semantics or become associated with the wrong entity.
- Store the hidden column position in update/delete plan metadata and include
  it in ExtensibleNode copy/out/read support.

PostgreSQL's native `tid` is packed into a scalar agtype value for transport
through AGE target lists:

```text
BlockNumber (32 bits) << 16 | OffsetNumber (16 bits)
```

Read-only `MATCH`/`RETURN` statements do not receive hidden target entries.

### Shared entity lookup

`find_entity_tuple()` centralizes tuple lookup for the writable executors.

1. If a hidden CTID is available, fetch that row version directly.
2. Accept it only when it is visible to the current snapshot and contains
   the expected graphid.
3. Otherwise, use a valid non-partial B-tree index whose first key is the
   entity `id`.
4. Fall back to a sequential scan only when no suitable `id` index exists.

This remains correct if a user drops a default vertex `id` index. It also
allows a user-created edge `id` index to serve as the fallback. The default
edge `start_id` and `end_id` indexes cannot resolve an edge by graphid.

A statement-local cache retains the tuple fetch slot, opened `id` index
relation, and negative index-search result. `SET` and `DELETE` own that cache
for their custom-scan lifetime.

CTID is always a hint rather than identity. A previous writable clause may
move the tuple and leave another alias with a stale CTID; the validation and
graphid fallback prevent an update or delete from targeting the wrong row.
After an update, the new CTID is propagated for later writes in the same
result row.

### Same-row alias consistency

The original `apply_update_list()` built replacement properties from the
agtype value stored at each update item's tuple position before locating the
current heap tuple. Different aliases were treated as independent positions
even when they contained the same graphid, and the existing synchronization
pass updated entities inside paths but not top-level aliases.

For example:

```cypher
MATCH (n:T), (m:T)
WHERE id(n) = id(m)
SET n.a = 1
SET m.b = n.a + 1
RETURN n.a, m.a, m.b
```

The query could return `1, NULL, 2` while the stored entity contained
`a = NULL, b = 2`.

The updated executor locates the current heap tuple before building the first
update for an entity position, refreshes stale base properties from that
tuple, synchronizes top-level aliases and paths with the same graphid, and
reuses the tuple for the physical update. `REMOVE` uses the same path and
receives the same consistency fix.

`DELETE` does not reconstruct properties, but it uses the validated lookup
helper so a stale alias CTID after an earlier `SET` cannot cause the wrong
tuple to be deleted.

The correctness fix and the lookup optimization are included together
because they share the same `apply_update_list()` control flow: the executor
must locate the current tuple before rebuilding properties, synchronize
same-entity references, and then reuse that tuple for the physical update.
Splitting them would require implementing and immediately replacing an
intermediate lookup path. If a correctness-only backport is requested, it
can be adapted to use the existing graphid fallback first.

### MERGE fallback cache

`MERGE` uses a separate lateral/eager custom-scan transform that does not
currently carry a reliable entity-to-CTID column position into its SET
metadata, so it does not receive a hidden CTID fast path in this change. When
a plan contains `ON MATCH SET` or `ON CREATE SET`, it creates the shared
graphid fallback cache for the statement lifetime and releases it when the
custom scan ends.

## Suggested review order

1. `src/backend/executor/cypher_utils.c`: shared CTID/index/SeqScan lookup.
2. `src/backend/parser/cypher_clause.c`: hidden CTID generation and `WITH`
   propagation.
3. `src/backend/executor/cypher_set.c`: current-property refresh and
   alias/path synchronization.
4. `src/backend/executor/cypher_delete.c` and
   `src/backend/executor/cypher_merge.c`: lookup/cache integration.
5. ExtensibleNode definitions and copy/out/read serialization.
6. Regression SQL and expected output.

## Performance

### Environment and method

- Baseline AGE:
  `801417404978823bd8732452c3f7959017584785`
- Patched AGE:
  `1bfdc51b32f67303132cedde7820748e0b46f224`
- PostgreSQL 18.4, built with `--disable-debug --disable-cassert` and
  `CFLAGS=-O2 -g`
- Ubuntu 22.04 and GCC 11.4.0 on both hosts
- Intel Xeon 6982P-C, 8 cores / 16 threads, 29 GiB RAM
- AMD EPYC 9T25, 4 cores / 8 threads, 15 GiB RAM
- Local Unix-domain socket
- `shared_buffers=1GB`, `fsync=off`, `synchronous_commit=off`,
  `full_page_writes=off`, `autovacuum=off`, `jit=off`

Each host ran the same complete benchmark matrix from 1,000 through
1,000,000 rows. PostgreSQL and its child backends were pinned to vCPU 2 to
avoid migration between virtual CPUs. Only `age.so` changed between variants.
Data reset, `VACUUM ANALYZE`, server restart, and shared-library replacement
were outside the timed interval.

The read-only control executes 20 prepared queries in one backend and reports
the per-query time, avoiding client startup and cold-backend costs from
dominating this short control. At 1,000,000 rows, controls use 15 measured
AB/BA-interleaved runs, `DELETE` uses five, and the longer writable and edge
workloads use three. Both variants receive an unreported warm-up. Negative
change means the patch is faster.

| Workload | Rows | Intel baseline | Intel patched | Change | AMD baseline | AMD patched | Change |
|---|---:|---:|---:|---:|---:|---:|---:|
| Read-only `MATCH`/count | 1,000,000 | 173.207 ms | 173.665 ms | +0.26% | 119.926 ms | 117.678 ms | -1.87% |
| SQL insert control | 1,000,000 | 1.512 s | 1.511 s | -0.08% | 1.411 s | 1.411 s | +0.07% |
| Cypher `CREATE` control | 1,000,000 | 1.769 s | 1.781 s | +0.68% | 1.579 s | 1.589 s | +0.63% |
| `SET` | 1,000,000 vertices | 1,146.793 s | 1,083.368 s | -5.53% | 772.290 s | 740.688 s | -4.09% |
| `REMOVE` | 1,000,000 vertices | 1,105.770 s | 1,087.867 s | -1.62% | 754.795 s | 757.081 s | +0.30% |
| `DELETE` | 1,000,000 vertices | 5.668 s | 4.654 s | -17.88% | 4.651 s | 3.870 s | -16.79% |
| `MERGE ON MATCH SET` | 1,000,000 operations | 1,085.185 s | 1,071.211 s | -1.29% | 755.175 s | 737.758 s | -2.31% |
| Edge `SET`, no edge `id` index | 1,000,000 | 8,958.601 s | 1,098.437 s | -87.74% | 9,974.254 s | 756.924 s | -92.41% |
| `DISTINCT` edge `SET`, edge `id` index | 1,000,000 | 1,154.458 s | 1,109.373 s | -3.91% | 795.588 s | 756.580 s | -4.90% |

The same matrix was also run at 1,000, 10,000, and 100,000 rows. `DELETE`
improves from 5–8% at 1,000 vertices to approximately 17–18% at 1,000,000 on
both CPUs. Edge `SET` without an `id` index improves from 31–35% at 1,000
edges to 88–93% at 1,000,000 edges. These are the two effects the new lookup
path is intended to address.

`SET` and `REMOVE` still spend most of their time rebuilding properties and
updating PostgreSQL tuples, so their smaller gains vary by processor.
`MERGE`, which uses only the fallback cache, and indexed `DISTINCT` edge
`SET`, where the hidden hint cannot cross `DISTINCT`, do not show a
consistent direct-CTID effect.

Read-only statements do not receive hidden CTID target entries. In the final
1,000,000-row cross-CPU run, read-only elapsed time changed by +0.26% on
Intel, with CV below 0.5% for both variants, and by -1.87% on AMD. An Intel
`perf stat` comparison also showed unchanged retired instructions and only
+0.36% cycles. No size-dependent read-only regression was observed from
1,000 through 1,000,000 rows.

A supplemental 10,000,000-row Intel run remained neutral for the control
workloads: read-only +0.44%, SQL insert -0.30%, and Cypher `CREATE` +0.45%.
`DELETE` improved by 19.30%, from 57.332 s to 46.265 s, across five measured
runs with CV below 0.5%.

### Benchmark reproduction

A self-contained reviewer script builds the baseline and patched commits,
creates an isolated PostgreSQL 18 cluster, runs the workloads in AB/BA order,
and writes raw and summarized CSV files. It neither installs AGE into the
PostgreSQL prefix nor modifies an existing cluster.

[repro_pr_benchmark.sh](https://github.com/user-attachments/files/30737318/repro_pr_benchmark.sh)

From an AGE checkout on the pull request branch:

```bash
chmod +x repro_pr_benchmark.sh
SERVER_CPU=2 READ_ONLY_BATCH_COUNT=20 CONTROL_ROWS=1000000 \
CONTROL_TRIALS=15 WRITE_ROWS=1000000 WRITE_TRIALS=3 \
WRITE_SCENARIOS="set remove merge_on_match_set" \
EDGE_SIZES=1000000 EDGE_TRIALS=3 \
DELETE_ROWS=1000000 DELETE_TRIALS=5 ./repro_pr_benchmark.sh \
  --age-repo "$PWD" \
  --pg-config /path/to/postgresql-18/bin/pg_config \
  --full
```

This command reproduces the 1,000,000-row timing matrix above. It is
intentionally long: a single no-index edge baseline sample takes several
hours on the tested hosts. Reviewers can first validate their environment
with:

```bash
SERVER_CPU=2 READ_ONLY_BATCH_COUNT=20 ./repro_pr_benchmark.sh \
  --age-repo "$PWD" \
  --pg-config /path/to/postgresql-18/bin/pg_config \
  --quick
```

The main output is `all-summary.csv`; per-group raw CSV, build logs,
PostgreSQL logs, and an environment manifest are retained alongside it.
Choose a `SERVER_CPU` available on the test host.

### Standalone edge-label benchmark

The following self-contained script creates an edge label with only the
default `start_id` and `end_id` indexes, loads the requested number of edges,
prints the actual indexes, runs `EXPLAIN ANALYZE`, and verifies the updated
row count:

[repro_edge_set_no_id_index.sql](https://github.com/user-attachments/files/30529509/repro_edge_set_no_id_index.sql)

```bash
# Quick check: 10,000 edges
psql -X -d <database> -f repro_edge_set_no_id_index.sql

# Same scale as the largest reported result; this can take several hours
psql -X -d <database> -v edge_count=1000000 \
  -f repro_edge_set_no_id_index.sql
```

### CPU profile

The 2,000,000-vertex `DELETE` workload was sampled at 199 Hz with
`cycles:u` and DWARF call graphs:

| Profile | Samples | Sample duration | Sampled cycles |
|---|---:|---:|---:|
| Baseline | 2,217 | 11.158 s | 37.43 billion |
| Patched | 1,822 | 9.144 s | 29.70 billion |

In the baseline, stacks below `process_delete_list()` containing
`index_getnext_slot` account for 16.56% of sampled cycles:

```text
process_delete_list
  index_getnext_slot
    index_getnext_tid
      btgettuple
        _bt_first
          _bt_search
```

That stack disappears from the patched profile. Its replacement accounts for
3.09% of patched sampled cycles:

```text
process_delete_list
  find_entity_tuple
    try_ctid_fetch_tuple
      table_tuple_fetch_row_version
        heapam_fetch_row_version
          heap_fetch
```

Baseline flame graph:

<img width="1200" height="750" alt="baseline-flamegraph-static" src="https://github.com/user-attachments/assets/990505db-a657-49ca-9200-62e28ceb3b9e" />

Patched flame graph:

<img width="1200" height="750" alt="patched-flamegraph-static" src="https://github.com/user-attachments/assets/08a0b2c2-28c0-4a27-92fd-1df516e4b291" />

Five-run `perf stat` medians for the 500,000-vertex `DELETE` workload:

| Event | Baseline | Patched | Change |
|---|---:|---:|---:|
| CPU cycles | 8,784,745,592 | 7,027,241,137 | -20.01% |
| Instructions | 28,468,929,329 | 22,572,493,361 | -20.71% |
| Branches | 5,228,809,347 | 4,153,536,763 | -20.56% |
| Branch misses | 5,534,090 | 3,547,249 | -35.90% |
| Cache references | 14,515,881 | 13,605,987 | -6.27% |
| Cache misses | 3,389,227 | 2,924,470 | -13.71% |

The elapsed-time improvement is accompanied by comparable reductions in
instructions and branches, supporting a CPU-work reduction rather than an
I/O-only effect.

## Tests

Built and tested against PostgreSQL 18.4:

- clean release build completed without warnings;
- targeted writable/VLE regression suites passed under debug/cassert:
  `cypher_set`, `cypher_remove`, `cypher_delete`, `cypher_with`,
  `cypher_vle`, and `cypher_merge`;
- targeted writable suites and the complete `security`/RLS suite passed with
  AddressSanitizer and `MEMORY_CONTEXT_CHECKING`;
- the current PR commit passed the full debug/cassert AGE regression suite:
  **43/43**.

New regression coverage includes:

- valid and stale CTID lookup, including fallback after an earlier `SET`;
- vertex and edge aliases that share a graphid across chained writes;
- dependent right-hand-side expressions and persisted-state verification;
- alias/path synchronization for `SET` and `REMOVE`;
- simple `WITH` references and renames;
- aggregation, `DISTINCT`, and computed-expression propagation boundaries;
- writable `WITH *` and `RETURN *` without leaking hidden CTID columns;
- stale CTID fallback for `REMOVE`, `DELETE`, and `DETACH DELETE`;
- fallback through a user-created edge `id` B-tree index;
- sequential-scan fallback after dropping a vertex label's `id` index;
- forced generic prepared-plan reuse across label-table DDL;
- direct TID-wrapper packing, including block/offset boundary values.

## Related issues

Closes #2484
Closes #2485
