### PR TITLE
Update NOTICE copyright year to 2026

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache AGE
-Copyright 2023 The Apache Software Foundation.
+Copyright 2026 The Apache Software Foundation.
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 


### PR DESCRIPTION
## Summary
- `NOTICE` still read "Copyright 2023," stale since 1.7.0.
- Flagged as a non-blocking observation in the 1.8.0 RC vote thread; fixing in master as noted there.

## Test plan
- Text-only change to the NOTICE file; no code or test impact.