### PR TITLE
Add missing ASF license header to regress/sql/agehash.sql

### DIFF
--- a/regress/sql/agehash.sql
+++ b/regress/sql/agehash.sql
@@ -1,4 +1,23 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
  * agehash internal selftest.
  *
  * Exercises the Robin Hood open-addressing hashtable used by AGE's hot-path


### PR DESCRIPTION
## Summary
- `regress/sql/agehash.sql` (added in #2421) was missing the standard ASF license header carried by every other file in `regress/sql/`.
- Flagged as a non-blocking observation in the 1.8.0 RC vote thread; fixing in master as noted there.

## Test plan
- Comment-only change; no behavioral effect on the regression test.