### PR TITLE
Fix transform_cypher_param to pass agtype_access_operator a VARIADIC array

### DIFF
--- a/regress/sql/cypher_create.sql
+++ b/regress/sql/cypher_create.sql
@@ -194,6 +194,31 @@ PREPARE p_2 AS SELECT * FROM cypher('cypher_create', $$CREATE (v:new_vertex {key
 EXECUTE p_2('{"var_name": "Hello Prepared Statements"}');
 EXECUTE p_2('{"var_name": "Hello Prepared Statements 2"}');
 
+-- prepared statement with scalar parameters used in MATCH and CREATE EDGE.
+-- Regression test: transform_cypher_param() previously called the VARIADIC
+-- agtype_access_operator without building the agtype[] ArrayExpr argument
+-- and without setting funcvariadic = true. Under the extended query
+-- protocol this caused agtype_access_operator to read past its argument
+-- at execution time, corrupting error messages with random bytes and
+-- producing client-side UnicodeDecodeError / invalid-start-byte errors.
+PREPARE p_create_edge(agtype) AS
+SELECT * FROM cypher('cypher_create', $$
+    MATCH (source:v {id: $src_id}), (target:v {id: $tgt_id})
+    CREATE (source)-[r:e {id: $edge_id}]->(target)
+    RETURN r
+$$, $1) AS (r agtype);
+
+-- seed vertices to match against
+SELECT * FROM cypher('cypher_create', $$
+    CREATE (:v {id: 'a'}), (:v {id: 'b'})
+$$) AS (a agtype);
+
+EXECUTE p_create_edge('{"src_id": "a", "tgt_id": "b", "edge_id": "edge1"}');
+EXECUTE p_create_edge('{"src_id": "a", "tgt_id": "b", "edge_id": "edge2"}');
+EXECUTE p_create_edge('{"src_id": "a", "tgt_id": "b", "edge_id": "edge3"}');
+
+DEALLOCATE p_create_edge;
+
 -- pl/pgsql
 CREATE FUNCTION create_test()
 RETURNS TABLE(vertex agtype)

--- a/src/backend/parser/cypher_expr.c
+++ b/src/backend/parser/cypher_expr.c
@@ -848,6 +848,7 @@ static Node *transform_cypher_param(cypher_parsestate *cpstate,
                                     cypher_param *cp)
 {
     ParseState *pstate = (ParseState *)cpstate;
+    ArrayExpr  *newa;
     Const *const_str;
     FuncExpr *func_expr;
     Oid func_access_oid;
@@ -867,6 +868,30 @@ static Node *transform_cypher_param(cypher_parsestate *cpstate,
     func_access_oid = get_ag_func_oid("agtype_access_operator", 1,
                                       AGTYPEARRAYOID);
 
+    /*
+     * agtype_access_operator is declared VARIADIC agtype[] and expects a
+     * single agtype[] ArrayExpr with funcvariadic = true. Every other call
+     * site in this file (see transform_cypher_map_projection,
+     * transform_cypher_indirection) assembles its arguments via
+     * make_agtype_array_expr() and sets funcvariadic; only this function was
+     * passing the Param and the key Const as separate list elements directly.
+     *
+     * With the Simple Query protocol PostgreSQL implicitly forms the variadic
+     * array from separate arguments at execution time, masking the bug. But
+     * under the Extended Query protocol (prepared statements /
+     * Parse-Bind-Execute) the executor does not perform that implicit
+     * assembly, so agtype_access_operator read past its single agtype
+     * argument treating adjacent memory as additional array elements. The
+     * resulting out-of-bounds read surfaced as corrupted relation names in
+     * error responses (random bytes mixed with fragments of property values
+     * such as "November", "customer", "communication"; control bytes such as
+     * 0x01), which client drivers then failed to UTF-8 decode:
+     *
+     *     UnicodeDecodeError: 'utf-8' ... invalid start byte
+     *
+     * The fix matches every other call site: pack the arguments into an
+     * agtype[] ArrayExpr and set funcvariadic = true.
+     */
     args = lappend(args, copyObject(cpstate->params));
 
     const_str = makeConst(AGTYPEOID, -1, InvalidOid, -1,
@@ -874,8 +899,11 @@ static Node *transform_cypher_param(cypher_parsestate *cpstate,
 
     args = lappend(args, const_str);
 
-    func_expr = makeFuncExpr(func_access_oid, AGTYPEOID, args, InvalidOid,
-                             InvalidOid, COERCE_EXPLICIT_CALL);
+    newa = make_agtype_array_expr(args);
+
+    func_expr = makeFuncExpr(func_access_oid, AGTYPEOID, list_make1(newa),
+                             InvalidOid, InvalidOid, COERCE_EXPLICIT_CALL);
+    func_expr->funcvariadic = true;
     func_expr->location = cp->location;
 
     return (Node *)func_expr;


### PR DESCRIPTION
## Root cause

`agtype_access_operator` is declared `VARIADIC agtype[]`. Every other call site in `cypher_expr.c` packs its arguments into a single `agtype[]` `ArrayExpr` via `make_agtype_array_expr()` and sets `funcvariadic = true` on the resulting `FuncExpr` (see `transform_cypher_map_projection`, `transform_cypher_indirection`).

`transform_cypher_param()` — the path that turns a Cypher `$param` reference into an AGE function call — was the only exception. It passed the bound Param and the key-name Const directly as separate `FuncExpr` arguments without wrapping them and without setting `funcvariadic`.

With the Simple Query protocol PostgreSQL implicitly assembles the variadic array from separate arguments at execution time, which masked the bug. Under the **Extended Query protocol (Parse/Bind/Execute prepared statements)** the executor does not perform that implicit assembly, so `agtype_access_operator` read past its single `agtype` argument and treated adjacent memory as additional array elements. The resulting out-of-bounds read surfaced as corrupted relation names in "relation does not exist" error responses (random bytes mixed with fragments of in-flight query text / property values such as "November", "customer", "communication", and control bytes like `0x01`). Drivers that UTF-8 decode the server error then raised:

UnicodeDecodeError: 'utf-8' codec can't decode byte 0x9e in position 51: invalid start byte

The bug reproduces with any Open/asyncpg/JDBC driver that uses prepared statements with bound `agtype` parameters against a Cypher query that references `$param` (for example `MERGE (n:base {entity_id: $entity_id})` or `MATCH (s:base {id: $src_id}), (t:base {id: $tgt_id}) CREATE (s)-[r:DIRECTED {…}]->(t)`, the shape used by LightRAG). The error content is unrelated to the payload — edges with pure-ASCII property values failed identically.

## Fix

Pack the two arguments in `make_agtype_array_expr()` and set `func_expr->funcvariadic = true`, exactly matching every other call site.

```c
newa = make_agtype_array_expr(args);
func_expr = makeFuncExpr(func_access_oid, AGTYPEOID, list_make1(newa),
                         InvalidOid, InvalidOid, COERCE_EXPLICIT_CALL);
func_expr->funcvariadic = true;
```

## Regression test
Added p_create_edge to regress/sql/cypher_create.sql, which PREPAREs a MATCH … {id: $src_id}, … {id: $tgt_id} CREATE ()-[:e {id: $edge_id}]->() statement (the exact shape used by LightRAG/asyncpg) and EXECUTEs it repeatedly. The expected output file (regress/expected/cypher_create.out) needs to be regenerated by running make installcheck against a built extension.