### PR TITLE
Fix earlier clauses' writes being invisible to later clauses (#2493)

### DIFF
--- a/regress/expected/cypher_create.out
+++ b/regress/expected/cypher_create.out
@@ -907,6 +907,115 @@ $$) as (m agtype);
 (1 row)
 
 --
+-- Issue 2493: a clause that reads must see everything a preceding clause
+-- wrote, not only the rows written by that clause's first input row.
+--
+SELECT create_graph('issue_2493');
+NOTICE:  graph "issue_2493" has been created
+ create_graph 
+--------------
+ 
+(1 row)
+
+-- all three created vertices must be visible to the later MATCH
+SELECT * FROM cypher('issue_2493', $$
+    UNWIND [1, 2, 3] AS i
+    CREATE (:vis {id: i})
+    WITH count(*) AS ignored
+    MATCH (n:vis)
+    RETURN count(n)
+$$) as (visible agtype);
+ visible 
+---------
+ 3
+(1 row)
+
+-- pre-existing and newly created vertices are both visible
+SELECT * FROM cypher('issue_2493', $$ CREATE (:pre {id: 0}) $$) as (a agtype);
+ a 
+---
+(0 rows)
+
+SELECT * FROM cypher('issue_2493', $$
+    UNWIND [1, 2] AS i
+    CREATE (:pre {id: i})
+    WITH count(*) AS ignored
+    MATCH (n:pre)
+    RETURN count(n)
+$$) as (visible agtype);
+ visible 
+---------
+ 3
+(1 row)
+
+-- as originally reported: OPTIONAL MATCH binds every created vertex
+SELECT * FROM cypher('issue_2493', $$
+    UNWIND [1, 2, 3] AS i
+    CREATE (:opt {id: i})
+    WITH count(*) AS ignored
+    OPTIONAL MATCH (a:opt)
+    RETURN count(*) AS rows, count(a) AS bound
+$$) as (rows agtype, bound agtype);
+ rows | bound 
+------+-------
+ 3    | 3
+(1 row)
+
+-- vertices written earlier drive a later CREATE (6 ordered pairs of 3)
+SELECT * FROM cypher('issue_2493', $$
+    UNWIND [1, 2, 3] AS i
+    CREATE (:src {id: i})
+    WITH count(*) AS ignored
+    MATCH (a:src), (b:src) WHERE a.id <> b.id
+    CREATE (a)-[:rel]->(b)
+$$) as (a agtype);
+ a 
+---
+(0 rows)
+
+SELECT * FROM cypher('issue_2493', $$
+    MATCH ()-[r:rel]->() RETURN count(r)
+$$) as (edges agtype);
+ edges 
+-------
+ 6
+(1 row)
+
+-- a CREATE must still not see its own writes: this creates 3 vertices, not
+-- an unbounded number
+SELECT * FROM cypher('issue_2493', $$
+    MATCH (n:src)
+    CREATE (:copy {from: n.id})
+$$) as (a agtype);
+ a 
+---
+(0 rows)
+
+SELECT * FROM cypher('issue_2493', $$
+    MATCH (n:copy) RETURN count(n)
+$$) as (copies agtype);
+ copies 
+--------
+ 3
+(1 row)
+
+SELECT drop_graph('issue_2493', true);
+NOTICE:  drop cascades to 8 other objects
+DETAIL:  drop cascades to table issue_2493._ag_label_vertex
+drop cascades to table issue_2493._ag_label_edge
+drop cascades to table issue_2493.vis
+drop cascades to table issue_2493.pre
+drop cascades to table issue_2493.opt
+drop cascades to table issue_2493.src
+drop cascades to table issue_2493.rel
+drop cascades to table issue_2493.copy
+NOTICE:  graph "issue_2493" has been dropped
+ drop_graph 
+------------
+ 
+(1 row)
+
+--
 -- Clean up
 --
 DROP TABLE simple_path;

--- a/regress/expected/cypher_set.out
+++ b/regress/expected/cypher_set.out
@@ -1228,6 +1228,96 @@ $$) AS (a agtype);
 (1 row)
 
 --
+-- Issue 2493: a clause that reads must see every update a preceding SET
+-- made, not only the updates from that clause's first input row.
+--
+SELECT create_graph('issue_2493_set');
+NOTICE:  graph "issue_2493_set" has been created
+ create_graph 
+--------------
+ 
+(1 row)
+
+SELECT * FROM cypher('issue_2493_set', $$
+    UNWIND [1, 2, 3] AS i CREATE (:x {id: i})
+$$) as (a agtype);
+ a 
+---
+(0 rows)
+
+-- all three updates must be visible to the later MATCH
+SELECT * FROM cypher('issue_2493_set', $$
+    MATCH (n:x) SET n.marked = true
+    WITH count(*) AS ignored
+    MATCH (m:x) WHERE m.marked = true
+    RETURN count(m)
+$$) as (visible agtype);
+ visible 
+---------
+ 3
+(1 row)
+
+-- the same for REMOVE, which shares the SET executor
+SELECT * FROM cypher('issue_2493_set', $$
+    MATCH (n:x) REMOVE n.marked
+    WITH count(*) AS ignored
+    MATCH (m:x) WHERE m.marked = true
+    RETURN count(m)
+$$) as (still_marked agtype);
+ still_marked 
+--------------
+ 0
+(1 row)
+
+-- updates written earlier drive a later CREATE
+SELECT * FROM cypher('issue_2493_set', $$
+    MATCH (n:x) SET n.ready = true
+    WITH count(*) AS ignored
+    MATCH (m:x) WHERE m.ready = true
+    CREATE (:derived {from: m.id})
+$$) as (a agtype);
+ a 
+---
+(0 rows)
+
+SELECT * FROM cypher('issue_2493_set', $$
+    MATCH (d:derived) RETURN count(d)
+$$) as (derived agtype);
+ derived 
+---------
+ 3
+(1 row)
+
+-- a SET must still not see its own writes: this updates each vertex once
+SELECT * FROM cypher('issue_2493_set', $$
+    MATCH (n:x) SET n.pass = 1 RETURN count(*)
+$$) as (updated agtype);
+ updated 
+---------
+ 3
+(1 row)
+
+SELECT * FROM cypher('issue_2493_set', $$
+    MATCH (m:x) WHERE m.pass = 1 RETURN count(m)
+$$) as (persisted agtype);
+ persisted 
+-----------
+ 3
+(1 row)
+
+SELECT drop_graph('issue_2493_set', true);
+NOTICE:  drop cascades to 4 other objects
+DETAIL:  drop cascades to table issue_2493_set._ag_label_vertex
+drop cascades to table issue_2493_set._ag_label_edge
+drop cascades to table issue_2493_set.x
+drop cascades to table issue_2493_set.derived
+NOTICE:  graph "issue_2493_set" has been dropped
+ drop_graph 
+------------
+ 
+(1 row)
+
+--
 -- Clean up
 --
 DROP TABLE tbl;

--- a/regress/sql/cypher_create.sql
+++ b/regress/sql/cypher_create.sql
@@ -476,6 +476,67 @@ SELECT * FROM cypher('cypher_create', $$
 $$) as (m agtype);
 
 --
+-- Issue 2493: a clause that reads must see everything a preceding clause
+-- wrote, not only the rows written by that clause's first input row.
+--
+SELECT create_graph('issue_2493');
+
+-- all three created vertices must be visible to the later MATCH
+SELECT * FROM cypher('issue_2493', $$
+    UNWIND [1, 2, 3] AS i
+    CREATE (:vis {id: i})
+    WITH count(*) AS ignored
+    MATCH (n:vis)
+    RETURN count(n)
+$$) as (visible agtype);
+
+-- pre-existing and newly created vertices are both visible
+SELECT * FROM cypher('issue_2493', $$ CREATE (:pre {id: 0}) $$) as (a agtype);
+
+SELECT * FROM cypher('issue_2493', $$
+    UNWIND [1, 2] AS i
+    CREATE (:pre {id: i})
+    WITH count(*) AS ignored
+    MATCH (n:pre)
+    RETURN count(n)
+$$) as (visible agtype);
+
+-- as originally reported: OPTIONAL MATCH binds every created vertex
+SELECT * FROM cypher('issue_2493', $$
+    UNWIND [1, 2, 3] AS i
+    CREATE (:opt {id: i})
+    WITH count(*) AS ignored
+    OPTIONAL MATCH (a:opt)
+    RETURN count(*) AS rows, count(a) AS bound
+$$) as (rows agtype, bound agtype);
+
+-- vertices written earlier drive a later CREATE (6 ordered pairs of 3)
+SELECT * FROM cypher('issue_2493', $$
+    UNWIND [1, 2, 3] AS i
+    CREATE (:src {id: i})
+    WITH count(*) AS ignored
+    MATCH (a:src), (b:src) WHERE a.id <> b.id
+    CREATE (a)-[:rel]->(b)
+$$) as (a agtype);
+
+SELECT * FROM cypher('issue_2493', $$
+    MATCH ()-[r:rel]->() RETURN count(r)
+$$) as (edges agtype);
+
+-- a CREATE must still not see its own writes: this creates 3 vertices, not
+-- an unbounded number
+SELECT * FROM cypher('issue_2493', $$
+    MATCH (n:src)
+    CREATE (:copy {from: n.id})
+$$) as (a agtype);
+
+SELECT * FROM cypher('issue_2493', $$
+    MATCH (n:copy) RETURN count(n)
+$$) as (copies agtype);
+
+SELECT drop_graph('issue_2493', true);
+
+--
 -- Clean up
 --
 DROP TABLE simple_path;

--- a/regress/sql/cypher_set.sql
+++ b/regress/sql/cypher_set.sql
@@ -543,6 +543,55 @@ SELECT * FROM cypher('issue_1884', $$
 $$) AS (a agtype);
 
 --
+-- Issue 2493: a clause that reads must see every update a preceding SET
+-- made, not only the updates from that clause's first input row.
+--
+SELECT create_graph('issue_2493_set');
+
+SELECT * FROM cypher('issue_2493_set', $$
+    UNWIND [1, 2, 3] AS i CREATE (:x {id: i})
+$$) as (a agtype);
+
+-- all three updates must be visible to the later MATCH
+SELECT * FROM cypher('issue_2493_set', $$
+    MATCH (n:x) SET n.marked = true
+    WITH count(*) AS ignored
+    MATCH (m:x) WHERE m.marked = true
+    RETURN count(m)
+$$) as (visible agtype);
+
+-- the same for REMOVE, which shares the SET executor
+SELECT * FROM cypher('issue_2493_set', $$
+    MATCH (n:x) REMOVE n.marked
+    WITH count(*) AS ignored
+    MATCH (m:x) WHERE m.marked = true
+    RETURN count(m)
+$$) as (still_marked agtype);
+
+-- updates written earlier drive a later CREATE
+SELECT * FROM cypher('issue_2493_set', $$
+    MATCH (n:x) SET n.ready = true
+    WITH count(*) AS ignored
+    MATCH (m:x) WHERE m.ready = true
+    CREATE (:derived {from: m.id})
+$$) as (a agtype);
+
+SELECT * FROM cypher('issue_2493_set', $$
+    MATCH (d:derived) RETURN count(d)
+$$) as (derived agtype);
+
+-- a SET must still not see its own writes: this updates each vertex once
+SELECT * FROM cypher('issue_2493_set', $$
+    MATCH (n:x) SET n.pass = 1 RETURN count(*)
+$$) as (updated agtype);
+
+SELECT * FROM cypher('issue_2493_set', $$
+    MATCH (m:x) WHERE m.pass = 1 RETURN count(m)
+$$) as (persisted agtype);
+
+SELECT drop_graph('issue_2493_set', true);
+
+--
 -- Clean up
 --
 DROP TABLE tbl;

--- a/src/backend/executor/cypher_create.c
+++ b/src/backend/executor/cypher_create.c
@@ -244,6 +244,29 @@ static TupleTableSlot *exec_cypher_create(CustomScanState *node)
      */
     if (!used)
     {
+        /*
+         * This clause is finished. Make everything it wrote visible to the
+         * clauses that read after it.
+         *
+         * Entities are inserted with the global command id (see
+         * insert_entity_tuple), and CommandCounterIncrement() above advances
+         * that id once per input row. es_snapshot->curcid does not follow it,
+         * so without this it stays one step past the command id used by the
+         * first input row, and everything written by the remaining rows is
+         * invisible for the rest of the statement (issue #2493).
+         *
+         * Syncing here, rather than after each row, is what keeps the clause
+         * from seeing its own writes: by this point the subtree is exhausted,
+         * so raising curcid cannot feed a created row back into the pattern
+         * that created it.
+         *
+         * Max() because Increment_Estate_CommandId can push curcid above the
+         * global command id, and lowering it would hide tuples that are
+         * already visible.
+         */
+        estate->es_snapshot->curcid = Max(estate->es_snapshot->curcid,
+                                          GetCurrentCommandId(false));
+
         return NULL;
     }
 

--- a/src/backend/executor/cypher_set.c
+++ b/src/backend/executor/cypher_set.c
@@ -883,6 +883,29 @@ static TupleTableSlot *exec_cypher_set(CustomScanState *node)
 
     if (TupIsNull(slot))
     {
+        /*
+         * This clause is finished. Make everything it wrote visible to the
+         * clauses that read after it.
+         *
+         * Updated tuples are written with the global command id (see the cid
+         * in update_entity_tuple), and CommandCounterIncrement() advances that
+         * id once per input row. es_snapshot->curcid does not follow it, so
+         * without this it stays one step past the command id used by the first
+         * input row, and every later row's update is invisible for the rest of
+         * the statement. Same defect as the CREATE path (issue #2493).
+         *
+         * Syncing here, rather than after each row, is what keeps the clause
+         * from seeing its own writes: by this point the subtree is exhausted,
+         * so raising curcid cannot feed an updated row back into the pattern
+         * that updated it.
+         *
+         * Max() because Increment_Estate_CommandId can push curcid above the
+         * global command id, and lowering it would hide tuples that are
+         * already visible.
+         */
+        estate->es_snapshot->curcid = Max(estate->es_snapshot->curcid,
+                                          GetCurrentCommandId(false));
+
         return NULL;
     }
 


### PR DESCRIPTION
Fixes #2493. Also fixes the visibility half of #2491, and the underlying defect behind #2490.

## Problem

In a multi-part query, a clause that reads sees only the rows written by the **first input row** of a preceding `CREATE` or `SET`. Everything written by the remaining input rows is invisible for the rest of the statement.

```sql
SELECT * FROM cypher('g', $cypher$
  UNWIND [1, 2, 3] AS i
  CREATE (:v {id: i})
  WITH count(*) AS ignored
  MATCH (n:v)
  RETURN count(n)
$cypher$) AS (visible agtype);
```

Returns `1`. All three vertices are persisted.

The visible unit is the command id, which covers one input row — so the symptom depends on how the write is driven, not how much it writes:

| Setup | Written | Visible to the later `MATCH` | Persisted |
|---|---|---|---|
| `UNWIND range(1,2) AS i CREATE (:N {id:i})` | 2 | **1** | 2 |
| `UNWIND range(1,8) AS i CREATE (:N {id:i})` | 8 | **1** | 8 |
| 5 pre-existing, then create 3 in-statement | 3 | **6** (5 + 1) | 8 |
| `CREATE (:N),(:N),(:N)` — one input row | 3 | 3 ✅ | 3 |

`SET` behaves the same way: `MATCH (n:x) SET n.marked = true WITH count(*) AS ig MATCH (m:x) WHERE m.marked = true RETURN count(m)` sees 1 of 3, though all 3 updates persist.

## Root cause

Entities are written with the **global** command id — `insert_entity_tuple` for `CREATE`, the `cid` in `update_entity_tuple` for `SET` — and `CommandCounterIncrement()` advances that id once per input row.

The executor's snapshot does not follow it. `CommandCounterIncrement()` updates the current and secondary snapshots, not the pushed one `es_snapshot` points at, and `Increment_Estate_CommandId` bumps `curcid` only once, when the clause begins. So `curcid` sits one step past the command id used by the first input row, and only that row's tuples satisfy `cmin < curcid`.

This is already documented in-tree at `src/backend/executor/cypher_utils.c:248-260`, where `entity_exists()` works around it locally with `Max(saved_curcid, GetCurrentCommandId(false))`. Nothing applied the same correction to ordinary `MATCH` scans.

## Fix

When a `CREATE` or `SET` clause reaches the end of its input, raise `es_snapshot->curcid` to the global command id:

```c
estate->es_snapshot->curcid = Max(estate->es_snapshot->curcid,
                                  GetCurrentCommandId(false));
```

Doing this at end of input rather than after each row is what preserves the existing protection against a clause seeing its own writes: by that point the subtree is exhausted, so raising `curcid` cannot feed a written row back into the pattern that wrote it. `Max()` because `Increment_Estate_CommandId` can push `curcid` above the global command id, and lowering it would hide tuples that are already visible.

`REMOVE` is covered by the `SET` path it shares. `DELETE` already synchronizes `curcid` explicitly (`cypher_delete.c:356`, `:482`) and was unaffected; `MERGE` behaved correctly in the same probes.

## Testing

Full suite green — **42/42**, PostgreSQL 18.4.

Behaviour changes, all verified:

| Case | Before | After |
|---|---|---|
| #2493 as filed | `rows=1, bound=1` | **`3, 3`** |
| #2490 driven by two input rows | 2 | **4** |
| Create k vertices, count visible (k=1,2,3,8) | 1, 1, 1, 1 | **1, 2, 3, 8** |
| 5 pre-existing + 3 new | 6 | **8** |
| #2491 middle stage (8 vertices → edges) | 0 edges | **56 edges** |
| `SET` 3 vertices, later `MATCH` on the new property | 1 | **3** |
| `REMOVE` from 3, later `MATCH` counts still-marked | 2 | **0** |
| `MATCH (n:N) CREATE (:N)` — must not self-feed | 6 | **6** (unchanged) |

New regression coverage in `cypher_create` and `cypher_set` for visibility of every written row, for writes from an earlier clause driving a later one, and for a write clause still not seeing its own writes. Each new assertion was confirmed to fail without this change — `visible` reports 1 instead of 3, `edges` 0 instead of 6, `still_marked` 2 instead of 0.

I also ran the suite on unmodified `master` and with this change through an identical harness: the outputs are byte-identical apart from the new assertions, so nothing else moved.

## Out of scope

#2491 additionally hits a separate defect, filed as #2494: the planner can place the DML `CustomScan` on a side of a join the executor never pulls, so the writes are skipped entirely and nothing persists. That is untouched here, and #2491 will still fail until it is fixed.
