### PR TITLE
Fix drop_label privilege check for non-superusers (unrecognized class ID)

### DIFF
--- a/regress/expected/security.out
+++ b/regress/expected/security.out
@@ -1669,9 +1669,12 @@ CREATE ROLE age_nonsuper LOGIN NOSUPERUSER;
 -- create_graph() creates a new schema in the current database, so the role
 -- needs CREATE on the database; managing labels needs USAGE + CREATE on
 -- ag_catalog. Grant CREATE on whatever database the tests run in.
-SELECT format('GRANT CREATE ON DATABASE %I TO age_nonsuper', current_database())
-\gexec
-GRANT CREATE ON DATABASE contrib_regression TO age_nonsuper
+DO $$
+BEGIN
+    EXECUTE format('GRANT CREATE ON DATABASE %I TO age_nonsuper',
+                   current_database());
+END
+$$;
 GRANT USAGE  ON SCHEMA ag_catalog TO age_nonsuper;
 GRANT CREATE ON SCHEMA ag_catalog TO age_nonsuper;
 -- Reproduce as the non-superuser role: it creates (and therefore OWNS) the

--- a/regress/expected/security.out
+++ b/regress/expected/security.out
@@ -1655,3 +1655,61 @@ NOTICE:  graph "rls_graph" has been dropped
  
 (1 row)
 
+-- ============================================================================
+-- NON-SUPERUSER drop_label REGRESSION TEST
+--
+-- Regression test for object_ownercheck() argument order in
+-- range_var_callback_for_remove_relation(). A non-superuser that OWNS a
+-- graph/label previously failed drop_label() with "unrecognized class ID"
+-- because rel_oid was passed as the classid instead of RelationRelationId.
+-- ============================================================================
+DROP ROLE IF EXISTS age_nonsuper;
+NOTICE:  role "age_nonsuper" does not exist, skipping
+CREATE ROLE age_nonsuper LOGIN NOSUPERUSER;
+-- create_graph() creates a new schema in the current database, so the role
+-- needs CREATE on the database; managing labels needs USAGE + CREATE on
+-- ag_catalog. Grant CREATE on whatever database the tests run in.
+SELECT format('GRANT CREATE ON DATABASE %I TO age_nonsuper', current_database())
+\gexec
+GRANT CREATE ON DATABASE contrib_regression TO age_nonsuper
+GRANT USAGE  ON SCHEMA ag_catalog TO age_nonsuper;
+GRANT CREATE ON SCHEMA ag_catalog TO age_nonsuper;
+-- Reproduce as the non-superuser role: it creates (and therefore OWNS) the
+-- graph and the label, then drops the label. Before the fix this raised
+-- "unrecognized class ID"; after the fix the label is dropped successfully.
+SET ROLE age_nonsuper;
+SELECT create_graph('repro_graph');
+NOTICE:  graph "repro_graph" has been created
+ create_graph 
+--------------
+ 
+(1 row)
+
+SELECT create_vlabel('repro_graph', 'repro_label');
+NOTICE:  VLabel "repro_label" has been created
+ create_vlabel 
+---------------
+ 
+(1 row)
+
+SELECT drop_label('repro_graph', 'repro_label');
+NOTICE:  label "repro_graph"."repro_label" has been dropped
+ drop_label 
+------------
+ 
+(1 row)
+
+SELECT drop_graph('repro_graph', true);
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table repro_graph._ag_label_vertex
+drop cascades to table repro_graph._ag_label_edge
+NOTICE:  graph "repro_graph" has been dropped
+ drop_graph 
+------------
+ 
+(1 row)
+
+RESET ROLE;
+-- Cleanup
+DROP OWNED BY age_nonsuper CASCADE;
+DROP ROLE age_nonsuper;

--- a/regress/sql/security.sql
+++ b/regress/sql/security.sql
@@ -1465,8 +1465,12 @@ CREATE ROLE age_nonsuper LOGIN NOSUPERUSER;
 -- create_graph() creates a new schema in the current database, so the role
 -- needs CREATE on the database; managing labels needs USAGE + CREATE on
 -- ag_catalog. Grant CREATE on whatever database the tests run in.
-SELECT format('GRANT CREATE ON DATABASE %I TO age_nonsuper', current_database())
-\gexec
+DO $$
+BEGIN
+    EXECUTE format('GRANT CREATE ON DATABASE %I TO age_nonsuper',
+                   current_database());
+END
+$$;
 GRANT USAGE  ON SCHEMA ag_catalog TO age_nonsuper;
 GRANT CREATE ON SCHEMA ag_catalog TO age_nonsuper;
 

--- a/regress/sql/security.sql
+++ b/regress/sql/security.sql
@@ -1449,3 +1449,37 @@ DROP ROLE rls_admin;
 
 -- Drop test graph
 SELECT drop_graph('rls_graph', true);
+
+-- ============================================================================
+-- NON-SUPERUSER drop_label REGRESSION TEST
+--
+-- Regression test for object_ownercheck() argument order in
+-- range_var_callback_for_remove_relation(). A non-superuser that OWNS a
+-- graph/label previously failed drop_label() with "unrecognized class ID"
+-- because rel_oid was passed as the classid instead of RelationRelationId.
+-- ============================================================================
+
+DROP ROLE IF EXISTS age_nonsuper;
+CREATE ROLE age_nonsuper LOGIN NOSUPERUSER;
+
+-- create_graph() creates a new schema in the current database, so the role
+-- needs CREATE on the database; managing labels needs USAGE + CREATE on
+-- ag_catalog. Grant CREATE on whatever database the tests run in.
+SELECT format('GRANT CREATE ON DATABASE %I TO age_nonsuper', current_database())
+\gexec
+GRANT USAGE  ON SCHEMA ag_catalog TO age_nonsuper;
+GRANT CREATE ON SCHEMA ag_catalog TO age_nonsuper;
+
+-- Reproduce as the non-superuser role: it creates (and therefore OWNS) the
+-- graph and the label, then drops the label. Before the fix this raised
+-- "unrecognized class ID"; after the fix the label is dropped successfully.
+SET ROLE age_nonsuper;
+SELECT create_graph('repro_graph');
+SELECT create_vlabel('repro_graph', 'repro_label');
+SELECT drop_label('repro_graph', 'repro_label');
+SELECT drop_graph('repro_graph', true);
+RESET ROLE;
+
+-- Cleanup
+DROP OWNED BY age_nonsuper CASCADE;
+DROP ROLE age_nonsuper;

--- a/src/backend/commands/label_commands.c
+++ b/src/backend/commands/label_commands.c
@@ -1036,7 +1036,7 @@ static void range_var_callback_for_remove_relation(const RangeVar *rel,
 
     /* relkind == expected_relkind */
 
-    if (!object_ownercheck(rel_oid, get_rel_namespace(rel_oid), GetUserId()))
+    if (!object_ownercheck(RelationRelationId, rel_oid, GetUserId()))
     {
         aclcheck_error(ACLCHECK_NOT_OWNER,
                        get_relkind_objtype(get_rel_relkind(rel_oid)),


### PR DESCRIPTION
## Problem

Any non-superuser calling `drop_label('graph', 'label')` (or dropping a vertex/edge label) fails with:

```
ERROR:  unrecognized class ID: <oid>
```

Superusers are unaffected.

## Root cause

In `src/backend/commands/label_commands.c`, `range_var_callback_for_remove_relation()` calls the PG16+ `object_ownercheck()` with the wrong argument order. The API is:

```c
bool object_ownercheck(Oid classid, Oid objectid, Oid roleid);
```

AGE passed `rel_oid` as `classid` (should be `RelationRelationId`) and a namespace OID as `objectid` (should be `rel_oid`). Since `classid` isn't a real catalog OID, the lookup hits the `default` case in `get_object_property` and raises `unrecognized class ID`. Superusers escape because `object_ownercheck` early-returns via `superuser_arg(roleid)` before the classid lookup.

This was introduced in the PG16 port: before PG16 the code used the correct 2-arg `pg_class_ownercheck(rel_oid, GetUserId())`. The same defect is present on `master`, `PG16`, `PG17`, and `PG18`; PG15 and earlier are unaffected. This PR fixes `master`.

## Fix

```c
-    if (!object_ownercheck(rel_oid, get_rel_namespace(rel_oid), GetUserId()))
+    if (!object_ownercheck(RelationRelationId, rel_oid, GetUserId()))
```

This matches upstream PostgreSQL's own `RangeVarCallbackForDropRelation` usage. `RelationRelationId` is already available via existing includes (`catalog/pg_class_d.h`); no new include needed.

## Testing

- Added a regression test in `regress/sql/security.sql`: a `NOSUPERUSER` role creates (and therefore owns) a graph and label, then successfully runs `drop_label`. Verified it **fails** with `ERROR: unrecognized class ID` on the unpatched build and **passes** after the fix.
- `make installcheck` full suite: **42/42 tests pass** (PostgreSQL 18).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>