### PR TITLE
VLE: cache edge/vertex classification and prune PATHS_BETWEEN via reverse BFS

### DIFF
--- a/src/backend/age.c
+++ b/src/backend/age.c
@@ -26,6 +26,7 @@
 #include "parser/cypher_analyze.h"
 #include "utils/ag_guc.h"
 #include "utils/age_global_graph.h"
+#include "utils/age_vle.h"
 
 #if PG_VERSION_NUM < 170000
 
@@ -63,6 +64,7 @@ void _PG_init(void)
         return;
     }
 
+    vle_define_guc_variables();
     register_ag_nodes();
     set_rel_pathlist_init();
     object_access_hook_init();

--- a/src/backend/parser/cypher_clause.c
+++ b/src/backend/parser/cypher_clause.c
@@ -5908,6 +5908,7 @@ static List *transform_match_entities(cypher_parsestate *cpstate, Query *query,
 {
     ParseState *pstate = (ParseState *)cpstate;
     ListCell *lc = NULL;
+    ListCell *next_lc = NULL;
     List *entities = NIL;
     int i = 0;
     bool node_declared_in_prev_clause = false;
@@ -6201,7 +6202,7 @@ static List *transform_match_entities(cypher_parsestate *cpstate, Query *query,
                  * the agtype vertex variable itself. The VLE execution
                  * logic will handle extracting the id from it.
                  */
-                ListCell *next_lc = lnext(path->path, lc);
+                next_lc = lnext(path->path, lc);
 
                 if (next_lc != NULL)
                 {

--- a/src/backend/parser/cypher_clause.c
+++ b/src/backend/parser/cypher_clause.c
@@ -6193,6 +6193,34 @@ static List *transform_match_entities(cypher_parsestate *cpstate, Query *query,
                     cr->fields = list_make1(linitial(cr->fields));
                 }
 
+                /*
+                 * Check if the next node (the target vertex) was originally
+                 * declared in a preceding clause. If it was, we need to
+                 * modify the second argument of the VLE function call.
+                 * Instead of referencing a table column, we just reference
+                 * the agtype vertex variable itself. The VLE execution
+                 * logic will handle extracting the id from it.
+                 */
+                ListCell *next_lc = lnext(path->path, lc);
+
+                if (next_lc != NULL)
+                {
+                    cypher_node *next_node = lfirst(next_lc);
+
+                    if (next_node->name != NULL &&
+                        colNameToVar(pstate, next_node->name, false, -1) != NULL)
+                    {
+                        FuncCall *func = (FuncCall*)rel->varlen;
+                        ColumnRef *veid_cr = makeNode(ColumnRef);
+                        ListCell *veid_cell = list_nth_cell(func->args, 1);
+
+                        veid_cr->fields = list_make1(makeString(next_node->name));
+                        veid_cr->location = -1;
+
+                        lfirst(veid_cell) = (Node *) veid_cr;
+                    }
+                }
+
                 /* make a transform entity for the vle */
                 vle_entity = transform_VLE_edge_entity(cpstate, rel, query);
 

--- a/src/backend/utils/adt/age_vle.c
+++ b/src/backend/utils/adt/age_vle.c
@@ -3565,7 +3565,7 @@ Datum age_vle(PG_FUNCTION_ARGS)
         if (!is_zero_bound)
         {
             /* the path_stack should have something in it if we have a path */
-            Assert(vlelctx->dfs_path_stack > 0);
+            Assert(gid_stack_size(vlelctx->dfs_path_stack) > 0);
 
             /*
              * Build the graphid array into a VLE_path_container from the
@@ -3740,7 +3740,7 @@ Datum age_match_vle_edge_to_id_qual(PG_FUNCTION_ARGS)
     {
         ereport(ERROR,
             (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-            errmsg("argument 1 of age_match_vle_edge_to_edge_qual must be a VLE_Path_Container")));
+            errmsg("argument 1 of age_match_vle_edge_to_id_qual must be a VLE_Path_Container")));
     }
 
     /* cast argument as a VLE_Path_Container and extract graphid array */
@@ -3768,7 +3768,7 @@ Datum age_match_vle_edge_to_id_qual(PG_FUNCTION_ARGS)
         {
             ereport(ERROR,
                     (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-                     errmsg("argument 2 of age_match_vle_edge_to_edge_qual must be an integer")));
+                     errmsg("argument 2 of age_match_vle_edge_to_id_qual must be an integer")));
         }
 
         id = get_ith_agtype_value_from_container(&edge_id->root, 0);
@@ -3777,7 +3777,7 @@ Datum age_match_vle_edge_to_id_qual(PG_FUNCTION_ARGS)
         {
             ereport(ERROR,
                     (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-                     errmsg("argument 2 of age_match_vle_edge_to_edge_qual must be an integer")));
+                     errmsg("argument 2 of age_match_vle_edge_to_id_qual must be an integer")));
         }
 
         gid = id->val.int_value;
@@ -3799,7 +3799,7 @@ Datum age_match_vle_edge_to_id_qual(PG_FUNCTION_ARGS)
     {
         ereport(ERROR,
                 (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-                 errmsg("argument 3 of age_match_vle_edge_to_edge_qual must be an integer")));
+                 errmsg("argument 3 of age_match_vle_edge_to_id_qual must be a boolean")));
     }
 
     position = get_ith_agtype_value_from_container(&pos_agt->root, 0);
@@ -3808,7 +3808,7 @@ Datum age_match_vle_edge_to_id_qual(PG_FUNCTION_ARGS)
     {
         ereport(ERROR,
                 (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-                 errmsg("argument 3 of age_match_vle_edge_to_edge_qual must be an integer")));
+                 errmsg("argument 3 of age_match_vle_edge_to_id_qual must be a boolean")));
     }
 
     vle_is_on_left = position->val.boolean;

--- a/src/backend/utils/adt/age_vle.c
+++ b/src/backend/utils/adt/age_vle.c
@@ -80,6 +80,7 @@
             (graphid *) (&vpc->graphid_array_data)
 #define EDGE_STATE_HTAB_NAME "Edge state "
 #define EDGE_STATE_HTAB_INITIAL_SIZE 100000
+#define VERTEX_EDGE_HTAB_INITIAL_SIZE 5000
 #define EXISTS_HTAB_NAME "known edges"
 #define EXISTS_HTAB_NAME_INITIAL_SIZE 1000
 #define MAXIMUM_NUMBER_OF_CACHED_LOCAL_CONTEXTS 5
@@ -90,11 +91,30 @@ typedef struct edge_state_entry
     graphid edge_id;               /* edge id, it is also the hash key */
     graphid start_vertex_id;       /* Topology cache for edge endpoints; */
     graphid end_vertex_id;         /* used for direction resolution in DFS. */
-    bool used_in_path;             /* like visited but more descriptive */
-    bool has_been_matched;         /* have we checked for a  match */
-    bool matched;                  /* is it a match */
+    uint8 flags;                   /* used_in_path: like visited but more descriptive */
+                                   /* has_been_matched: have we checked for a  match */
+                                   /* matched: is it a match */
 } edge_state_entry;
 
+
+/*
+ * Macros for manipulating edge_state_entry flags: used_in_path,
+ * has_been_matched stored, matched in a single uint8 field.
+ * These replace three separate booleans to save space in the hash table.
+*/
+#define USE_IN_PATH_FLAGS_MASK 0b00000001
+#define HAS_BEEN_MATCHED_FLAGS_MASK 0b00000010
+#define MATCHED_FLAGS_MASK 0b00000100
+
+#define EDGE_STATE_ENTRY_USE_IN_PATH(ese) ((ese)->flags & USE_IN_PATH_FLAGS_MASK)
+#define EDGE_STATE_ENTRY_HAS_BEEN_MATCHED(ese) ((ese)->flags & HAS_BEEN_MATCHED_FLAGS_MASK)
+#define EDGE_STATE_ENTRY_MATCHED(ese) ((ese)->flags & MATCHED_FLAGS_MASK)
+#define EDGE_STATE_ENTRY_SET_USE_IN_PATH(ese) ((ese)->flags |= USE_IN_PATH_FLAGS_MASK)
+#define EDGE_STATE_ENTRY_SET_HAS_BEEN_MATCHED(ese) ((ese)->flags |= HAS_BEEN_MATCHED_FLAGS_MASK)
+#define EDGE_STATE_ENTRY_SET_MATCHED(ese) ((ese)->flags |= MATCHED_FLAGS_MASK)
+#define EDGE_STATE_ENTRY_UNSET_USE_IN_PATH(ese) ((ese)->flags &= ~USE_IN_PATH_FLAGS_MASK)
+#define EDGE_STATE_ENTRY_UNSET_HAS_BEEN_MATCHED(ese) ((ese)->flags &= ~HAS_BEEN_MATCHED_FLAGS_MASK)
+#define EDGE_STATE_ENTRY_UNSET_MATCHED(ese) ((ese)->flags &= ~MATCHED_FLAGS_MASK)
 /*
  * Vertex-level cache of statically-valid adjacent edges (see
  * get_or_build_vertex_edge_cache). "Statically valid" means the edge passed
@@ -528,7 +548,7 @@ static void create_VLE_local_state_hashtable(VLE_local_context *vlelctx)
         vertex_edge_ctl.entrysize = sizeof(vertex_edge_cache_entry);
         vertex_edge_ctl.hash = graphid_hash;
         vlelctx->vertex_edge_cache = hash_create("VLE vertex edge cache",
-                                                 EDGE_STATE_HTAB_INITIAL_SIZE,
+                                                 VERTEX_EDGE_HTAB_INITIAL_SIZE,
                                                  &vertex_edge_ctl,
                                                  HASH_ELEM | HASH_FUNCTION);
     }
@@ -1162,9 +1182,7 @@ static edge_state_entry *get_edge_state_with_hash(VLE_local_context *vlelctx,
     if (!found)
     {
         ese->edge_id = edge_id;
-        ese->used_in_path = false;
-        ese->has_been_matched = false;
-        ese->matched = false;
+        ese->flags = 0;
         /*
          * start_vertex_id/end_vertex_id are only ever read once
          * has_been_matched is true -- see get_next_vertex_from_state(),
@@ -1366,7 +1384,7 @@ static bool dfs_find_a_path_between(VLE_local_context *vlelctx)
          * in the path (loop - we need to remove the edge from the edge stack
          * and start with the next edge).
          */
-        if (ese->used_in_path)
+        if (EDGE_STATE_ENTRY_USE_IN_PATH(ese))
         {
             graphid path_edge_id;
 
@@ -1379,7 +1397,7 @@ static bool dfs_find_a_path_between(VLE_local_context *vlelctx)
             if (edge_id == path_edge_id)
             {
                 gid_stack_pop(path_stack);
-                ese->used_in_path = false;
+                EDGE_STATE_ENTRY_UNSET_USE_IN_PATH(ese);
             }
             /* now remove it from the edge stack */
             gid_stack_pop(edge_stack);
@@ -1403,7 +1421,7 @@ static bool dfs_find_a_path_between(VLE_local_context *vlelctx)
          * Mark it and push it on the path stack. There is no need to push it on
          * the edge stack as it is already there.
          */
-        ese->used_in_path = true;
+        EDGE_STATE_ENTRY_SET_USE_IN_PATH(ese);
         gid_stack_push(path_stack, edge_id);
 
         /*
@@ -1513,7 +1531,7 @@ static bool dfs_find_a_path_from(VLE_local_context *vlelctx)
          * in the path (loop - we need to remove the edge from the edge stack
          * and start with the next edge).
          */
-        if (ese->used_in_path)
+        if (EDGE_STATE_ENTRY_USE_IN_PATH(ese))
         {
             graphid path_edge_id;
 
@@ -1526,7 +1544,7 @@ static bool dfs_find_a_path_from(VLE_local_context *vlelctx)
             if (edge_id == path_edge_id)
             {
                 gid_stack_pop(path_stack);
-                ese->used_in_path = false;
+                EDGE_STATE_ENTRY_UNSET_USE_IN_PATH(ese);
             }
             /* now remove it from the edge stack */
             gid_stack_pop(edge_stack);
@@ -1550,7 +1568,7 @@ static bool dfs_find_a_path_from(VLE_local_context *vlelctx)
          * Mark it and push it on the path stack. There is no need to push it on
          * the edge stack as it is already there.
          */
-        ese->used_in_path = true;
+        EDGE_STATE_ENTRY_SET_USE_IN_PATH(ese);
         gid_stack_push(path_stack, edge_id);
 
         /*
@@ -1802,15 +1820,22 @@ static vertex_edge_cache_entry *get_or_build_vertex_edge_cache(
              * triggered classification -- so it is safe to reuse. Only
              * classify (and cache start/end) the first time, ever.
              */
-            if (!ese->has_been_matched)
+            if (!EDGE_STATE_ENTRY_HAS_BEEN_MATCHED(ese))
             {
-                ese->has_been_matched = true;
-                ese->matched = is_an_edge_match(vlelctx, ee);
+                EDGE_STATE_ENTRY_SET_HAS_BEEN_MATCHED(ese);
+                if (is_an_edge_match(vlelctx, ee))
+                {
+                    EDGE_STATE_ENTRY_SET_MATCHED(ese);
+                }
+                else
+                {
+                    EDGE_STATE_ENTRY_UNSET_MATCHED(ese);
+                }
                 ese->start_vertex_id = get_edge_entry_start_vertex_id(ee);
                 ese->end_vertex_id = get_edge_entry_end_vertex_id(ee);
             }
 
-            if (ese->matched)
+            if (EDGE_STATE_ENTRY_MATCHED(ese))
             {
                 scratch[nscratch++] = batch_eids[i];
             }
@@ -2228,15 +2253,22 @@ static void rdist_expand_vertex(VLE_local_context *vlelctx, graphid u,
                 elog(ERROR, "rdist_expand_vertex: no edge found");
             }
 
-            if (!ese->has_been_matched)
+            if (!EDGE_STATE_ENTRY_HAS_BEEN_MATCHED(ese))
             {
-                ese->has_been_matched = true;
-                ese->matched = is_an_edge_match(vlelctx, ee);
+                EDGE_STATE_ENTRY_SET_HAS_BEEN_MATCHED(ese);
+                if (is_an_edge_match(vlelctx, ee))
+                {
+                    EDGE_STATE_ENTRY_SET_MATCHED(ese);
+                }
+                else
+                {
+                    EDGE_STATE_ENTRY_UNSET_MATCHED(ese);
+                }
                 ese->start_vertex_id = get_edge_entry_start_vertex_id(ee);
                 ese->end_vertex_id = get_edge_entry_end_vertex_id(ee);
             }
 
-            if (!ese->matched)
+            if (!EDGE_STATE_ENTRY_MATCHED(ese))
             {
                 continue;
             }
@@ -2418,7 +2450,7 @@ static void add_valid_vertex_edges(VLE_local_context *vlelctx,
              * Don't add any edges that we have already seen because they
              * will cause a loop to form.
              */
-            if (ese->used_in_path)
+            if (EDGE_STATE_ENTRY_USE_IN_PATH(ese))
             {
                 continue;
             }

--- a/src/backend/utils/adt/age_vle.c
+++ b/src/backend/utils/adt/age_vle.c
@@ -68,7 +68,9 @@
 #include "miscadmin.h"
 #include "nodes/pg_list.h"
 #include "utils/datum.h"
+#include "utils/guc.h"
 #include "utils/lsyscache.h"
+#include "utils/memutils.h"
 
 #include "utils/age_vle.h"
 #include "catalog/ag_graph.h"
@@ -79,42 +81,151 @@
 #define GET_GRAPHID_ARRAY_FROM_CONTAINER(vpc) \
             (graphid *) (&vpc->graphid_array_data)
 #define EDGE_STATE_HTAB_NAME "Edge state "
-#define EDGE_STATE_HTAB_INITIAL_SIZE 100000
-#define VERTEX_EDGE_HTAB_INITIAL_SIZE 5000
 #define EXISTS_HTAB_NAME "known edges"
 #define EXISTS_HTAB_NAME_INITIAL_SIZE 1000
-#define MAXIMUM_NUMBER_OF_CACHED_LOCAL_CONTEXTS 5
 
-/* edge state entry for the edge_state_hashtable */
+/*
+ * ---------------------------------------------------------------------
+ * GUC-controlled memory knobs for the VLE caches
+ * ---------------------------------------------------------------------
+ */
+int vle_edge_state_htab_initial_size = 16384;
+int vle_vertex_edge_htab_initial_size = 1024;
+int vle_edge_state_max_entries = 2000000;
+int vle_vertex_edge_cache_max_entries = 200000;
+int vle_vertex_edge_cache_max_kb = 65536;
+int vle_reverse_dist_max_entries = 500000;
+int vle_max_cached_contexts = 5;
+bool vle_edge_state_eviction_enabled = true;
+
+#define MAXIMUM_NUMBER_OF_CACHED_LOCAL_CONTEXTS (vle_max_cached_contexts)
+
+void vle_define_guc_variables(void)
+{
+    DefineCustomIntVariable("age.vle_edge_state_htab_initial_size",
+                            "Initial bucket count for the per-query VLE edge-state hash table.",
+                            "Lower values reduce baseline memory for small VLE queries; "
+                            "the table still grows on demand for larger ones.",
+                            &vle_edge_state_htab_initial_size,
+                            vle_edge_state_htab_initial_size, 16, 10000000,
+                            PGC_USERSET, 0, NULL, NULL, NULL);
+
+    DefineCustomIntVariable("age.vle_vertex_edge_htab_initial_size",
+                            "Initial bucket count for the per-query VLE vertex->edges cache.",
+                            NULL,
+                            &vle_vertex_edge_htab_initial_size,
+                            vle_vertex_edge_htab_initial_size, 16, 10000000,
+                            PGC_USERSET, 0, NULL, NULL, NULL);
+
+    DefineCustomIntVariable("age.vle_edge_state_max_entries",
+                            "Soft cap on live entries in the VLE edge-state hash table "
+                            "before background eviction of unreferenced entries kicks in.",
+                            "Entries currently pinned (part of the active DFS path or "
+                            "still sitting unresolved on the DFS edge stack) are never "
+                            "evicted, so actual memory can still exceed this in the "
+                            "worst case -- see age.vle_edge_state_eviction_enabled.",
+                            &vle_edge_state_max_entries,
+                            vle_edge_state_max_entries, 1000, INT_MAX,
+                            PGC_USERSET, 0, NULL, NULL, NULL);
+
+    DefineCustomIntVariable("age.vle_vertex_edge_cache_max_entries",
+                            "Soft cap on the number of vertices whose statically-valid "
+                            "adjacent edges are cached at once (VLE vertex_edge_cache).",
+                            "Unlike the edge-state cache, this one is a pure "
+                            "performance cache with no pinning constraints, so it is "
+                            "always evicted down to the cap using an LRU/clock policy.",
+                            &vle_vertex_edge_cache_max_entries,
+                            vle_vertex_edge_cache_max_entries, 1000, INT_MAX,
+                            PGC_USERSET, 0, NULL, NULL, NULL);
+
+    DefineCustomIntVariable("age.vle_vertex_edge_cache_max_kb",
+                            "Soft cap, in kilobytes, on the memory backing "
+                            "VLE vertex_edge_cache's cached adjacency arrays.",
+                            "A single high-degree (hub) vertex can hold far more "
+                            "memory than age.vle_vertex_edge_cache_max_entries alone "
+                            "would suggest; this bounds the cache by its actual "
+                            "footprint.",
+                            &vle_vertex_edge_cache_max_kb,
+                            vle_vertex_edge_cache_max_kb, 1024, INT_MAX,
+                            PGC_USERSET, 0, NULL, NULL, NULL);
+
+    DefineCustomIntVariable("age.vle_reverse_dist_max_entries",
+                            "Cap on the reverse-BFS distance table used to prune "
+                            "PATHS_BETWEEN VLE queries.",
+                            "Once reached, the reverse BFS simply stops advancing "
+                            "(graceful degradation of pruning power, never a "
+                            "correctness issue -- under-pruning only costs speed).",
+                            &vle_reverse_dist_max_entries,
+                            vle_reverse_dist_max_entries, 1000, INT_MAX,
+                            PGC_USERSET, 0, NULL, NULL, NULL);
+
+    DefineCustomIntVariable("age.vle_max_cached_contexts",
+                            "Maximum number of VLE_local_context objects (one per "
+                            "distinct VLE grammar node) kept cached per backend.",
+                            NULL,
+                            &vle_max_cached_contexts,
+                            vle_max_cached_contexts, 1, 1000,
+                            PGC_USERSET, 0, NULL, NULL, NULL);
+
+    DefineCustomBoolVariable("age.vle_edge_state_eviction_enabled",
+                            "Enable clock-style eviction of unreferenced entries in "
+                            "the VLE edge-state hash table once "
+                            "age.vle_edge_state_max_entries is exceeded.",
+                            "When disabled, the edge-state cache grows without a "
+                            "hard bound (still only ever holding matched edges).",
+                            &vle_edge_state_eviction_enabled,
+                            vle_edge_state_eviction_enabled,
+                            PGC_USERSET, 0, NULL, NULL, NULL);
+}
+
+/*
+ * Edge state entry for the edge_state_hashtable.
+ *
+ * An entry is created here only for an edge that passed
+ * is_an_edge_match() -- see get_or_build_vertex_edge_cache() and
+ * rdist_expand_vertex(). Presence in the table therefore implies
+ * "matched"; there is no separate matched flag.
+ *
+ * pin_count is the number of times this edge_id currently sits,
+ * unpopped, somewhere on vlelctx->dfs_edge_stack. Because vertices (not
+ * just edges) can be revisited by the DFS, the SAME edge_id can be
+ * pushed onto dfs_edge_stack more than once while an older, still-open
+ * copy is buried deeper in the stack (see add_valid_vertex_edges() and
+ * the single gid_stack_pop(edge_stack) sites in dfs_find_a_path_between/
+ * from()). used_in_path alone is therefore NOT sufficient to know an
+ * entry is safe to evict -- a pin_count of 0 is: it means no live
+ * occurrence of this edge remains anywhere on the stack, in any state.
+ */
 typedef struct edge_state_entry
 {
     graphid edge_id;               /* edge id, it is also the hash key */
     graphid start_vertex_id;       /* Topology cache for edge endpoints; */
     graphid end_vertex_id;         /* used for direction resolution in DFS. */
-    uint8 flags;                   /* used_in_path: like visited but more descriptive */
-                                   /* has_been_matched: have we checked for a  match */
-                                   /* matched: is it a match */
+    uint32 state;               /* bits 0-29: live occurrences on dfs_edge_stack; */
+                                    /* 0 <=> safe to evict (see above)    */
+                                /* bit 30: used_in_path; bit 31: clock_ref (eviction) */
 } edge_state_entry;
 
 
 /*
- * Macros for manipulating edge_state_entry flags: used_in_path,
- * has_been_matched stored, matched in a single uint8 field.
- * These replace three separate booleans to save space in the hash table.
-*/
-#define USE_IN_PATH_FLAGS_MASK 0b00000001
-#define HAS_BEEN_MATCHED_FLAGS_MASK 0b00000010
-#define MATCHED_FLAGS_MASK 0b00000100
+ * Macros for manipulating edge_state_entry flags: used_in_path and
+ * clock_ref, packed into a single uint8 field.
+ */
+#define PIN_COUNT_MASK 0b00111111111111111111111111111111U /* bits 0-29 */
+#define USE_IN_PATH_FLAGS_MASK 0b01000000000000000000000000000000U /* bit 30 */
+#define CLOCK_REF_FLAGS_MASK   0b10000000000000000000000000000000U /* bit 31 */
 
-#define EDGE_STATE_ENTRY_USE_IN_PATH(ese) ((ese)->flags & USE_IN_PATH_FLAGS_MASK)
-#define EDGE_STATE_ENTRY_HAS_BEEN_MATCHED(ese) ((ese)->flags & HAS_BEEN_MATCHED_FLAGS_MASK)
-#define EDGE_STATE_ENTRY_MATCHED(ese) ((ese)->flags & MATCHED_FLAGS_MASK)
-#define EDGE_STATE_ENTRY_SET_USE_IN_PATH(ese) ((ese)->flags |= USE_IN_PATH_FLAGS_MASK)
-#define EDGE_STATE_ENTRY_SET_HAS_BEEN_MATCHED(ese) ((ese)->flags |= HAS_BEEN_MATCHED_FLAGS_MASK)
-#define EDGE_STATE_ENTRY_SET_MATCHED(ese) ((ese)->flags |= MATCHED_FLAGS_MASK)
-#define EDGE_STATE_ENTRY_UNSET_USE_IN_PATH(ese) ((ese)->flags &= ~USE_IN_PATH_FLAGS_MASK)
-#define EDGE_STATE_ENTRY_UNSET_HAS_BEEN_MATCHED(ese) ((ese)->flags &= ~HAS_BEEN_MATCHED_FLAGS_MASK)
-#define EDGE_STATE_ENTRY_UNSET_MATCHED(ese) ((ese)->flags &= ~MATCHED_FLAGS_MASK)
+#define EDGE_STATE_ENTRY_USE_IN_PATH(ese) ((ese)->state & USE_IN_PATH_FLAGS_MASK)
+#define EDGE_STATE_ENTRY_SET_USE_IN_PATH(ese) ((ese)->state |= USE_IN_PATH_FLAGS_MASK)
+#define EDGE_STATE_ENTRY_UNSET_USE_IN_PATH(ese) ((ese)->state &= ~USE_IN_PATH_FLAGS_MASK)
+
+#define EDGE_STATE_ENTRY_CLOCK_REF(ese) ((ese)->state & CLOCK_REF_FLAGS_MASK)
+#define EDGE_STATE_ENTRY_SET_CLOCK_REF(ese) ((ese)->state |= CLOCK_REF_FLAGS_MASK)
+#define EDGE_STATE_ENTRY_UNSET_CLOCK_REF(ese) ((ese)->state &= ~CLOCK_REF_FLAGS_MASK)
+
+#define EDGE_STATE_ENTRY_PIN_COUNT(ese) ((ese)->state & PIN_COUNT_MASK)
+#define EDGE_STATE_ENTRY_PIN_COUNT_INC(ese) ((ese)->state = ((ese)->state & ~PIN_COUNT_MASK) | (EDGE_STATE_ENTRY_PIN_COUNT(ese) + 1))
+#define EDGE_STATE_ENTRY_PIN_COUNT_DEC(ese) ((ese)->state = ((ese)->state & ~PIN_COUNT_MASK) | (EDGE_STATE_ENTRY_PIN_COUNT(ese) - 1))
 /*
  * Vertex-level cache of statically-valid adjacent edges (see
  * get_or_build_vertex_edge_cache). "Statically valid" means the edge passed
@@ -135,6 +246,14 @@ typedef struct vertex_edge_cache_entry
                                       * nvalid, not to the raw adjacency
                                       * count -- see the repalloc in
                                       * get_or_build_vertex_edge_cache(). */
+    bool clock_ref;                 /* eviction: touched since last sweep?
+                                      * Unlike edge_state_entry, this cache
+                                      * has NO pinning requirement -- the
+                                      * returned pointer is only ever used
+                                      * synchronously within a single
+                                      * add_valid_vertex_edges() call, never
+                                      * retained -- so any entry is always
+                                      * safe to evict and rebuild later. */
 } vertex_edge_cache_entry;
 
 /*
@@ -213,7 +332,21 @@ typedef struct VLE_local_context
                                       * been created for this vlelctx */
     graphid reverse_dist_target;    /* veid for reverse_dist_table */
     bool reverse_dist_exhausted;    /* true once the reverse-BFS frontier
-                                      * is drained or past the uidx budget */
+                                      * is fully drained (or past the uidx
+                                      * budget) -- a PROOF that any vertex
+                                      * not already in reverse_dist_table
+                                      * is unreachable within scope. Only
+                                      * this flag may make
+                                      * get_or_advance_reverse_dist() return
+                                      * PG_INT64_MAX for an unknown vertex. */
+    bool reverse_dist_capped;       /* true once age.vle_reverse_dist_max_entries
+                                      * stopped the reverse BFS from
+                                      * admitting new frontier vertices.
+                                      * This is NOT a reachability proof --
+                                      * it just means we gave up early to
+                                      * respect a memory budget -- so it
+                                      * must never be treated the way
+                                      * reverse_dist_exhausted is. */
     rdist_queue reverse_dist_queue; /* reverse-BFS frontier */
     GraphIdStack *dfs_vertex_stack; /* dfs stack for vertices (array-based) */
     GraphIdStack *dfs_edge_stack;   /* dfs stack for edges (array-based) */
@@ -290,6 +423,15 @@ static void free_VLE_local_context(VLE_local_context *vlelctx);
 static edge_state_entry *get_edge_state_with_hash(VLE_local_context *vlelctx,
                                                   graphid edge_id,
                                                   uint32 hashvalue);
+static edge_state_entry *find_edge_state_with_hash(VLE_local_context *vlelctx,
+                                                    graphid edge_id,
+                                                    uint32 hashvalue);
+static edge_state_entry *insert_matched_edge_state(VLE_local_context *vlelctx,
+                                                    graphid edge_id,
+                                                    uint32 hashvalue,
+                                                    edge_entry *ee);
+static void evict_edge_state_entries_if_needed(VLE_local_context *vlelctx);
+static void evict_vertex_edge_cache_entries_if_needed(VLE_local_context *vlelctx);
 /* graphid data structures */
 static void load_initial_dfs_stacks(VLE_local_context *vlelctx);
 static bool dfs_find_a_path_between(VLE_local_context *vlelctx);
@@ -506,7 +648,7 @@ static void create_VLE_local_state_hashtable(VLE_local_context *vlelctx)
     edge_state_ctl.entrysize = sizeof(edge_state_entry);
     edge_state_ctl.hash = graphid_hash;
     vlelctx->edge_state_hashtable = hash_create(eshn,
-                                                EDGE_STATE_HTAB_INITIAL_SIZE,
+                                                vle_edge_state_htab_initial_size,
                                                 &edge_state_ctl,
                                                 HASH_ELEM | HASH_FUNCTION);
     pfree_if_not_null(eshn);
@@ -548,7 +690,7 @@ static void create_VLE_local_state_hashtable(VLE_local_context *vlelctx)
         vertex_edge_ctl.entrysize = sizeof(vertex_edge_cache_entry);
         vertex_edge_ctl.hash = graphid_hash;
         vlelctx->vertex_edge_cache = hash_create("VLE vertex edge cache",
-                                                 VERTEX_EDGE_HTAB_INITIAL_SIZE,
+                                                 vle_vertex_edge_htab_initial_size,
                                                  &vertex_edge_ctl,
                                                  HASH_ELEM | HASH_FUNCTION);
     }
@@ -1168,6 +1310,23 @@ static VLE_local_context *build_local_vle_context(FunctionCallInfo fcinfo,
  * both the dynahash edge_state_hashtable here and the agehash-backed
  * edge_table on the global-graph lookup path elsewhere.
  */
+/*
+ * Get (creating if necessary) the edge_state_entry for edge_id.
+ *
+ * Every caller -- the DFS peek at the top of dfs_find_a_path_between()/
+ * from(), and the dynamic used_in_path re-check in
+ * add_valid_vertex_edges() -- only ever asks about an edge already known
+ * to be statically valid (matched): it came out of
+ * vertex_edge_cache_entry->valid_edges[], or it is already sitting on
+ * dfs_edge_stack. A lookup miss therefore never means "not yet
+ * classified" (that only happens in get_or_build_vertex_edge_cache() /
+ * rdist_expand_vertex(), which gate insertion on is_an_edge_match()); it
+ * means the entry was reclaimed by evict_edge_state_entries_if_needed()
+ * while unreferenced (pin_count == 0, not used_in_path). On a miss we
+ * re-derive start/end from the underlying edge and recreate the entry in
+ * the same neutral state (pin_count 0, flags 0) it was evicted in, which
+ * makes eviction transparent to every caller.
+ */
 static edge_state_entry *get_edge_state_with_hash(VLE_local_context *vlelctx,
                                                   graphid edge_id,
                                                   uint32 hashvalue)
@@ -1181,23 +1340,184 @@ static edge_state_entry *get_edge_state_with_hash(VLE_local_context *vlelctx,
                                             HASH_ENTER, &found);
     if (!found)
     {
-        ese->edge_id = edge_id;
-        ese->flags = 0;
+        edge_entry *ee = get_edge_entry_with_hash(vlelctx->ggctx, edge_id,
+                                                  hashvalue);
+
+        if (ee == NULL)
+        {
+            elog(ERROR, "get_edge_state_with_hash: no edge found");
+        }
+
         /*
-         * start_vertex_id/end_vertex_id are only ever read once
-         * has_been_matched is true -- see get_next_vertex_from_state(),
-         * which also Assert()s that precondition for cassert builds. Zero
-         * them here anyway (rather than leaving them as whatever garbage
-         * hash_search_with_hash_value's palloc happened to return) so that
-         * any accidental early read in a production (non-cassert) build
-         * resolves deterministically to graphid 0 -- which cannot be a
-         * real vertex id -- instead of silently "succeeding" with
-         * plausible-looking uninitialized bytes.
+         * Callers only ever pass an edge_id already known to be a match
+         * (see above), so it is not re-verified in production builds --
+         * only re-confirmed here under assertions, to catch any future
+         * caller that violates the precondition instead of silently
+         * fabricating state for a non-matching edge.
          */
-        ese->start_vertex_id = 0;
-        ese->end_vertex_id = 0;
+        Assert(is_an_edge_match(vlelctx, ee));
+
+        ese->edge_id = edge_id;
+        ese->state = 0;
+        ese->start_vertex_id = get_edge_entry_start_vertex_id(ee);
+        ese->end_vertex_id = get_edge_entry_end_vertex_id(ee);
     }
+
+    /* mark as recently touched for the clock-eviction sweep */
+    EDGE_STATE_ENTRY_SET_CLOCK_REF(ese);
+
     return ese;
+}
+
+/*
+ * HASH_FIND-only counterpart of get_edge_state_with_hash(), used by the
+ * classification call sites (get_or_build_vertex_edge_cache(),
+ * rdist_expand_vertex()) to check whether edge_id has already been
+ * classified as a match, without creating an entry as a side effect --
+ * an edge that fails is_an_edge_match() must never get an entry, or
+ * edge_state_hashtable would grow with every rejected edge instead of
+ * just the matched ones.
+ */
+static edge_state_entry *find_edge_state_with_hash(VLE_local_context *vlelctx,
+                                                    graphid edge_id,
+                                                    uint32 hashvalue)
+{
+    bool found = false;
+    edge_state_entry *ese;
+
+    ese = (edge_state_entry *)hash_search_with_hash_value(
+                                            vlelctx->edge_state_hashtable,
+                                            (void *)&edge_id, hashvalue,
+                                            HASH_FIND, &found);
+    if (found)
+    {
+        EDGE_STATE_ENTRY_SET_CLOCK_REF(ese);
+        return ese;
+    }
+    return NULL;
+}
+
+/*
+ * Record edge_id as a freshly-matched edge in edge_state_hashtable. Only
+ * called right after is_an_edge_match() returned true for it (see
+ * get_or_build_vertex_edge_cache() and rdist_expand_vertex()), and only
+ * when a prior find_edge_state_with_hash() call already established that
+ * no entry exists yet -- so found is expected to come back false here.
+ *
+ * found is still checked rather than assumed: if it ever does come back
+ * true (e.g. a future caller stops honoring that precondition), the
+ * existing entry -- and in particular its pin_count and used_in_path,
+ * which encode live DFS state -- must be left untouched. Overwriting them
+ * unconditionally would silently corrupt in-progress path tracking.
+ */
+static edge_state_entry *insert_matched_edge_state(VLE_local_context *vlelctx,
+                                                    graphid edge_id,
+                                                    uint32 hashvalue,
+                                                    edge_entry *ee)
+{
+    edge_state_entry *ese;
+    bool found = false;
+
+    ese = (edge_state_entry *) hash_search_with_hash_value(
+                                            vlelctx->edge_state_hashtable,
+                                            (void *) &edge_id, hashvalue,
+                                            HASH_ENTER, &found);
+    if (!found)
+    {
+        ese->edge_id = edge_id;
+        ese->state = 0;
+        ese->start_vertex_id = get_edge_entry_start_vertex_id(ee);
+        ese->end_vertex_id = get_edge_entry_end_vertex_id(ee);
+    }
+    EDGE_STATE_ENTRY_SET_CLOCK_REF(ese);
+
+    return ese;
+}
+
+/*
+ * Clock-style eviction for edge_state_hashtable, triggered once the table
+ * exceeds age.vle_edge_state_max_entries.
+ *
+ * Safety: an entry is only ever removed when BOTH pin_count == 0 (no live
+ * occurrence anywhere on dfs_edge_stack -- see the struct comment on
+ * edge_state_entry) AND it is not used_in_path. used_in_path can only be
+ * set while at least one occurrence is pinned, so the pin_count check
+ * alone is sufficient in a correctly-functioning traversal; the
+ * used_in_path check is kept as a cheap, defensive belt-and-braces
+ * condition. Every eviction is followed, on next access, by a transparent
+ * re-derivation in get_edge_state_with_hash() -- see that function's
+ * comment for why this is fully safe.
+ *
+ * A sweep evicts down to a low-water mark below the cap rather than
+ * stopping the instant it dips under it, so the table has room to absorb
+ * a batch of further insertions before the next full sweep is needed.
+ * Without this, a workload that hovers right at the cap can end up
+ * paying for a full table scan on every single insertion.
+ *
+ * At most two passes are made per call: a clock algorithm's first pass
+ * may do no more than clear the "recently used" bit on every remaining
+ * candidate (giving each one more reprieve), in which case a second pass
+ * is what actually reclaims them. A third pass could never find anything
+ * a second pass didn't already make eligible, so two is both necessary
+ * and sufficient. If two passes still leave the table above the
+ * low-water mark, everything left is pinned, and no amount of sweeping
+ * will free more -- the table is simply that busy right now.
+ *
+ * hash_seq_search() explicitly supports removing the just-returned
+ * element mid-scan (documented dynahash behavior), so HASH_REMOVE here is
+ * safe to call from inside the scan loop.
+ */
+static void evict_edge_state_entries_if_needed(VLE_local_context *vlelctx)
+{
+    long low_watermark;
+    int  pass;
+
+    if (!vle_edge_state_eviction_enabled)
+    {
+        return;
+    }
+
+    if (hash_get_num_entries(vlelctx->edge_state_hashtable) <=
+        vle_edge_state_max_entries)
+    {
+        return;
+    }
+
+    low_watermark = vle_edge_state_max_entries -
+                        (vle_edge_state_max_entries / 8);
+
+    for (pass = 0;
+         pass < 2 &&
+             hash_get_num_entries(vlelctx->edge_state_hashtable) >
+                 low_watermark;
+         pass++)
+    {
+        HASH_SEQ_STATUS status;
+        edge_state_entry *ese;
+
+        hash_seq_init(&status, vlelctx->edge_state_hashtable);
+        while ((ese = (edge_state_entry *) hash_seq_search(&status)) != NULL)
+        {
+            if (EDGE_STATE_ENTRY_PIN_COUNT(ese) > 0 || EDGE_STATE_ENTRY_USE_IN_PATH(ese))
+            {
+                /* live occurrence(s) on dfs_edge_stack -- never evict */
+                continue;
+            }
+
+            if (EDGE_STATE_ENTRY_CLOCK_REF(ese))
+            {
+                /* give it one more sweep before it becomes eligible */
+                EDGE_STATE_ENTRY_UNSET_CLOCK_REF(ese);
+                continue;
+            }
+
+            (void) hash_search_with_hash_value(vlelctx->edge_state_hashtable,
+                                               (void *) &ese->edge_id,
+                                               graphid_hash(&ese->edge_id,
+                                                            sizeof(int64)),
+                                               HASH_REMOVE, NULL);
+        }
+    }
 }
 
 /*
@@ -1260,7 +1580,7 @@ static graphid get_next_vertex(VLE_local_context *vlelctx, edge_entry *ee)
  * moves to when it takes edge `ese`, using only start_vertex_id/end_vertex_id
  * already cached on the edge_state_entry -- no edge_entry lookup required.
  *
- * Precondition: ese->has_been_matched must be true (guaranteed for any edge
+ * Precondition: ese must represent a matched edge (guaranteed for any edge
  * that ever reaches the DFS hot loop, since only matched edges are ever
  * pushed onto dfs_edge_stack -- see get_or_build_vertex_edge_cache() and the
  * push site in add_valid_vertex_edges()).
@@ -1273,7 +1593,7 @@ static graphid get_next_vertex(VLE_local_context *vlelctx, edge_entry *ee)
 static graphid get_next_vertex_from_state(VLE_local_context *vlelctx,
                                           edge_state_entry *ese)
 {
-    Assert(ese->has_been_matched);
+    Assert(ese != NULL);
 
     switch (vlelctx->edge_direction)
     {
@@ -1401,6 +1721,14 @@ static bool dfs_find_a_path_between(VLE_local_context *vlelctx)
             }
             /* now remove it from the edge stack */
             gid_stack_pop(edge_stack);
+            /*
+             * This occurrence of edge_id is done -- see the
+             * pin_count comment on edge_state_entry. Once this
+             * reaches 0 and used_in_path is clear, the entry
+             * becomes eligible for eviction.
+             */
+            Assert(EDGE_STATE_ENTRY_PIN_COUNT(ese) > 0);
+            EDGE_STATE_ENTRY_PIN_COUNT_DEC(ese);
             /*
              * Remove its source vertex, if we are looking at edges as
              * un-directional. We only maintain the vertex stack when the
@@ -1549,6 +1877,14 @@ static bool dfs_find_a_path_from(VLE_local_context *vlelctx)
             /* now remove it from the edge stack */
             gid_stack_pop(edge_stack);
             /*
+             * This occurrence of edge_id is done -- see the
+             * pin_count comment on edge_state_entry. Once this
+             * reaches 0 and used_in_path is clear, the entry
+             * becomes eligible for eviction.
+             */
+            Assert(EDGE_STATE_ENTRY_PIN_COUNT(ese) > 0);
+            EDGE_STATE_ENTRY_PIN_COUNT_DEC(ese);
+            /*
              * Remove its source vertex, if we are looking at edges as
              * un-directional. We only maintain the vertex stack when the
              * edge_direction is CYPHER_REL_DIR_NONE. This is to save space
@@ -1694,11 +2030,21 @@ static vertex_edge_cache_entry *get_or_build_vertex_edge_cache(
     int32     scratch_cap;
     MemoryContext oldcontext;
 
+    /*
+     * Keep the cache within its cap BEFORE inserting a new key, not
+     * after -- evicting after insertion would risk immediately evicting
+     * the entry we are about to build. This is a pure performance cache
+     * with no pinning constraints (see the clock_ref field comment on
+     * vertex_edge_cache_entry), so eviction here is always safe.
+     */
+    evict_vertex_edge_cache_entries_if_needed(vlelctx);
+
     vce = (vertex_edge_cache_entry *) hash_search(vlelctx->vertex_edge_cache,
                                                   &vertex_id, HASH_ENTER,
                                                   &found);
     if (found)
     {
+        vce->clock_ref = true;
         return vce;
     }
 
@@ -1744,11 +2090,14 @@ static vertex_edge_cache_entry *get_or_build_vertex_edge_cache(
     MemoryContextSwitchTo(oldcontext);
 
     /*
-     * Same 5-phase MLP-batched pipeline as before (gather/hash/lookup ee/
-     * lookup ese/apply) -- the only change is that it now runs exactly once
-     * per vertex for the lifetime of this VLE_local_context, instead of once
-     * per *visit*. The dynamic used_in_path / is_edge_in_path check is
-     * deliberately NOT done here -- see add_valid_vertex_edges() below.
+     * Walks each adjacency array exactly once for the lifetime of this
+     * VLE_local_context (not once per visit to vertex_id), in batches
+     * pipelined across five phases -- gather, hash, look up any existing
+     * classification, look up the underlying edge for anything not yet
+     * classified, then classify and collect -- so that the latency of
+     * independent hash/heap lookups within a batch can overlap. The
+     * dynamic used_in_path / is_edge_in_path check is deliberately NOT
+     * done here -- see add_valid_vertex_edges() below.
      */
     while (idx_out < sz_out || idx_in < sz_in || idx_self < sz_self)
     {
@@ -1783,64 +2132,78 @@ static vertex_edge_cache_entry *get_or_build_vertex_edge_cache(
             batch_hashes[i] = graphid_hash(&batch_eids[i], sizeof(int64));
         }
 
-        /* Phase 3: K back-to-back edge_table (agehash) lookups (MLP wave 1) */
+        /*
+         * Phase 3: K back-to-back edge_state_hashtable FIND-only lookups
+         * (MLP wave 1), checked before touching edge_table at all. A hit
+         * means this edge was already classified as a match earlier
+         * (only possible for CYPHER_REL_DIR_NONE, or overlap with the
+         * PATHS_BETWEEN reverse-BFS walk in rdist_expand_vertex() -- see
+         * that function). edge_state_hashtable only ever holds matched
+         * edges (see the struct comment on edge_state_entry), so a miss
+         * here always means "not yet classified", never "classified and
+         * rejected".
+         */
         for (i = 0; i < batch_n; i++)
         {
-            batch_ee[i] = get_edge_entry_with_hash(vlelctx->ggctx,
-                                                   batch_eids[i],
-                                                   batch_hashes[i]);
+            batch_ese[i] = find_edge_state_with_hash(vlelctx, batch_eids[i],
+                                                      batch_hashes[i]);
         }
 
-        /* Phase 4: K back-to-back edge_state_hashtable lookups (MLP wave 2) */
+        /*
+         * Phase 4: K back-to-back edge_table (agehash) lookups (MLP wave
+         * 2), but ONLY for edges Phase 3 didn't already resolve as a
+         * known match. This avoids the edge_entry lookup entirely (not
+         * just the property heap_fetch inside is_an_edge_match()) on the
+         * common repeat-visit path.
+         */
         for (i = 0; i < batch_n; i++)
         {
-            batch_ese[i] = get_edge_state_with_hash(vlelctx,
-                                                    batch_eids[i],
-                                                    batch_hashes[i]);
+            batch_ee[i] = (batch_ese[i] == NULL)
+                            ? get_edge_entry_with_hash(vlelctx->ggctx,
+                                                       batch_eids[i],
+                                                       batch_hashes[i])
+                            : NULL;
         }
 
-        /* Phase 5: classify and collect into scratch[] */
+        /* Phase 5: classify newly-seen edges and collect into scratch[] */
         for (i = 0; i < batch_n; i++)
         {
-            edge_entry       *ee  = batch_ee[i];
             edge_state_entry *ese = batch_ese[i];
 
-            if (ee == NULL)
+            if (ese == NULL)
             {
-                elog(ERROR, "get_or_build_vertex_edge_cache: no edge found");
+                edge_entry *ee = batch_ee[i];
+
+                if (ee == NULL)
+                {
+                    elog(ERROR, "get_or_build_vertex_edge_cache: no edge found");
+                }
+
+                if (!is_an_edge_match(vlelctx, ee))
+                {
+                    /*
+                     * Not a match: no edge_state_entry is created for
+                     * it. edge_state_hashtable's size is thus bounded by
+                     * the number of matched edges ever seen, not by
+                     * every edge ever scanned -- the dominant factor on
+                     * a low-selectivity VLE predicate over a dense or
+                     * hub-heavy graph. The cost is that a rejected edge
+                     * encountered a second time (undirected traversal,
+                     * or overlap with the PATHS_BETWEEN reverse-BFS
+                     * walk) is re-classified rather than remembered.
+                     */
+                    continue;
+                }
+
+                ese = insert_matched_edge_state(vlelctx, batch_eids[i],
+                                                batch_hashes[i], ee);
             }
 
-            /*
-             * has_been_matched may already be true here -- this edge could
-             * have been classified earlier via its OTHER endpoint (only
-             * possible for CYPHER_REL_DIR_NONE, where the same edge appears
-             * in both endpoints' adjacency arrays). is_an_edge_match()'s
-             * result depends only on the edge's own label/properties and
-             * this grammar node's constraints -- never on which endpoint
-             * triggered classification -- so it is safe to reuse. Only
-             * classify (and cache start/end) the first time, ever.
-             */
-            if (!EDGE_STATE_ENTRY_HAS_BEEN_MATCHED(ese))
-            {
-                EDGE_STATE_ENTRY_SET_HAS_BEEN_MATCHED(ese);
-                if (is_an_edge_match(vlelctx, ee))
-                {
-                    EDGE_STATE_ENTRY_SET_MATCHED(ese);
-                }
-                else
-                {
-                    EDGE_STATE_ENTRY_UNSET_MATCHED(ese);
-                }
-                ese->start_vertex_id = get_edge_entry_start_vertex_id(ee);
-                ese->end_vertex_id = get_edge_entry_end_vertex_id(ee);
-            }
-
-            if (EDGE_STATE_ENTRY_MATCHED(ese))
-            {
-                scratch[nscratch++] = batch_eids[i];
-            }
+            scratch[nscratch++] = batch_eids[i];
         }
     }
+
+    evict_edge_state_entries_if_needed(vlelctx);
 
     /*
      * Shrink to the actual number of statically-valid edges. scratch_cap is
@@ -1868,8 +2231,78 @@ static vertex_edge_cache_entry *get_or_build_vertex_edge_cache(
     vce->vertex_id = vertex_id;
     vce->nvalid = nscratch;
     vce->valid_edges = scratch;
+    vce->clock_ref = true;
 
     return vce;
+}
+
+/*
+ * Clock-style eviction for vertex_edge_cache, triggered once the table
+ * exceeds age.vle_vertex_edge_cache_max_entries, or the memory actually
+ * backing its cached adjacency arrays exceeds age.vle_vertex_edge_cache_max_kb
+ * -- an entry-count cap alone under-protects against a small number of
+ * high-degree (hub) vertices, each with a disproportionately large
+ * valid_edges[] array.
+ *
+ * No pinning is needed here (unlike edge_state_hashtable): the
+ * vertex_edge_cache_entry pointer returned by get_or_build_vertex_edge_cache()
+ * is only ever used synchronously, within a single call to
+ * add_valid_vertex_edges(), and never retained past it -- so any entry can
+ * be evicted (and its valid_edges[] array freed) at any time between
+ * calls. A revisited vertex simply gets its cache rebuilt from the
+ * underlying adjacency arrays, which is deterministic and correct, just
+ * not free -- exactly the ordinary LRU-cache-miss cost/memory trade-off.
+ *
+ * See evict_edge_state_entries_if_needed() for why eviction targets a
+ * low-water mark below the cap, and why two passes are both necessary and
+ * sufficient for a clock sweep.
+ */
+static void evict_vertex_edge_cache_entries_if_needed(VLE_local_context *vlelctx)
+{
+    long   low_watermark;
+    Size   max_bytes = (Size) vle_vertex_edge_cache_max_kb * 1024;
+    int    pass;
+
+    if (hash_get_num_entries(vlelctx->vertex_edge_cache) <=
+            vle_vertex_edge_cache_max_entries &&
+        MemoryContextMemAllocated(vlelctx->vertex_edge_cache_mcxt, false) <=
+            max_bytes)
+    {
+        return;
+    }
+
+    low_watermark = vle_vertex_edge_cache_max_entries -
+                        (vle_vertex_edge_cache_max_entries / 8);
+
+    for (pass = 0;
+         pass < 2 &&
+             (hash_get_num_entries(vlelctx->vertex_edge_cache) >
+                  low_watermark ||
+              MemoryContextMemAllocated(vlelctx->vertex_edge_cache_mcxt,
+                                        false) > max_bytes - (max_bytes / 8));
+         pass++)
+    {
+        HASH_SEQ_STATUS status;
+        vertex_edge_cache_entry *vce;
+
+        hash_seq_init(&status, vlelctx->vertex_edge_cache);
+        while ((vce = (vertex_edge_cache_entry *) hash_seq_search(&status)) != NULL)
+        {
+            if (vce->clock_ref)
+            {
+                vce->clock_ref = false;
+                continue;
+            }
+
+            if (vce->valid_edges != NULL)
+            {
+                pfree(vce->valid_edges);
+            }
+
+            (void) hash_search(vlelctx->vertex_edge_cache, &vce->vertex_id,
+                               HASH_REMOVE, NULL);
+        }
+    }
 }
 
 /* ------------------------------------------------------------------------
@@ -2138,6 +2571,7 @@ static void reset_reverse_dist_state_if_needed(VLE_local_context *vlelctx)
     vlelctx->reverse_dist_initialized = true;
     vlelctx->reverse_dist_target = vlelctx->veid;
     vlelctx->reverse_dist_exhausted = false;
+    vlelctx->reverse_dist_capped = false;
     rdist_queue_reset(vlelctx, &vlelctx->reverse_dist_queue);
     rdist_queue_push(vlelctx, &vlelctx->reverse_dist_queue, vlelctx->veid);
     set_reverse_dist(vlelctx, vlelctx->veid, 0);
@@ -2228,49 +2662,46 @@ static void rdist_expand_vertex(VLE_local_context *vlelctx, graphid u,
             batch_hashes[i] = graphid_hash(&batch_eids[i], sizeof(int64));
         }
 
+        /* Phase: FIND-only edge_state lookup first -- see the identical
+         * pattern (and rationale) in get_or_build_vertex_edge_cache(). */
         for (i = 0; i < batch_n; i++)
         {
-            batch_ee[i] = get_edge_entry_with_hash(vlelctx->ggctx,
-                                                   batch_eids[i],
-                                                   batch_hashes[i]);
+            batch_ese[i] = find_edge_state_with_hash(vlelctx, batch_eids[i],
+                                                      batch_hashes[i]);
         }
 
         for (i = 0; i < batch_n; i++)
         {
-            batch_ese[i] = get_edge_state_with_hash(vlelctx, batch_eids[i],
-                                                    batch_hashes[i]);
+            batch_ee[i] = (batch_ese[i] == NULL)
+                            ? get_edge_entry_with_hash(vlelctx->ggctx,
+                                                       batch_eids[i],
+                                                       batch_hashes[i])
+                            : NULL;
         }
 
         for (i = 0; i < batch_n; i++)
         {
-            edge_entry       *ee  = batch_ee[i];
             edge_state_entry *ese = batch_ese[i];
             graphid p;
             int64 unused_dist;
+            int64 new_dist;
 
-            if (ee == NULL)
+            if (ese == NULL)
             {
-                elog(ERROR, "rdist_expand_vertex: no edge found");
-            }
+                edge_entry *ee = batch_ee[i];
 
-            if (!EDGE_STATE_ENTRY_HAS_BEEN_MATCHED(ese))
-            {
-                EDGE_STATE_ENTRY_SET_HAS_BEEN_MATCHED(ese);
-                if (is_an_edge_match(vlelctx, ee))
+                if (ee == NULL)
                 {
-                    EDGE_STATE_ENTRY_SET_MATCHED(ese);
+                    elog(ERROR, "rdist_expand_vertex: no edge found");
                 }
-                else
-                {
-                    EDGE_STATE_ENTRY_UNSET_MATCHED(ese);
-                }
-                ese->start_vertex_id = get_edge_entry_start_vertex_id(ee);
-                ese->end_vertex_id = get_edge_entry_end_vertex_id(ee);
-            }
 
-            if (!EDGE_STATE_ENTRY_MATCHED(ese))
-            {
-                continue;
+                if (!is_an_edge_match(vlelctx, ee))
+                {
+                    continue;
+                }
+
+                ese = insert_matched_edge_state(vlelctx, batch_eids[i],
+                                                batch_hashes[i], ee);
             }
 
             switch (flipped_dir)
@@ -2294,20 +2725,68 @@ static void rdist_expand_vertex(VLE_local_context *vlelctx, graphid u,
                 continue;
             }
 
-            set_reverse_dist(vlelctx, p, du + 1);
+            new_dist = du + 1;
+
+            /*
+             * A reverse distance of exactly uidx or more can never help
+             * add_valid_vertex_edges() prune a candidate: that check is
+             *   depth_so_far + 1 + dnext > uidx
+             * and for dnext == uidx this reduces to depth_so_far + 1 > 0,
+             * which holds for every depth_so_far >= 0. Such a distance
+             * therefore behaves exactly like the "unreachable"
+             * PG_INT64_MAX sentinel for pruning purposes, and is not worth
+             * a reverse_dist_table entry -- typically the single widest
+             * layer of the reverse BFS. Only applies when uidx is finite.
+             */
+            if (!vlelctx->uidx_infinite && new_dist >= vlelctx->uidx)
+            {
+                continue;
+            }
+
+            /*
+             * The reverse-BFS distance table is a pruning heuristic, not
+             * a source of truth: an entry missing from it is read by
+             * get_or_advance_reverse_dist() as "prune this candidate",
+             * so it must never be capped by simply refusing to insert
+             * without also recording that the search stopped early.
+             * age.vle_reverse_dist_max_entries bounds it by degrading the
+             * reverse BFS to a fail-open state instead: once reached, no
+             * further frontier vertices are admitted, and unresolved
+             * vertices are treated by get_or_advance_reverse_dist() as
+             * "not provably prunable" rather than "unreachable" -- see
+             * reverse_dist_capped's field comment.
+             */
+            if (hash_get_num_entries(vlelctx->reverse_dist_table) >=
+                vle_reverse_dist_max_entries)
+            {
+                vlelctx->reverse_dist_capped = true;
+                continue;
+            }
+
+            set_reverse_dist(vlelctx, p, new_dist);
             rdist_queue_push(vlelctx, &vlelctx->reverse_dist_queue, p);
         }
     }
+
+    evict_edge_state_entries_if_needed(vlelctx);
 }
 
 /*
- * Return w's reverse distance to veid, advancing the lazy BFS frontier as
- * far as necessary (and no farther) to answer this specific query.
+ * Resolve w's distance from veid along the flipped-direction adjacency,
+ * advancing the lazy reverse BFS only as far as necessary to answer this
+ * specific query.
  *
- * Returns PG_INT64_MAX for "not reachable within the current target's
- * scope" -- either truly unreachable, or reachable only beyond the uidx
- * budget, which is equally useless for pruning purposes and is why both
- * cases are folded into the same sentinel rather than distinguished.
+ * The reverse BFS is a pruning heuristic for VLE_FUNCTION_PATHS_BETWEEN:
+ * add_valid_vertex_edges() discards a candidate edge once it can prove
+ * the remaining budget can no longer reach veid. Proving unreachability
+ * requires having actually exhausted the search (reverse_dist_exhausted);
+ * merely stopping early to respect age.vle_reverse_dist_max_entries
+ * (reverse_dist_capped) proves nothing, so the two must not be treated
+ * alike. Returning PG_INT64_MAX in the capped-but-not-exhausted case
+ * would make a memory limit silently discard valid paths, so this
+ * function instead fails open: a distance of 0 for an unresolved vertex
+ * never triggers pruning by itself (see add_valid_vertex_edges()), it
+ * just forfeits the pruning benefit for that particular candidate.
  */
 static int64 get_or_advance_reverse_dist(VLE_local_context *vlelctx, graphid w)
 {
@@ -2323,6 +2802,11 @@ static int64 get_or_advance_reverse_dist(VLE_local_context *vlelctx, graphid w)
         return PG_INT64_MAX;
     }
 
+    if (vlelctx->reverse_dist_capped)
+    {
+        return 0;
+    }
+
     while (!rdist_queue_is_empty(&vlelctx->reverse_dist_queue))
     {
         graphid u = rdist_queue_pop(&vlelctx->reverse_dist_queue);
@@ -2335,11 +2819,14 @@ static int64 get_or_advance_reverse_dist(VLE_local_context *vlelctx, graphid w)
         }
 
         /*
-         * BFS pop order is non-decreasing in depth: once we've popped one
-         * vertex at or past the budget, every vertex still queued is at
-         * least as deep, so none of them can help either.
+         * BFS pop order is non-decreasing in depth. Every neighbour of u
+         * would land at du + 1, and rdist_expand_vertex() already refuses
+         * to record any distance >= uidx as useless for pruning -- so
+         * once du + 1 >= uidx, expanding u (and everything still queued
+         * behind it) cannot add anything, and there is no point walking
+         * its adjacency at all.
          */
-        if (!vlelctx->uidx_infinite && du >= vlelctx->uidx)
+        if (!vlelctx->uidx_infinite && du + 1 >= vlelctx->uidx)
         {
             break;
         }
@@ -2350,6 +2837,18 @@ static int64 get_or_advance_reverse_dist(VLE_local_context *vlelctx, graphid w)
         if (try_get_reverse_dist(vlelctx, w, &dist))
         {
             return dist;
+        }
+
+        if (vlelctx->reverse_dist_capped)
+        {
+            /*
+             * The cap was already reached (permanently, for this target
+             * -- reverse_dist_table never shrinks below it once hit, see
+             * rdist_expand_vertex()), so continuing to pop and expand the
+             * rest of the queue would just repeat the same no-op cap
+             * check for every remaining candidate.
+             */
+            return 0;
         }
     }
 
@@ -2513,6 +3012,16 @@ static void add_valid_vertex_edges(VLE_local_context *vlelctx,
                 gid_stack_push(vertex_stack, vertex_id);
             }
             gid_stack_push(edge_stack, edge_id);
+            /*
+             * This edge_id now has a live, unpopped occurrence on
+             * dfs_edge_stack. pin_count protects its edge_state_entry
+             * from eviction until every such occurrence is popped again
+             * (see the struct comment on edge_state_entry) -- vertices
+             * can be revisited, so the SAME edge_id can end up pushed
+             * more than once while an older copy is still buried deeper
+             * in the stack.
+             */
+            EDGE_STATE_ENTRY_PIN_COUNT_INC(ese);
             Assert(vlelctx->edge_direction != CYPHER_REL_DIR_NONE ||
                    gid_stack_size(vertex_stack) == gid_stack_size(edge_stack));
         }

--- a/src/backend/utils/adt/age_vle.c
+++ b/src/backend/utils/adt/age_vle.c
@@ -88,31 +88,11 @@
 typedef struct edge_state_entry
 {
     graphid edge_id;               /* edge id, it is also the hash key */
+    graphid start_vertex_id;       /* Topology cache for edge endpoints; */
+    graphid end_vertex_id;         /* used for direction resolution in DFS. */
     bool used_in_path;             /* like visited but more descriptive */
     bool has_been_matched;         /* have we checked for a  match */
     bool matched;                  /* is it a match */
-    /*
-     * Topology cache, populated once (alongside has_been_matched/matched)
-     * the first time this edge is classified in get_or_build_vertex_edge_cache().
-     * Both endpoints are cached -- NOT a single pre-resolved "next vertex" --
-     * because for CYPHER_REL_DIR_NONE the correct next vertex depends on
-     * which endpoint the DFS is currently standing on, which can differ
-     * between the first time an edge is classified and a later, unrelated
-     * point in the same traversal where it is approached from the other
-     * side. See get_next_vertex_from_state() for the direction-resolution
-     * logic, which mirrors get_next_vertex() but reads from this cache
-     * instead of re-fetching the edge_entry.
-     *
-     * Valid if and only if has_been_matched is true. Zeroed (not left
-     * uninitialized) on a fresh entry in get_edge_state_with_hash(): they
-     * are only ever read once has_been_matched is true (asserted in
-     * get_next_vertex_from_state() for cassert builds), but zeroing means
-     * any accidental early read in a production build resolves to graphid
-     * 0 -- which cannot be a real vertex id -- instead of uninitialized
-     * palloc'd memory.
-     */
-    graphid start_vertex_id;
-    graphid end_vertex_id;
 } edge_state_entry;
 
 /*

--- a/src/backend/utils/adt/age_vle.c
+++ b/src/backend/utils/adt/age_vle.c
@@ -138,6 +138,30 @@ typedef struct vertex_edge_cache_entry
 } vertex_edge_cache_entry;
 
 /*
+ * Resumable FIFO frontier queue for the lazy reverse-BFS in
+ * get_or_advance_reverse_dist().
+ */
+typedef struct rdist_queue
+{
+    graphid *data;
+    int64 head;
+    int64 tail;
+    int64 cap;  /* power of two */
+    int64 count;
+    int64 max_count;
+} rdist_queue;
+
+/*
+ * Entry in vlelctx->reverse_dist_table: vertex_id -> its reverse-BFS
+ * distance to vlelctx->veid, for the CURRENT target only.
+ */
+typedef struct reverse_dist_entry
+{
+    graphid vertex_id;              /* hash key */
+    int64 dist;
+} reverse_dist_entry;
+
+/*
  * VLE_path_function is an enum for the path function to use. This currently can
  * be one of two possibilities - where the target vertex is provided and where
  * it isn't.
@@ -171,30 +195,26 @@ typedef struct VLE_local_context
     HTAB *edge_state_hashtable;    /* local state hashtable for our edges */
     HTAB *vertex_edge_cache;       /* vertex_id -> statically-valid adjacent
                                      * edges (see get_or_build_vertex_edge_cache) */
-    MemoryContext vertex_edge_cache_mcxt; /* Dedicated child context, created
-                                     * explicitly in
-                                     * create_VLE_local_state_hashtable() and
-                                     * deleted explicitly in
-                                     * free_VLE_local_context(). Owns every
-                                     * valid_edges[] array pointed to from
-                                     * vertex_edge_cache entries above.
-                                     *
-                                     * Deliberately NOT "whatever
-                                     * CurrentMemoryContext happens to be" --
-                                     * this context is created once, up
-                                     * front, specifically for this purpose,
-                                     * so its lifetime does not depend on
-                                     * which of this file's several call
-                                     * sites is building this
-                                     * VLE_local_context (the LRU-cached
-                                     * TopMemoryContext path, the uncached
-                                     * multi_call_memory_ctx SRF path, or
-                                     * sp_minhops_fallback()'s private
-                                     * scratch context all do the right
-                                     * thing automatically, because we just
-                                     * parent off whatever CurrentMemoryContext
-                                     * is *once*, at creation, and then own
-                                     * deletion of our own child ourselves). */
+    MemoryContext vertex_edge_cache_mcxt; /* Child context for valid_edges[]; managed explicitly. */
+
+    /*
+     * Lazy reverse-BFS state for VLE_FUNCTION_PATHS_BETWEEN pruning.
+     *
+     * This state is target-specific: reverse_dist_table is valid only
+     * for the current veid and is rebuilt when veid changes.  It is
+     * deliberately separate from vertex_edge_cache, whose entries are
+     * valid for the whole VLE_local_context.
+     */
+    HTAB *reverse_dist_table;       /* vertex_id -> reverse_dist_entry,
+                                      * valid only for the current veid */
+    MemoryContext reverse_dist_mcxt; /* owns reverse_dist_table and
+                                      * reverse_dist_queue.data */
+    bool reverse_dist_initialized;  /* true after reverse_dist_table has
+                                      * been created for this vlelctx */
+    graphid reverse_dist_target;    /* veid for reverse_dist_table */
+    bool reverse_dist_exhausted;    /* true once the reverse-BFS frontier
+                                      * is drained or past the uidx budget */
+    rdist_queue reverse_dist_queue; /* reverse-BFS frontier */
     GraphIdStack *dfs_vertex_stack; /* dfs stack for vertices (array-based) */
     GraphIdStack *dfs_edge_stack;   /* dfs stack for edges (array-based) */
     GraphIdStack *dfs_path_stack;   /* dfs stack containing the path (array-based) */
@@ -284,6 +304,22 @@ static vertex_edge_cache_entry *get_or_build_vertex_edge_cache(
                                                     VLE_local_context *vlelctx,
                                                     graphid vertex_id);
 static bool is_edge_in_path(VLE_local_context *vlelctx, graphid edge_id);
+/* reverse-BFS pruning for VLE_FUNCTION_PATHS_BETWEEN (see add_valid_vertex_edges) */
+static cypher_rel_dir flip_edge_direction(cypher_rel_dir dir);
+static void reset_reverse_dist_state_if_needed(VLE_local_context *vlelctx);
+static void set_reverse_dist(VLE_local_context *vlelctx, graphid vertex_id,
+                             int64 dist);
+static bool try_get_reverse_dist(VLE_local_context *vlelctx, graphid vertex_id,
+                                 int64 *dist);
+static void rdist_expand_vertex(VLE_local_context *vlelctx, graphid u,
+                                int64 du, cypher_rel_dir flipped_dir);
+static int64 get_or_advance_reverse_dist(VLE_local_context *vlelctx,
+                                         graphid w);
+static void rdist_queue_push(VLE_local_context *vlelctx, rdist_queue *q,
+                             graphid v);
+static graphid rdist_queue_pop(rdist_queue *q);
+static bool rdist_queue_is_empty(rdist_queue *q);
+static void rdist_queue_reset(VLE_local_context *vlelctx, rdist_queue *q);
 /* VLE path and edge building functions */
 static VLE_path_container *create_VLE_path_container(int64 path_size);
 static VLE_path_container *build_VLE_path_container(VLE_local_context *vlelctx);
@@ -516,6 +552,14 @@ static void create_VLE_local_state_hashtable(VLE_local_context *vlelctx)
                                                  &vertex_edge_ctl,
                                                  HASH_ELEM | HASH_FUNCTION);
     }
+
+    /*
+     * Dedicated context for reverse-BFS pruning state.  The table itself
+     * is created lazily because only PATHS_BETWEEN uses it.
+     */
+    vlelctx->reverse_dist_mcxt = AllocSetContextCreate(CurrentMemoryContext,
+                                                       "VLE reverse distance",
+                                                       ALLOCSET_DEFAULT_SIZES);
 }
 
 /*
@@ -701,6 +745,27 @@ static void free_VLE_local_context(VLE_local_context *vlelctx)
     }
 
     /*
+     * Free the reverse-BFS pruning state.  The dedicated context owns
+     * both the distance table storage and the queue data.
+     */
+    if (vlelctx->reverse_dist_table != NULL)
+    {
+        hash_destroy(vlelctx->reverse_dist_table);
+        vlelctx->reverse_dist_table = NULL;
+    }
+    if (vlelctx->reverse_dist_mcxt != NULL)
+    {
+        MemoryContextDelete(vlelctx->reverse_dist_mcxt);
+        vlelctx->reverse_dist_mcxt = NULL;
+    }
+    vlelctx->reverse_dist_queue.data = NULL;
+    vlelctx->reverse_dist_queue.head = 0;
+    vlelctx->reverse_dist_queue.tail = 0;
+    vlelctx->reverse_dist_queue.cap = 0;
+    vlelctx->reverse_dist_queue.count = 0;
+    vlelctx->reverse_dist_queue.max_count = 0;
+
+    /*
      * Free the DFS stacks. When is_dirty is false, the stacks are in the
      * current context and need explicit cleanup. When is_dirty is true
      * (cached context), only free the containers — the contents were
@@ -759,6 +824,12 @@ static void load_initial_dfs_stacks(VLE_local_context *vlelctx)
     {
         return;
     }
+
+    /*
+    * Every fresh traversal passes through here, so this is the correct
+    * place to reset reverse-BFS pruning state if the target changed.
+    */
+    reset_reverse_dist_state_if_needed(vlelctx);
 
     /* add in the edges for the start vertex */
     add_valid_vertex_edges(vlelctx, vlelctx->vsid);
@@ -1796,6 +1867,484 @@ static vertex_edge_cache_entry *get_or_build_vertex_edge_cache(
     return vce;
 }
 
+/* ------------------------------------------------------------------------
+ * Reverse-BFS-from-veid pruning, for VLE_FUNCTION_PATHS_BETWEEN only.
+ *
+ * Only PATHS_BETWEEN has a concrete target vertex, so it's the only mode
+ * where "will this branch ever reach the target within the remaining hop
+ * budget" is even a meaningful question. Nothing below is invoked from
+ * dfs_find_a_path_from()'s path -- see the path_function guard in
+ * add_valid_vertex_edges().
+ *
+ * Correctness rests on one fact: let d(v) be the shortest-path distance
+ * from v to veid over the FULL matched-edge-filtered graph, ignoring which
+ * edges the current DFS path has already used. Then d(v) is always <= the
+ * true remaining distance once already-used edges are excluded (removing
+ * edges can only lengthen or preserve a shortest path, never shorten it).
+ * So "depth_so_far + 1 + d(next) > uidx" is a SAFE pruning condition -- it
+ * never discards a real valid path -- even though it is not a complete
+ * dead-end detector (a path can still turn out to be blocked later by an
+ * edge already in use; the ordinary used_in_path check catches that case
+ * the normal way, just possibly a little later). This is exactly why it
+ * would be UNSOUND to instead memoize "v is a dead end" keyed on which
+ * edges are currently used_in_path: that quantity is path-state-dependent
+ * and cannot be safely reused across different branches of the same DFS.
+ * d(v) as defined here has no such dependency, which is what makes
+ * memoizing it permanently, and reusing it anywhere in the traversal, safe.
+ *
+ * IMPORTANT INVARIANT: none of these functions return a raw
+ * reverse_dist_entry pointer to their caller.  set_reverse_dist() and
+ * try_get_reverse_dist() copy the scalar distance in or out and keep
+ * the entry pointer local.  This keeps the code safe if the hashtable
+ * implementation ever moves entries on insert or growth.
+ * ------------------------------------------------------------------------
+ */
+
+/*
+ * "Reverse BFS from veid under direction D" == "forward BFS from veid under
+ * flip(D)". CYPHER_REL_DIR_LEFT's forward step already walks a vertex's
+ * in-array and lands on the edge's start -- i.e. it already walks backwards
+ * along the edge -- which is exactly the predecessor-step reverse-BFS needs
+ * for a RIGHT-oriented query, and symmetrically the other way around.
+ * CYPHER_REL_DIR_NONE is self-symmetric (undirected).
+ */
+static cypher_rel_dir flip_edge_direction(cypher_rel_dir dir)
+{
+    switch (dir)
+    {
+        case CYPHER_REL_DIR_RIGHT:
+            return CYPHER_REL_DIR_LEFT;
+        case CYPHER_REL_DIR_LEFT:
+            return CYPHER_REL_DIR_RIGHT;
+        case CYPHER_REL_DIR_NONE:
+        default:
+            return CYPHER_REL_DIR_NONE;
+    }
+}
+
+/*
+ * Minimum size for the reverse-BFS queue.  The queue is not shrunk
+ * below this value, to avoid reallocating for small targets.
+ */
+#define RDIST_QUEUE_MIN_CAP 256
+
+/* Initial size for the reverse-distance hash table. */
+#define RDIST_TABLE_MIN_SIZE 256
+
+static void rdist_queue_grow(VLE_local_context *vlelctx, rdist_queue *q)
+{
+    MemoryContext oldcontext;
+    int64 oldcap = q->cap;
+    int64 newcap;
+    graphid *newdata;
+
+    Assert(q->cap == 0 || q->count == q->cap);
+
+    newcap = (oldcap == 0) ? RDIST_QUEUE_MIN_CAP : oldcap * 2;
+
+    oldcontext = MemoryContextSwitchTo(vlelctx->reverse_dist_mcxt);
+    newdata = (graphid *) palloc(sizeof(graphid) * newcap);
+
+    if (q->data != NULL && q->count > 0)
+    {
+        int64 i;
+
+        /*
+         * Copy active elements in FIFO order. This happens only on grow,
+         * not on ordinary push/pop.
+         */
+        for (i = 0; i < q->count; i++)
+        {
+            newdata[i] = q->data[(q->head + i) & (oldcap - 1)];
+        }
+    }
+
+    if (q->data != NULL)
+    {
+        pfree(q->data);
+    }
+
+    MemoryContextSwitchTo(oldcontext);
+
+    q->data = newdata;
+    q->cap = newcap;
+    q->head = 0;
+    q->tail = q->count;
+}
+
+static void rdist_queue_push(VLE_local_context *vlelctx, rdist_queue *q,
+                             graphid v)
+{
+    if (q->cap == 0 || q->count == q->cap)
+    {
+        rdist_queue_grow(vlelctx, q);
+    }
+
+    q->data[q->tail] = v;
+    q->tail = (q->tail + 1) & (q->cap - 1);
+    q->count++;
+
+    if (q->count > q->max_count)
+    {
+        q->max_count = q->count;
+    }
+}
+
+static bool rdist_queue_is_empty(rdist_queue *q)
+{
+    return q->count == 0;
+}
+
+static graphid rdist_queue_pop(rdist_queue *q)
+{
+    graphid v;
+
+    Assert(q->count > 0);
+
+    v = q->data[q->head];
+    q->head = (q->head + 1) & (q->cap - 1);
+    q->count--;
+
+    return v;
+}
+
+/*
+ * Rewind to an empty queue for a new generation (new veid). If the
+ * PREVIOUS generation used far less of the array than its current capacity
+ * -- e.g. one huge query on a dense graph, followed on a cached vlelctx by
+ * many small ones on unrelated later queries -- shrink the backing array
+ * back down instead of holding the peak-ever size for the rest of this
+ * vlelctx's lifetime. Hysteresis (4x threshold + a floor) avoids
+ * reallocating on every single reset for queries of similar size run
+ * back-to-back.
+ */
+static void rdist_queue_reset(VLE_local_context *vlelctx, rdist_queue *q)
+{
+    int64 peak = q->max_count;
+
+    /*
+     * Shrink if the previous generation's peak frontier was much smaller
+     * than the current capacity. Keep a minimum size to avoid reallocating
+     * for small/typical queries.
+     */
+    if (q->data != NULL && q->cap > RDIST_QUEUE_MIN_CAP &&
+        peak < q->cap / 4)
+    {
+        MemoryContext oldcontext;
+        int64 newcap = RDIST_QUEUE_MIN_CAP;
+        int64 want = peak * 2;
+
+        while (newcap < want)
+        {
+            newcap <<= 1;
+        }
+
+        oldcontext = MemoryContextSwitchTo(vlelctx->reverse_dist_mcxt);
+        pfree(q->data);
+        q->data = (graphid *) palloc(sizeof(graphid) * newcap);
+        MemoryContextSwitchTo(oldcontext);
+
+        q->cap = newcap;
+    }
+
+    q->head = 0;
+    q->tail = 0;
+    q->count = 0;
+    q->max_count = 0;
+}
+
+/*
+ * Store dist as vertex_id's reverse distance. Never returns the entry
+ * pointer to the caller -- see the invariant in the block comment above.
+ */
+static void set_reverse_dist(VLE_local_context *vlelctx, graphid vertex_id,
+                             int64 dist)
+{
+    reverse_dist_entry *rde;
+    bool found;
+
+    rde = (reverse_dist_entry *) hash_search(vlelctx->reverse_dist_table,
+                                             &vertex_id, HASH_ENTER, &found);
+    rde->vertex_id = vertex_id;
+    rde->dist = dist;
+}
+
+/*
+ * Read-only: true and *dist set iff vertex_id's reverse distance is
+ * already known for the CURRENT target. A vertex the reverse BFS has never
+ * reached simply isn't known, which is a very different thing from "known
+ * to be unreachable" -- see reverse_dist_exhausted in
+ * get_or_advance_reverse_dist(). Never returns the entry pointer to the
+ * caller -- see the invariant in the block comment above.
+ */
+static bool try_get_reverse_dist(VLE_local_context *vlelctx, graphid vertex_id,
+                                 int64 *dist)
+{
+    reverse_dist_entry *rde;
+    bool found;
+
+    rde = (reverse_dist_entry *) hash_search(vlelctx->reverse_dist_table,
+                                             &vertex_id, HASH_FIND, &found);
+    if (found)
+    {
+        *dist = rde->dist;
+        return true;
+    }
+    return false;
+}
+
+/*
+ * Rebuild reverse_dist_table and the BFS queue if the target vertex
+ * changed.  Other path functions have no fixed target, so they do not
+ * use this state.
+ */
+static void reset_reverse_dist_state_if_needed(VLE_local_context *vlelctx)
+{
+    if (vlelctx->path_function != VLE_FUNCTION_PATHS_BETWEEN)
+    {
+        return;
+    }
+
+    if (vlelctx->reverse_dist_initialized &&
+        vlelctx->reverse_dist_target == vlelctx->veid)
+    {
+        return;
+    }
+
+    if (vlelctx->reverse_dist_table != NULL)
+    {
+        hash_destroy(vlelctx->reverse_dist_table);
+    }
+    {
+        HASHCTL ctl;
+        MemoryContext oldcontext;
+
+        oldcontext = MemoryContextSwitchTo(vlelctx->reverse_dist_mcxt);
+        MemSet(&ctl, 0, sizeof(ctl));
+        ctl.keysize = sizeof(int64);
+        ctl.entrysize = sizeof(reverse_dist_entry);
+        ctl.hash = graphid_hash;
+        vlelctx->reverse_dist_table = hash_create("VLE reverse distance",
+                                                  RDIST_TABLE_MIN_SIZE, &ctl,
+                                                  HASH_ELEM | HASH_FUNCTION);
+        MemoryContextSwitchTo(oldcontext);
+    }
+
+    vlelctx->reverse_dist_initialized = true;
+    vlelctx->reverse_dist_target = vlelctx->veid;
+    vlelctx->reverse_dist_exhausted = false;
+    rdist_queue_reset(vlelctx, &vlelctx->reverse_dist_queue);
+    rdist_queue_push(vlelctx, &vlelctx->reverse_dist_queue, vlelctx->veid);
+    set_reverse_dist(vlelctx, vlelctx->veid, 0);
+}
+
+/*
+ * Expand frontier vertex u (currently known to be at reverse-distance du
+ * from veid): walk u's flipped-direction adjacency, classify each edge
+ * through the SAME edge_state_hashtable that get_or_build_vertex_edge_cache()
+ * and add_valid_vertex_edges() use (an edge classified by either the
+ * forward vertex_edge_cache build or this reverse walk is never
+ * reclassified by the other -- is_an_edge_match()'s result depends only on
+ * the edge itself, never on which side or direction discovered it first),
+ * and push any newly-discovered predecessor at distance du+1.
+ *
+ * Deliberately does NOT go through get_or_build_vertex_edge_cache() -- that
+ * would classify u's FORWARD-direction adjacency (wrong direction for this
+ * walk) and would force the expensive classification work for vertices
+ * that may turn out to be pruned and never actually visited by the forward
+ * DFS. This function does its own adjacency walk, in the flipped direction.
+ */
+static void rdist_expand_vertex(VLE_local_context *vlelctx, graphid u,
+                                int64 du, cypher_rel_dir flipped_dir)
+{
+    vertex_entry *ve = NULL;
+    graphid *arr_out = NULL;
+    int32    sz_out = 0;
+    int32    idx_out = 0;
+    graphid *arr_in = NULL;
+    int32    sz_in = 0;
+    int32    idx_in = 0;
+    graphid *arr_self = NULL;
+    int32    sz_self = 0;
+    int32    idx_self = 0;
+    VertexEdgeArray *vea = NULL;
+
+    ve = get_vertex_entry(vlelctx->ggctx, u);
+    if (ve == NULL)
+    {
+        /* defensive only -- u was reached via a real, already-classified edge */
+        return;
+    }
+
+    if (flipped_dir == CYPHER_REL_DIR_RIGHT || flipped_dir == CYPHER_REL_DIR_NONE)
+    {
+        vea = get_vertex_entry_edges_out_array(ve);
+        arr_out = vea->array;
+        sz_out  = vea->size;
+    }
+    if (flipped_dir == CYPHER_REL_DIR_LEFT || flipped_dir == CYPHER_REL_DIR_NONE)
+    {
+        vea = get_vertex_entry_edges_in_array(ve);
+        arr_in = vea->array;
+        sz_in  = vea->size;
+    }
+    vea = get_vertex_entry_edges_self_array(ve);
+    arr_self = vea->array;
+    sz_self  = vea->size;
+
+    while (idx_out < sz_out || idx_in < sz_in || idx_self < sz_self)
+    {
+        graphid           batch_eids[VLE_LOOKUP_BATCH];
+        uint32            batch_hashes[VLE_LOOKUP_BATCH];
+        edge_entry       *batch_ee[VLE_LOOKUP_BATCH];
+        edge_state_entry *batch_ese[VLE_LOOKUP_BATCH];
+        int batch_n = 0;
+        int i;
+
+        while (batch_n < VLE_LOOKUP_BATCH &&
+               (idx_out < sz_out || idx_in < sz_in || idx_self < sz_self))
+        {
+            if (idx_out < sz_out)
+            {
+                batch_eids[batch_n++] = arr_out[idx_out++];
+            }
+            else if (idx_in < sz_in)
+            {
+                batch_eids[batch_n++] = arr_in[idx_in++];
+            }
+            else
+            {
+                batch_eids[batch_n++] = arr_self[idx_self++];
+            }
+        }
+
+        for (i = 0; i < batch_n; i++)
+        {
+            batch_hashes[i] = graphid_hash(&batch_eids[i], sizeof(int64));
+        }
+
+        for (i = 0; i < batch_n; i++)
+        {
+            batch_ee[i] = get_edge_entry_with_hash(vlelctx->ggctx,
+                                                   batch_eids[i],
+                                                   batch_hashes[i]);
+        }
+
+        for (i = 0; i < batch_n; i++)
+        {
+            batch_ese[i] = get_edge_state_with_hash(vlelctx, batch_eids[i],
+                                                    batch_hashes[i]);
+        }
+
+        for (i = 0; i < batch_n; i++)
+        {
+            edge_entry       *ee  = batch_ee[i];
+            edge_state_entry *ese = batch_ese[i];
+            graphid p;
+            int64 unused_dist;
+
+            if (ee == NULL)
+            {
+                elog(ERROR, "rdist_expand_vertex: no edge found");
+            }
+
+            if (!ese->has_been_matched)
+            {
+                ese->has_been_matched = true;
+                ese->matched = is_an_edge_match(vlelctx, ee);
+                ese->start_vertex_id = get_edge_entry_start_vertex_id(ee);
+                ese->end_vertex_id = get_edge_entry_end_vertex_id(ee);
+            }
+
+            if (!ese->matched)
+            {
+                continue;
+            }
+
+            switch (flipped_dir)
+            {
+                case CYPHER_REL_DIR_RIGHT:
+                    p = ese->end_vertex_id;
+                    break;
+                case CYPHER_REL_DIR_LEFT:
+                    p = ese->start_vertex_id;
+                    break;
+                case CYPHER_REL_DIR_NONE:
+                default:
+                    p = (ese->start_vertex_id == u) ? ese->end_vertex_id
+                                                    : ese->start_vertex_id;
+                    break;
+            }
+
+            /* already known (discovered earlier, at this-or-smaller depth) */
+            if (try_get_reverse_dist(vlelctx, p, &unused_dist))
+            {
+                continue;
+            }
+
+            set_reverse_dist(vlelctx, p, du + 1);
+            rdist_queue_push(vlelctx, &vlelctx->reverse_dist_queue, p);
+        }
+    }
+}
+
+/*
+ * Return w's reverse distance to veid, advancing the lazy BFS frontier as
+ * far as necessary (and no farther) to answer this specific query.
+ *
+ * Returns PG_INT64_MAX for "not reachable within the current target's
+ * scope" -- either truly unreachable, or reachable only beyond the uidx
+ * budget, which is equally useless for pruning purposes and is why both
+ * cases are folded into the same sentinel rather than distinguished.
+ */
+static int64 get_or_advance_reverse_dist(VLE_local_context *vlelctx, graphid w)
+{
+    int64 dist;
+
+    if (try_get_reverse_dist(vlelctx, w, &dist))
+    {
+        return dist;
+    }
+
+    if (vlelctx->reverse_dist_exhausted)
+    {
+        return PG_INT64_MAX;
+    }
+
+    while (!rdist_queue_is_empty(&vlelctx->reverse_dist_queue))
+    {
+        graphid u = rdist_queue_pop(&vlelctx->reverse_dist_queue);
+        int64   du;
+        cypher_rel_dir flipped_dir;
+
+        if (!try_get_reverse_dist(vlelctx, u, &du))
+        {
+            elog(ERROR, "get_or_advance_reverse_dist: frontier vertex has no distance");
+        }
+
+        /*
+         * BFS pop order is non-decreasing in depth: once we've popped one
+         * vertex at or past the budget, every vertex still queued is at
+         * least as deep, so none of them can help either.
+         */
+        if (!vlelctx->uidx_infinite && du >= vlelctx->uidx)
+        {
+            break;
+        }
+
+        flipped_dir = flip_edge_direction(vlelctx->edge_direction);
+        rdist_expand_vertex(vlelctx, u, du, flipped_dir);
+
+        if (try_get_reverse_dist(vlelctx, w, &dist))
+        {
+            return dist;
+        }
+    }
+
+    vlelctx->reverse_dist_exhausted = true;
+    return PG_INT64_MAX;
+}
+
 /*
  * Helper function to add in valid vertex edges as part of the dfs path
  * algorithm. What constitutes a valid edge is the following -
@@ -1892,6 +2441,51 @@ static void add_valid_vertex_edges(VLE_local_context *vlelctx,
             if (ese->used_in_path)
             {
                 continue;
+            }
+
+            /*
+             * PATHS_BETWEEN only: prune this candidate if it provably
+             * cannot reach veid within the remaining hop budget. Checked
+             * here, after the cheaper is_edge_in_path/used_in_path checks
+             * have already had a chance to skip the edge for free, and
+             * using ese->start_vertex_id/end_vertex_id (already resolved,
+             * no extra lookup) rather than a fresh edge_entry fetch.
+             */
+            if (vlelctx->path_function == VLE_FUNCTION_PATHS_BETWEEN)
+            {
+                graphid next_vertex_id;
+                int64   dnext;
+
+                switch (vlelctx->edge_direction)
+                {
+                    case CYPHER_REL_DIR_RIGHT:
+                        next_vertex_id = ese->end_vertex_id;
+                        break;
+                    case CYPHER_REL_DIR_LEFT:
+                        next_vertex_id = ese->start_vertex_id;
+                        break;
+                    case CYPHER_REL_DIR_NONE:
+                    default:
+                        next_vertex_id = (ese->start_vertex_id == vertex_id)
+                                            ? ese->end_vertex_id
+                                            : ese->start_vertex_id;
+                        break;
+                }
+
+                dnext = get_or_advance_reverse_dist(vlelctx, next_vertex_id);
+
+                /*
+                 * dnext == PG_INT64_MAX is checked before the budget
+                 * arithmetic, and short-circuits it via ||, specifically
+                 * to avoid overflowing depth_so_far + 1 + dnext.
+                 */
+                if (dnext == PG_INT64_MAX ||
+                    (!vlelctx->uidx_infinite &&
+                     gid_stack_size(vlelctx->dfs_path_stack) + 1 + dnext >
+                         vlelctx->uidx))
+                {
+                    continue;
+                }
             }
 
             /*

--- a/src/backend/utils/adt/age_vle.c
+++ b/src/backend/utils/adt/age_vle.c
@@ -367,7 +367,7 @@ static bool dfs_find_a_path_from(VLE_local_context *vlelctx);
 static bool do_vsid_and_veid_exist(VLE_local_context *vlelctx);
 static void add_valid_vertex_edges(VLE_local_context *vlelctx,
                                    graphid vertex_id);
-static graphid get_next_vertex(VLE_local_context *vlelctx, edge_entry *ee);
+static __attribute__((unused)) graphid get_next_vertex(VLE_local_context *vlelctx, edge_entry *ee);
 static graphid get_next_vertex_from_state(VLE_local_context *vlelctx,
                                           edge_state_entry *ese);
 static vertex_edge_cache_entry *get_or_build_vertex_edge_cache(
@@ -1350,7 +1350,7 @@ static void evict_edge_state_entries_if_needed(VLE_local_context *vlelctx)
  * Helper function to get the id of the next vertex to move to. This is to
  * simplify finding the next vertex due to the VLE edge's direction.
  */
-static graphid get_next_vertex(VLE_local_context *vlelctx, edge_entry *ee)
+static __attribute__((unused)) graphid get_next_vertex(VLE_local_context *vlelctx, edge_entry *ee)
 {
     graphid terminal_vertex_id;
 
@@ -1440,7 +1440,7 @@ static graphid get_next_vertex_from_state(VLE_local_context *vlelctx,
 
             elog(ERROR, "get_next_vertex_from_state: no parent match");
         }
-
+        /* fall through */
         default:
             elog(ERROR, "get_next_vertex_from_state: unknown edge direction");
     }

--- a/src/backend/utils/adt/age_vle.c
+++ b/src/backend/utils/adt/age_vle.c
@@ -103,76 +103,57 @@ bool vle_edge_state_eviction_enabled = true;
 void vle_define_guc_variables(void)
 {
     DefineCustomIntVariable("age.vle_edge_state_htab_initial_size",
-                            "Initial bucket count for the per-query VLE edge-state hash table.",
-                            "Lower values reduce baseline memory for small VLE queries; "
-                            "the table still grows on demand for larger ones.",
+                            "Initial size of the VLE edge-state hash table.",
+                            "Lower values save memory for small queries; grows dynamically.",
                             &vle_edge_state_htab_initial_size,
                             vle_edge_state_htab_initial_size, 16, 10000000,
                             PGC_USERSET, 0, NULL, NULL, NULL);
 
     DefineCustomIntVariable("age.vle_vertex_edge_htab_initial_size",
-                            "Initial bucket count for the per-query VLE vertex->edges cache.",
+                            "Initial size of the VLE vertex-edges cache.",
                             NULL,
                             &vle_vertex_edge_htab_initial_size,
                             vle_vertex_edge_htab_initial_size, 16, 10000000,
                             PGC_USERSET, 0, NULL, NULL, NULL);
 
     DefineCustomIntVariable("age.vle_edge_state_max_entries",
-                            "Soft cap on live entries in the VLE edge-state hash table "
-                            "before background eviction of unreferenced entries kicks in.",
-                            "Entries currently pinned (part of the active DFS path or "
-                            "still sitting unresolved on the DFS edge stack) are never "
-                            "evicted, so actual memory can still exceed this in the "
-                            "worst case -- see age.vle_edge_state_eviction_enabled.",
+                            "Soft limit on VLE edge-state hash table entries.",
+                            "Triggers eviction. Pinned entries are never evicted, so actual memory may exceed this.",
                             &vle_edge_state_max_entries,
                             vle_edge_state_max_entries, 1000, INT_MAX,
                             PGC_USERSET, 0, NULL, NULL, NULL);
 
     DefineCustomIntVariable("age.vle_vertex_edge_cache_max_entries",
-                            "Soft cap on the number of vertices whose statically-valid "
-                            "adjacent edges are cached at once (VLE vertex_edge_cache).",
-                            "Unlike the edge-state cache, this one is a pure "
-                            "performance cache with no pinning constraints, so it is "
-                            "always evicted down to the cap using an LRU/clock policy.",
+                            "Soft limit on cached vertices in the VLE vertex-edges cache.",
+                            "Evicts entries down to the limit using an LRU/clock policy.",
                             &vle_vertex_edge_cache_max_entries,
                             vle_vertex_edge_cache_max_entries, 1000, INT_MAX,
                             PGC_USERSET, 0, NULL, NULL, NULL);
 
     DefineCustomIntVariable("age.vle_vertex_edge_cache_max_kb",
-                            "Soft cap, in kilobytes, on the memory backing "
-                            "VLE vertex_edge_cache's cached adjacency arrays.",
-                            "A single high-degree (hub) vertex can hold far more "
-                            "memory than age.vle_vertex_edge_cache_max_entries alone "
-                            "would suggest; this bounds the cache by its actual "
-                            "footprint.",
+                            "Soft limit on memory for VLE vertex-edges cache.",
+                            "Bounds the cache by actual memory footprint rather than entry count.",
                             &vle_vertex_edge_cache_max_kb,
                             vle_vertex_edge_cache_max_kb, 1024, INT_MAX,
-                            PGC_USERSET, 0, NULL, NULL, NULL);
+                            PGC_USERSET, GUC_UNIT_KB, NULL, NULL, NULL);
 
     DefineCustomIntVariable("age.vle_reverse_dist_max_entries",
-                            "Cap on the reverse-BFS distance table used to prune "
-                            "PATHS_BETWEEN VLE queries.",
-                            "Once reached, the reverse BFS simply stops advancing "
-                            "(graceful degradation of pruning power, never a "
-                            "correctness issue -- under-pruning only costs speed).",
+                            "Limit on the reverse-BFS distance table used for pruning.",
+                            "If exceeded, pruning gracefully degrades without affecting correctness.",
                             &vle_reverse_dist_max_entries,
                             vle_reverse_dist_max_entries, 1000, INT_MAX,
                             PGC_USERSET, 0, NULL, NULL, NULL);
 
     DefineCustomIntVariable("age.vle_max_cached_contexts",
-                            "Maximum number of VLE_local_context objects (one per "
-                            "distinct VLE grammar node) kept cached per backend.",
+                            "Max cached VLE local contexts per backend.",
                             NULL,
                             &vle_max_cached_contexts,
                             vle_max_cached_contexts, 1, 1000,
                             PGC_USERSET, 0, NULL, NULL, NULL);
 
     DefineCustomBoolVariable("age.vle_edge_state_eviction_enabled",
-                            "Enable clock-style eviction of unreferenced entries in "
-                            "the VLE edge-state hash table once "
-                            "age.vle_edge_state_max_entries is exceeded.",
-                            "When disabled, the edge-state cache grows without a "
-                            "hard bound (still only ever holding matched edges).",
+                            "Enable eviction in the VLE edge-state hash table.",
+                            "If disabled, the cache grows without a hard bound.",
                             &vle_edge_state_eviction_enabled,
                             vle_edge_state_eviction_enabled,
                             PGC_USERSET, 0, NULL, NULL, NULL);
@@ -185,31 +166,18 @@ void vle_define_guc_variables(void)
  * is_an_edge_match() -- see get_or_build_vertex_edge_cache() and
  * rdist_expand_vertex(). Presence in the table therefore implies
  * "matched"; there is no separate matched flag.
- *
- * pin_count is the number of times this edge_id currently sits,
- * unpopped, somewhere on vlelctx->dfs_edge_stack. Because vertices (not
- * just edges) can be revisited by the DFS, the SAME edge_id can be
- * pushed onto dfs_edge_stack more than once while an older, still-open
- * copy is buried deeper in the stack (see add_valid_vertex_edges() and
- * the single gid_stack_pop(edge_stack) sites in dfs_find_a_path_between/
- * from()). used_in_path alone is therefore NOT sufficient to know an
- * entry is safe to evict -- a pin_count of 0 is: it means no live
- * occurrence of this edge remains anywhere on the stack, in any state.
  */
 typedef struct edge_state_entry
 {
     graphid edge_id;               /* edge id, it is also the hash key */
     graphid start_vertex_id;       /* Topology cache for edge endpoints; */
     graphid end_vertex_id;         /* used for direction resolution in DFS. */
-    uint32 state;               /* bits 0-29: live occurrences on dfs_edge_stack; */
-                                    /* 0 <=> safe to evict (see above)    */
-                                /* bit 30: used_in_path; bit 31: clock_ref (eviction) */
+    uint32 state;                  /* [0-29]: pin_count, [30]: used_in_path, [31]: clock_ref */
 } edge_state_entry;
-
 
 /*
  * Macros for manipulating edge_state_entry flags: used_in_path and
- * clock_ref, packed into a single uint8 field.
+ * clock_ref, packed into a single uint32 field.
  */
 #define PIN_COUNT_MASK 0b00111111111111111111111111111111U /* bits 0-29 */
 #define USE_IN_PATH_FLAGS_MASK 0b01000000000000000000000000000000U /* bit 30 */
@@ -227,33 +195,15 @@ typedef struct edge_state_entry
 #define EDGE_STATE_ENTRY_PIN_COUNT_INC(ese) ((ese)->state = ((ese)->state & ~PIN_COUNT_MASK) | (EDGE_STATE_ENTRY_PIN_COUNT(ese) + 1))
 #define EDGE_STATE_ENTRY_PIN_COUNT_DEC(ese) ((ese)->state = ((ese)->state & ~PIN_COUNT_MASK) | (EDGE_STATE_ENTRY_PIN_COUNT(ese) - 1))
 /*
- * Vertex-level cache of statically-valid adjacent edges (see
- * get_or_build_vertex_edge_cache). "Statically valid" means the edge passed
- * is_an_edge_match() -- it says nothing about whether the edge is currently
- * usable in the DFS (that is path-dependent and re-checked on every visit
- * by add_valid_vertex_edges()).
+ * Vertex cache of edges that passed is_an_edge_match().
+ * Path validity is re-checked dynamically by add_valid_vertex_edges().
  */
 typedef struct vertex_edge_cache_entry
 {
-    graphid vertex_id;              /* vertex id, it is also the hash key */
-    int32 nvalid;                   /* number of entries in valid_edges */
-    graphid *valid_edges;           /* palloc'd array (in
-                                      * vlelctx->vertex_edge_cache_mcxt) of
-                                      * edge ids that passed is_an_edge_match
-                                      * for this vertex, in the same relative
-                                      * order they were discovered (out, then
-                                      * in, then self). Sized to exactly
-                                      * nvalid, not to the raw adjacency
-                                      * count -- see the repalloc in
-                                      * get_or_build_vertex_edge_cache(). */
-    bool clock_ref;                 /* eviction: touched since last sweep?
-                                      * Unlike edge_state_entry, this cache
-                                      * has NO pinning requirement -- the
-                                      * returned pointer is only ever used
-                                      * synchronously within a single
-                                      * add_valid_vertex_edges() call, never
-                                      * retained -- so any entry is always
-                                      * safe to evict and rebuild later. */
+    graphid vertex_id;      /* Hash key */
+    int32 nvalid;           /* Count of valid_edges */
+    graphid *valid_edges;   /* palloc'd array size nvalid */
+    bool clock_ref;         /* Eviction marker. */
 } vertex_edge_cache_entry;
 
 /*
@@ -312,41 +262,19 @@ typedef struct VLE_local_context
     bool uidx_infinite;            /* flag if the upper bound is omitted */
     cypher_rel_dir edge_direction; /* the direction of the edge */
     HTAB *edge_state_hashtable;    /* local state hashtable for our edges */
-    HTAB *vertex_edge_cache;       /* vertex_id -> statically-valid adjacent
-                                     * edges (see get_or_build_vertex_edge_cache) */
-    MemoryContext vertex_edge_cache_mcxt; /* Child context for valid_edges[]; managed explicitly. */
+    HTAB *vertex_edge_cache;       /* vertex_id -> statically-valid adjacent */
+    MemoryContext vertex_edge_cache_mcxt; /* Child context for valid_edges[] */
 
-    /*
-     * Lazy reverse-BFS state for VLE_FUNCTION_PATHS_BETWEEN pruning.
-     *
-     * This state is target-specific: reverse_dist_table is valid only
-     * for the current veid and is rebuilt when veid changes.  It is
-     * deliberately separate from vertex_edge_cache, whose entries are
-     * valid for the whole VLE_local_context.
-     */
-    HTAB *reverse_dist_table;       /* vertex_id -> reverse_dist_entry,
-                                      * valid only for the current veid */
-    MemoryContext reverse_dist_mcxt; /* owns reverse_dist_table and
-                                      * reverse_dist_queue.data */
-    bool reverse_dist_initialized;  /* true after reverse_dist_table has
-                                      * been created for this vlelctx */
-    graphid reverse_dist_target;    /* veid for reverse_dist_table */
-    bool reverse_dist_exhausted;    /* true once the reverse-BFS frontier
-                                      * is fully drained (or past the uidx
-                                      * budget) -- a PROOF that any vertex
-                                      * not already in reverse_dist_table
-                                      * is unreachable within scope. Only
-                                      * this flag may make
-                                      * get_or_advance_reverse_dist() return
-                                      * PG_INT64_MAX for an unknown vertex. */
-    bool reverse_dist_capped;       /* true once age.vle_reverse_dist_max_entries
-                                      * stopped the reverse BFS from
-                                      * admitting new frontier vertices.
-                                      * This is NOT a reachability proof --
-                                      * it just means we gave up early to
-                                      * respect a memory budget -- so it
-                                      * must never be treated the way
-                                      * reverse_dist_exhausted is. */
+    /* Lazy reverse-BFS state for VLE_FUNCTION_PATHS_BETWEEN pruning.
+     * Target-specific: valid only for current reverse_dist_target. */
+    HTAB *reverse_dist_table;           /* vertex_id -> reverse_dist_entry */
+    MemoryContext reverse_dist_mcxt;    /* Owns reverse_dist_table and queue data */
+    bool reverse_dist_initialized;      /* Table created for this vlelctx */
+    graphid reverse_dist_target;        /* Current target veid */
+    bool reverse_dist_exhausted;        /* Frontier fully drained: unreachable vertices
+                                         * are proven unreachable within scope.
+                                         * Only this flag allows returning PG_INT64_MAX. */
+    bool reverse_dist_capped;           /* BFS stopped by memory budget */
     rdist_queue reverse_dist_queue; /* reverse-BFS frontier */
     GraphIdStack *dfs_vertex_stack; /* dfs stack for vertices (array-based) */
     GraphIdStack *dfs_edge_stack;   /* dfs stack for edges (array-based) */
@@ -446,7 +374,7 @@ static vertex_edge_cache_entry *get_or_build_vertex_edge_cache(
                                                     VLE_local_context *vlelctx,
                                                     graphid vertex_id);
 static bool is_edge_in_path(VLE_local_context *vlelctx, graphid edge_id);
-/* reverse-BFS pruning for VLE_FUNCTION_PATHS_BETWEEN (see add_valid_vertex_edges) */
+/* reverse-BFS pruning for VLE_FUNCTION_PATHS_BETWEEN */
 static cypher_rel_dir flip_edge_direction(cypher_rel_dir dir);
 static void reset_reverse_dist_state_if_needed(VLE_local_context *vlelctx);
 static void set_reverse_dist(VLE_local_context *vlelctx, graphid vertex_id,
@@ -653,30 +581,7 @@ static void create_VLE_local_state_hashtable(VLE_local_context *vlelctx)
                                                 HASH_ELEM | HASH_FUNCTION);
     pfree_if_not_null(eshn);
 
-    /*
-     * Create a dedicated child context to own every valid_edges[] array
-     * that will ever be allocated by get_or_build_vertex_edge_cache().
-     *
-     * We deliberately do NOT just capture CurrentMemoryContext into a bare
-     * MemoryContext field and palloc directly into it: this function is
-     * called from three different sites (the LRU-cached path in
-     * build_local_vle_context(), which runs under TopMemoryContext; the
-     * uncached SRF path, which runs under funcctx->multi_call_memory_ctx;
-     * and sp_minhops_fallback(), which runs under its own private scratch
-     * context). All three currently do the right thing, but relying on
-     * "whichever context the caller happened to switch to before calling
-     * in here" is exactly the kind of ambient-context assumption that
-     * silently breaks under refactoring. Creating our OWN child context
-     * here means its lifetime is entirely our responsibility, symmetric
-     * with hash_destroy() below: we explicitly MemoryContextDelete() it in
-     * free_VLE_local_context(), the same way hash_destroy() explicitly
-     * frees edge_state_hashtable's storage. Correctness no longer depends
-     * on what CurrentMemoryContext happens to be, here or at any future
-     * call site -- we still parent off it (so it is reclaimed for free if
-     * an ancestor context is ever deleted first, e.g. via
-     * sp_minhops_fallback()'s MemoryContextDelete(tmpctx)), but we never
-     * depend on that parent to be the one doing the cleanup.
-     */
+    /* Dedicated child context for valid_edges[] */
     vlelctx->vertex_edge_cache_mcxt = AllocSetContextCreate(CurrentMemoryContext,
                                                             "VLE vertex edge cache",
                                                             ALLOCSET_DEFAULT_SIZES);
@@ -860,36 +765,21 @@ static void free_VLE_local_context(VLE_local_context *vlelctx)
     hash_destroy(vlelctx->edge_state_hashtable);
     vlelctx->edge_state_hashtable = NULL;
 
-    /*
-     * Free the vertex edge cache's own hashtable storage (its entries --
-     * fixed-size vertex_edge_cache_entry structs, held in dynahash's own
-     * private child context). This does NOT free the valid_edges[] arrays
-     * those entries point to.
-     */
+    /* Free vertex edge cache hashtable (entries only, not valid_edges[]). */
     if (vlelctx->vertex_edge_cache != NULL)
     {
         hash_destroy(vlelctx->vertex_edge_cache);
         vlelctx->vertex_edge_cache = NULL;
     }
 
-    /*
-     * Explicitly delete the dedicated context that owns every valid_edges[]
-     * array. This is what actually reclaims that memory -- hash_destroy()
-     * above never touches it. Symmetric, on purpose, with the hash_destroy()
-     * calls: every allocator this function uses gets an explicit, owned
-     * teardown call here, none of them are left to an ambient parent
-     * context to clean up "eventually".
-     */
+    /* Free context owning valid_edges[] arrays. */
     if (vlelctx->vertex_edge_cache_mcxt != NULL)
     {
         MemoryContextDelete(vlelctx->vertex_edge_cache_mcxt);
         vlelctx->vertex_edge_cache_mcxt = NULL;
     }
 
-    /*
-     * Free the reverse-BFS pruning state.  The dedicated context owns
-     * both the distance table storage and the queue data.
-     */
+    /* Free reverse-BFS state: context owns both table and queue data. */
     if (vlelctx->reverse_dist_table != NULL)
     {
         hash_destroy(vlelctx->reverse_dist_table);
@@ -1310,23 +1200,6 @@ static VLE_local_context *build_local_vle_context(FunctionCallInfo fcinfo,
  * both the dynahash edge_state_hashtable here and the agehash-backed
  * edge_table on the global-graph lookup path elsewhere.
  */
-/*
- * Get (creating if necessary) the edge_state_entry for edge_id.
- *
- * Every caller -- the DFS peek at the top of dfs_find_a_path_between()/
- * from(), and the dynamic used_in_path re-check in
- * add_valid_vertex_edges() -- only ever asks about an edge already known
- * to be statically valid (matched): it came out of
- * vertex_edge_cache_entry->valid_edges[], or it is already sitting on
- * dfs_edge_stack. A lookup miss therefore never means "not yet
- * classified" (that only happens in get_or_build_vertex_edge_cache() /
- * rdist_expand_vertex(), which gate insertion on is_an_edge_match()); it
- * means the entry was reclaimed by evict_edge_state_entries_if_needed()
- * while unreferenced (pin_count == 0, not used_in_path). On a miss we
- * re-derive start/end from the underlying edge and recreate the entry in
- * the same neutral state (pin_count 0, flags 0) it was evicted in, which
- * makes eviction transparent to every caller.
- */
 static edge_state_entry *get_edge_state_with_hash(VLE_local_context *vlelctx,
                                                   graphid edge_id,
                                                   uint32 hashvalue)
@@ -1348,13 +1221,6 @@ static edge_state_entry *get_edge_state_with_hash(VLE_local_context *vlelctx,
             elog(ERROR, "get_edge_state_with_hash: no edge found");
         }
 
-        /*
-         * Callers only ever pass an edge_id already known to be a match
-         * (see above), so it is not re-verified in production builds --
-         * only re-confirmed here under assertions, to catch any future
-         * caller that violates the precondition instead of silently
-         * fabricating state for a non-matching edge.
-         */
         Assert(is_an_edge_match(vlelctx, ee));
 
         ese->edge_id = edge_id;
@@ -1369,15 +1235,7 @@ static edge_state_entry *get_edge_state_with_hash(VLE_local_context *vlelctx,
     return ese;
 }
 
-/*
- * HASH_FIND-only counterpart of get_edge_state_with_hash(), used by the
- * classification call sites (get_or_build_vertex_edge_cache(),
- * rdist_expand_vertex()) to check whether edge_id has already been
- * classified as a match, without creating an entry as a side effect --
- * an edge that fails is_an_edge_match() must never get an entry, or
- * edge_state_hashtable would grow with every rejected edge instead of
- * just the matched ones.
- */
+/* HASH_FIND-only lookup; avoids creating entries for non-matching edges. */
 static edge_state_entry *find_edge_state_with_hash(VLE_local_context *vlelctx,
                                                     graphid edge_id,
                                                     uint32 hashvalue)
@@ -1398,17 +1256,10 @@ static edge_state_entry *find_edge_state_with_hash(VLE_local_context *vlelctx,
 }
 
 /*
- * Record edge_id as a freshly-matched edge in edge_state_hashtable. Only
- * called right after is_an_edge_match() returned true for it (see
- * get_or_build_vertex_edge_cache() and rdist_expand_vertex()), and only
- * when a prior find_edge_state_with_hash() call already established that
- * no entry exists yet -- so found is expected to come back false here.
- *
- * found is still checked rather than assumed: if it ever does come back
- * true (e.g. a future caller stops honoring that precondition), the
- * existing entry -- and in particular its pin_count and used_in_path,
- * which encode live DFS state -- must be left untouched. Overwriting them
- * unconditionally would silently corrupt in-progress path tracking.
+ * Insert a freshly-matched edge into edge_state_hashtable.
+ * Called only after is_an_edge_match() succeeded and find_edge_state_with_hash()
+ * confirmed no entry exists. If an entry unexpectedly exists, it is left
+ * untouched to preserve live DFS state (pin_count, used_in_path).
  */
 static edge_state_entry *insert_matched_edge_state(VLE_local_context *vlelctx,
                                                     graphid edge_id,
@@ -1435,37 +1286,12 @@ static edge_state_entry *insert_matched_edge_state(VLE_local_context *vlelctx,
 }
 
 /*
- * Clock-style eviction for edge_state_hashtable, triggered once the table
- * exceeds age.vle_edge_state_max_entries.
- *
- * Safety: an entry is only ever removed when BOTH pin_count == 0 (no live
- * occurrence anywhere on dfs_edge_stack -- see the struct comment on
- * edge_state_entry) AND it is not used_in_path. used_in_path can only be
- * set while at least one occurrence is pinned, so the pin_count check
- * alone is sufficient in a correctly-functioning traversal; the
- * used_in_path check is kept as a cheap, defensive belt-and-braces
- * condition. Every eviction is followed, on next access, by a transparent
- * re-derivation in get_edge_state_with_hash() -- see that function's
- * comment for why this is fully safe.
- *
- * A sweep evicts down to a low-water mark below the cap rather than
- * stopping the instant it dips under it, so the table has room to absorb
- * a batch of further insertions before the next full sweep is needed.
- * Without this, a workload that hovers right at the cap can end up
- * paying for a full table scan on every single insertion.
- *
- * At most two passes are made per call: a clock algorithm's first pass
- * may do no more than clear the "recently used" bit on every remaining
- * candidate (giving each one more reprieve), in which case a second pass
- * is what actually reclaims them. A third pass could never find anything
- * a second pass didn't already make eligible, so two is both necessary
- * and sufficient. If two passes still leave the table above the
- * low-water mark, everything left is pinned, and no amount of sweeping
- * will free more -- the table is simply that busy right now.
- *
- * hash_seq_search() explicitly supports removing the just-returned
- * element mid-scan (documented dynahash behavior), so HASH_REMOVE here is
- * safe to call from inside the scan loop.
+ * Clock-style eviction for edge_state_hashtable when exceeding max_entries.
+ * Evicts only entries with pin_count == 0 and !used_in_path; safe because
+ * get_edge_state_with_hash() transparently re-derives evicted entries.
+ * Sweeps down to a low-water mark (7/8 of cap) to avoid per-insertion scans.
+ * At most two passes: first clears clock_ref bits, second performs removal.
+ * hash_seq_search() safely supports HASH_REMOVE mid-scan.
  */
 static void evict_edge_state_entries_if_needed(VLE_local_context *vlelctx)
 {
@@ -1576,19 +1402,10 @@ static graphid get_next_vertex(VLE_local_context *vlelctx, edge_entry *ee)
 }
 
 /*
- * Cache-based counterpart to get_next_vertex(). Resolves the vertex the DFS
- * moves to when it takes edge `ese`, using only start_vertex_id/end_vertex_id
- * already cached on the edge_state_entry -- no edge_entry lookup required.
- *
- * Precondition: ese must represent a matched edge (guaranteed for any edge
- * that ever reaches the DFS hot loop, since only matched edges are ever
- * pushed onto dfs_edge_stack -- see get_or_build_vertex_edge_cache() and the
- * push site in add_valid_vertex_edges()).
- *
- * Mirrors get_next_vertex()'s branching exactly; see that function's
- * comments for why CYPHER_REL_DIR_NONE must consult the vertex stack (the
- * next vertex for an undirected edge depends on which endpoint the DFS is
- * currently standing on, not on the edge alone).
+ * Cached counterpart to get_next_vertex(). Resolves next vertex using
+ * endpoints stored in edge_state_entry, avoiding edge_entry lookup.
+ * For CYPHER_REL_DIR_NONE, consults dfs_vertex_stack (must be in lockstep
+ * with dfs_edge_stack) to determine direction based on current position.
  */
 static graphid get_next_vertex_from_state(VLE_local_context *vlelctx,
                                           edge_state_entry *ese)
@@ -1607,18 +1424,6 @@ static graphid get_next_vertex_from_state(VLE_local_context *vlelctx,
         {
             graphid parent_vertex_id;
 
-            /*
-             * The whole vertex-stack scheme for CYPHER_REL_DIR_NONE relies
-             * on dfs_vertex_stack and dfs_edge_stack staying in lockstep
-             * (one vertex pushed/popped per edge pushed/popped -- see
-             * add_valid_vertex_edges() and the backtracking branches in
-             * dfs_find_a_path_between()/dfs_find_a_path_from()). Cheap
-             * enough to check on every step in cassert builds, and it
-             * would catch a future refactor breaking that invariant
-             * immediately instead of manifesting as a confusing
-             * "get_next_vertex_from_state: no parent match" error (or
-             * worse, a wrong-but-plausible path) far away from the bug.
-             */
             Assert(gid_stack_size(vlelctx->dfs_vertex_stack) ==
                    gid_stack_size(vlelctx->dfs_edge_stack));
 
@@ -1721,12 +1526,7 @@ static bool dfs_find_a_path_between(VLE_local_context *vlelctx)
             }
             /* now remove it from the edge stack */
             gid_stack_pop(edge_stack);
-            /*
-             * This occurrence of edge_id is done -- see the
-             * pin_count comment on edge_state_entry. Once this
-             * reaches 0 and used_in_path is clear, the entry
-             * becomes eligible for eviction.
-             */
+
             Assert(EDGE_STATE_ENTRY_PIN_COUNT(ese) > 0);
             EDGE_STATE_ENTRY_PIN_COUNT_DEC(ese);
             /*
@@ -1752,12 +1552,7 @@ static bool dfs_find_a_path_between(VLE_local_context *vlelctx)
         EDGE_STATE_ENTRY_SET_USE_IN_PATH(ese);
         gid_stack_push(path_stack, edge_id);
 
-        /*
-         * Resolve the next vertex directly from the cache populated by
-         * get_or_build_vertex_edge_cache() when this edge was first
-         * classified. No edge_entry lookup needed here -- that lookup
-         * already happened once, ever, per edge, not once per DFS step.
-         */
+        /* Resolve next vertex from cached edge state */
         next_vertex_id = get_next_vertex_from_state(vlelctx, ese);
 
         /*
@@ -1876,12 +1671,7 @@ static bool dfs_find_a_path_from(VLE_local_context *vlelctx)
             }
             /* now remove it from the edge stack */
             gid_stack_pop(edge_stack);
-            /*
-             * This occurrence of edge_id is done -- see the
-             * pin_count comment on edge_state_entry. Once this
-             * reaches 0 and used_in_path is clear, the entry
-             * becomes eligible for eviction.
-             */
+
             Assert(EDGE_STATE_ENTRY_PIN_COUNT(ese) > 0);
             EDGE_STATE_ENTRY_PIN_COUNT_DEC(ese);
             /*
@@ -1974,39 +1764,15 @@ static bool is_edge_in_path(VLE_local_context *vlelctx, graphid edge_id)
 #define VLE_LOOKUP_BATCH 8
 
 /*
- * Build (on first visit) or fetch (on every subsequent visit) the static
- * classification cache for `vertex_id`: the subset of its adjacent edges
- * that pass is_an_edge_match(), independent of anything path-dependent.
+ * Build or fetch the static classification cache for vertex_id: adjacent
+ * edges passing is_an_edge_match(), independent of path state.
  *
- * This is the "vertex-level adjacency cache" optimization. It is deliberately
- * split apart from the DYNAMIC used_in_path/is_edge_in_path check, which
- * changes constantly as the DFS advances and backtracks and can therefore
- * never be cached at the vertex level -- only the *static* match result can.
- *
- * On the very first visit to a vertex, this runs the same 5-phase MLP-batched
- * pipeline that add_valid_vertex_edges used to run on *every* visit: gather,
- * hash, look up edge_entry (agehash), look up/create edge_state_entry
- * (dynahash), classify. On every subsequent visit, this is a single dynahash
- * lookup that returns the already-built array -- the adjacency arrays are
- * never re-walked, and get_edge_entry_with_hash() (the expensive, L3-miss
- * prone lookup) is never called again for any edge already classified,
- * whether it was classified from this vertex or from its other endpoint.
- *
- * Note that because this cache lives in vlelctx and, for a grammar-node
- * backed VLE call (the normal Cypher path -- see build_local_vle_context()'s
- * use_cache handling), vlelctx itself is reused across many separate
- * age_vle() SRF invocations (e.g. once per outer-loop row feeding into a
- * VLE join), this cache's benefit compounds far beyond a single path
- * enumeration: a vertex visited by row 1's traversal is already fully
- * classified, for free, if row 2's traversal ever reaches it too. This
- * also means the cache can grow large over the lifetime of a long-running
- * backend, which is exactly why vertex_edge_cache_mcxt's lifetime has to be
- * managed explicitly rather than left to an ambient context -- see
- * create_VLE_local_state_hashtable() and free_VLE_local_context().
- *
- * The returned array and its length are only ever read by the caller
- * (add_valid_vertex_edges) below; they are never mutated after this
- * function returns.
+ * First visit runs a 5-phase MLP-batched pipeline (gather, hash, edge_state
+ * lookup, edge_entry lookup, classify). Subsequent visits are a single
+ * dynahash lookup; get_edge_entry_with_hash() is never called again for
+ * already-classified edges. Cache persists across SRF invocations when
+ * vlelctx is reused, so memory is managed via vertex_edge_cache_mcxt.
+ * Returned array is read-only after this function returns.
  */
 static vertex_edge_cache_entry *get_or_build_vertex_edge_cache(
                                                     VLE_local_context *vlelctx,
@@ -2030,13 +1796,6 @@ static vertex_edge_cache_entry *get_or_build_vertex_edge_cache(
     int32     scratch_cap;
     MemoryContext oldcontext;
 
-    /*
-     * Keep the cache within its cap BEFORE inserting a new key, not
-     * after -- evicting after insertion would risk immediately evicting
-     * the entry we are about to build. This is a pure performance cache
-     * with no pinning constraints (see the clock_ref field comment on
-     * vertex_edge_cache_entry), so eviction here is always safe.
-     */
     evict_vertex_edge_cache_entries_if_needed(vlelctx);
 
     vce = (vertex_edge_cache_entry *) hash_search(vlelctx->vertex_edge_cache,
@@ -2078,13 +1837,8 @@ static vertex_edge_cache_entry *get_or_build_vertex_edge_cache(
 
     scratch_cap = sz_out + sz_in + sz_self;
 
-    /*
-     * The result array must outlive this SRF call (it is read on every
-     * future visit to this vertex, across many successive age_vle()
-     * invocations), so it must be allocated in
-     * vlelctx->vertex_edge_cache_mcxt, not whatever the ambient
-     * CurrentMemoryContext happens to be here.
-     */
+
+    /* Result must outlive this SRF call; allocate in dedicated context. */
     oldcontext = MemoryContextSwitchTo(vlelctx->vertex_edge_cache_mcxt);
     scratch = (scratch_cap > 0) ? palloc(sizeof(graphid) * scratch_cap) : NULL;
     MemoryContextSwitchTo(oldcontext);
@@ -2095,9 +1849,7 @@ static vertex_edge_cache_entry *get_or_build_vertex_edge_cache(
      * pipelined across five phases -- gather, hash, look up any existing
      * classification, look up the underlying edge for anything not yet
      * classified, then classify and collect -- so that the latency of
-     * independent hash/heap lookups within a batch can overlap. The
-     * dynamic used_in_path / is_edge_in_path check is deliberately NOT
-     * done here -- see add_valid_vertex_edges() below.
+     * independent hash/heap lookups within a batch can overlap.
      */
     while (idx_out < sz_out || idx_in < sz_in || idx_self < sz_self)
     {
@@ -2181,17 +1933,7 @@ static vertex_edge_cache_entry *get_or_build_vertex_edge_cache(
 
                 if (!is_an_edge_match(vlelctx, ee))
                 {
-                    /*
-                     * Not a match: no edge_state_entry is created for
-                     * it. edge_state_hashtable's size is thus bounded by
-                     * the number of matched edges ever seen, not by
-                     * every edge ever scanned -- the dominant factor on
-                     * a low-selectivity VLE predicate over a dense or
-                     * hub-heavy graph. The cost is that a rejected edge
-                     * encountered a second time (undirected traversal,
-                     * or overlap with the PATHS_BETWEEN reverse-BFS
-                     * walk) is re-classified rather than remembered.
-                     */
+                    /* Rejected edges get no entry; re-classified on revisit */
                     continue;
                 }
 
@@ -2205,14 +1947,7 @@ static vertex_edge_cache_entry *get_or_build_vertex_edge_cache(
 
     evict_edge_state_entries_if_needed(vlelctx);
 
-    /*
-     * Shrink to the actual number of statically-valid edges. scratch_cap is
-     * the raw (unfiltered) adjacency count; on a dense graph with a
-     * selective edge predicate nscratch can be far smaller, and this array
-     * lives for the remaining lifetime of vlelctx (potentially the lifetime
-     * of a long-running, cached, reused-across-many-SRF-calls backend --
-     * see the note at the top of this function), so the gap matters.
-     */
+    /* Shrink to actual matched count */
     if (scratch != NULL)
     {
         oldcontext = MemoryContextSwitchTo(vlelctx->vertex_edge_cache_mcxt);
@@ -2237,25 +1972,11 @@ static vertex_edge_cache_entry *get_or_build_vertex_edge_cache(
 }
 
 /*
- * Clock-style eviction for vertex_edge_cache, triggered once the table
- * exceeds age.vle_vertex_edge_cache_max_entries, or the memory actually
- * backing its cached adjacency arrays exceeds age.vle_vertex_edge_cache_max_kb
- * -- an entry-count cap alone under-protects against a small number of
- * high-degree (hub) vertices, each with a disproportionately large
- * valid_edges[] array.
- *
- * No pinning is needed here (unlike edge_state_hashtable): the
- * vertex_edge_cache_entry pointer returned by get_or_build_vertex_edge_cache()
- * is only ever used synchronously, within a single call to
- * add_valid_vertex_edges(), and never retained past it -- so any entry can
- * be evicted (and its valid_edges[] array freed) at any time between
- * calls. A revisited vertex simply gets its cache rebuilt from the
- * underlying adjacency arrays, which is deterministic and correct, just
- * not free -- exactly the ordinary LRU-cache-miss cost/memory trade-off.
- *
- * See evict_edge_state_entries_if_needed() for why eviction targets a
- * low-water mark below the cap, and why two passes are both necessary and
- * sufficient for a clock sweep.
+ * Clock-style eviction for vertex_edge_cache when exceeding entry count
+ * or memory (max_kb) caps. Memory cap protects against hub vertices with
+ * large valid_edges[] arrays. No pinning needed: entries are used only
+ * synchronously within add_valid_vertex_edges() and can always be rebuilt.
+ * Sweeps to low-water mark (7/8 of cap) over at most two passes.
  */
 static void evict_vertex_edge_cache_entries_if_needed(VLE_local_context *vlelctx)
 {
@@ -2447,24 +2168,14 @@ static graphid rdist_queue_pop(rdist_queue *q)
 }
 
 /*
- * Rewind to an empty queue for a new generation (new veid). If the
- * PREVIOUS generation used far less of the array than its current capacity
- * -- e.g. one huge query on a dense graph, followed on a cached vlelctx by
- * many small ones on unrelated later queries -- shrink the backing array
- * back down instead of holding the peak-ever size for the rest of this
- * vlelctx's lifetime. Hysteresis (4x threshold + a floor) avoids
- * reallocating on every single reset for queries of similar size run
- * back-to-back.
+ * Reset queue for new generation. Shrinks backing array if previous peak
+ * was < 1/4 capacity (with hysteresis floor) to avoid holding peak size
+ * across unrelated cached queries.
  */
 static void rdist_queue_reset(VLE_local_context *vlelctx, rdist_queue *q)
 {
     int64 peak = q->max_count;
 
-    /*
-     * Shrink if the previous generation's peak frontier was much smaller
-     * than the current capacity. Keep a minimum size to avoid reallocating
-     * for small/typical queries.
-     */
     if (q->data != NULL && q->cap > RDIST_QUEUE_MIN_CAP &&
         peak < q->cap / 4)
     {
@@ -2508,12 +2219,8 @@ static void set_reverse_dist(VLE_local_context *vlelctx, graphid vertex_id,
 }
 
 /*
- * Read-only: true and *dist set iff vertex_id's reverse distance is
- * already known for the CURRENT target. A vertex the reverse BFS has never
- * reached simply isn't known, which is a very different thing from "known
- * to be unreachable" -- see reverse_dist_exhausted in
- * get_or_advance_reverse_dist(). Never returns the entry pointer to the
- * caller -- see the invariant in the block comment above.
+ * Read-only lookup: returns true and sets *dist if vertex is known for
+ * current target. Unknown != unreachable (see reverse_dist_exhausted).
  */
 static bool try_get_reverse_dist(VLE_local_context *vlelctx, graphid vertex_id,
                                  int64 *dist)
@@ -2727,35 +2434,13 @@ static void rdist_expand_vertex(VLE_local_context *vlelctx, graphid u,
 
             new_dist = du + 1;
 
-            /*
-             * A reverse distance of exactly uidx or more can never help
-             * add_valid_vertex_edges() prune a candidate: that check is
-             *   depth_so_far + 1 + dnext > uidx
-             * and for dnext == uidx this reduces to depth_so_far + 1 > 0,
-             * which holds for every depth_so_far >= 0. Such a distance
-             * therefore behaves exactly like the "unreachable"
-             * PG_INT64_MAX sentinel for pruning purposes, and is not worth
-             * a reverse_dist_table entry -- typically the single widest
-             * layer of the reverse BFS. Only applies when uidx is finite.
-             */
+            /* Distance >= uidx is useless for pruning; treat as unreachable. */
             if (!vlelctx->uidx_infinite && new_dist >= vlelctx->uidx)
             {
                 continue;
             }
 
-            /*
-             * The reverse-BFS distance table is a pruning heuristic, not
-             * a source of truth: an entry missing from it is read by
-             * get_or_advance_reverse_dist() as "prune this candidate",
-             * so it must never be capped by simply refusing to insert
-             * without also recording that the search stopped early.
-             * age.vle_reverse_dist_max_entries bounds it by degrading the
-             * reverse BFS to a fail-open state instead: once reached, no
-             * further frontier vertices are admitted, and unresolved
-             * vertices are treated by get_or_advance_reverse_dist() as
-             * "not provably prunable" rather than "unreachable" -- see
-             * reverse_dist_capped's field comment.
-             */
+            /* Cap table size by degrading to fail-open (not false-unreachable). */
             if (hash_get_num_entries(vlelctx->reverse_dist_table) >=
                 vle_reverse_dist_max_entries)
             {
@@ -2772,84 +2457,44 @@ static void rdist_expand_vertex(VLE_local_context *vlelctx, graphid u,
 }
 
 /*
- * Resolve w's distance from veid along the flipped-direction adjacency,
- * advancing the lazy reverse BFS only as far as necessary to answer this
- * specific query.
- *
- * The reverse BFS is a pruning heuristic for VLE_FUNCTION_PATHS_BETWEEN:
- * add_valid_vertex_edges() discards a candidate edge once it can prove
- * the remaining budget can no longer reach veid. Proving unreachability
- * requires having actually exhausted the search (reverse_dist_exhausted);
- * merely stopping early to respect age.vle_reverse_dist_max_entries
- * (reverse_dist_capped) proves nothing, so the two must not be treated
- * alike. Returning PG_INT64_MAX in the capped-but-not-exhausted case
- * would make a memory limit silently discard valid paths, so this
- * function instead fails open: a distance of 0 for an unresolved vertex
- * never triggers pruning by itself (see add_valid_vertex_edges()), it
- * just forfeits the pruning benefit for that particular candidate.
+ * Resolve w's reverse distance, advancing lazy BFS only as needed.
+ * Returns PG_INT64_MAX only if search is exhausted (proven unreachable).
+ * If capped by memory limit, returns 0 (fail-open: forfeits pruning but
+ * never silently discards valid paths). Unresolved vertices with dist=0
+ * do not trigger pruning in add_valid_vertex_edges().
  */
 static int64 get_or_advance_reverse_dist(VLE_local_context *vlelctx, graphid w)
 {
     int64 dist;
 
     if (try_get_reverse_dist(vlelctx, w, &dist))
-    {
         return dist;
-    }
 
     if (vlelctx->reverse_dist_exhausted)
-    {
         return PG_INT64_MAX;
-    }
 
     if (vlelctx->reverse_dist_capped)
-    {
-        return 0;
-    }
+        return 0; /* Fail-open: cap proves nothing about reachability */
 
     while (!rdist_queue_is_empty(&vlelctx->reverse_dist_queue))
     {
         graphid u = rdist_queue_pop(&vlelctx->reverse_dist_queue);
-        int64   du;
-        cypher_rel_dir flipped_dir;
+        int64 du;
 
         if (!try_get_reverse_dist(vlelctx, u, &du))
-        {
             elog(ERROR, "get_or_advance_reverse_dist: frontier vertex has no distance");
-        }
 
-        /*
-         * BFS pop order is non-decreasing in depth. Every neighbour of u
-         * would land at du + 1, and rdist_expand_vertex() already refuses
-         * to record any distance >= uidx as useless for pruning -- so
-         * once du + 1 >= uidx, expanding u (and everything still queued
-         * behind it) cannot add anything, and there is no point walking
-         * its adjacency at all.
-         */
+        /* BFS is non-decreasing; once du+1 >= uidx, further expansion is useless. */
         if (!vlelctx->uidx_infinite && du + 1 >= vlelctx->uidx)
-        {
             break;
-        }
 
-        flipped_dir = flip_edge_direction(vlelctx->edge_direction);
-        rdist_expand_vertex(vlelctx, u, du, flipped_dir);
+        rdist_expand_vertex(vlelctx, u, du, flip_edge_direction(vlelctx->edge_direction));
 
         if (try_get_reverse_dist(vlelctx, w, &dist))
-        {
             return dist;
-        }
 
         if (vlelctx->reverse_dist_capped)
-        {
-            /*
-             * The cap was already reached (permanently, for this target
-             * -- reverse_dist_table never shrinks below it once hit, see
-             * rdist_expand_vertex()), so continuing to pop and expand the
-             * rest of the queue would just repeat the same no-op cap
-             * check for every remaining candidate.
-             */
-            return 0;
-        }
+            return 0; /* Cap is permanent for this target; stop early */
     }
 
     vlelctx->reverse_dist_exhausted = true;
@@ -2857,115 +2502,66 @@ static int64 get_or_advance_reverse_dist(VLE_local_context *vlelctx, graphid w)
 }
 
 /*
- * Helper function to add in valid vertex edges as part of the dfs path
- * algorithm. What constitutes a valid edge is the following -
- *
- *     1) Edge matches the correct direction specified.
- *     2) Edge is not currently in the path.
- *     3) Edge matches minimum edge properties specified.
- *
- * Note: The vertex must exist.
- *
- * Static classification (which of this vertex's edges match at all) is
- * handled by get_or_build_vertex_edge_cache() above and computed at most
- * once per vertex. This function only re-checks the DYNAMIC used_in_path
- * state, which must be re-checked on every visit, but now only for the
- * pre-filtered set of statically-valid edges -- not the full adjacency
- * list -- and with no edge_entry (agehash) lookups at all on repeat visits.
- *
- * The dynamic edge_state_hashtable lookups below are still run through the
- * same batched gather/hash/lookup/apply pipeline as
- * get_or_build_vertex_edge_cache() uses, for the same MLP reason: even
- * though only one hashtable is involved now (not two), a repeat visit to a
- * hot, highly-connected vertex can still re-check dozens of edges, and
- * batching the dynahash HASH_ENTER calls hides their miss latency the same
- * way it did before this vertex's edges were split out of the per-visit
- * pipeline.
+ * Add valid edges to DFS stack. Validity requires: correct direction,
+ * not currently in path, and matching edge properties. Static classification
+ * (direction + properties) is pre-filtered by get_or_build_vertex_edge_cache()
+ * and computed at most once per vertex. This function only re-checks the
+ * DYNAMIC used_in_path state for that pre-filtered set -- no edge_entry
+ * lookups on repeat visits. Uses batched MLP pipeline for edge_state
+ * lookups to hide latency when hot vertices have many statically-valid edges.
  */
 static void add_valid_vertex_edges(VLE_local_context *vlelctx,
                                    graphid vertex_id)
 {
     GraphIdStack *vertex_stack = vlelctx->dfs_vertex_stack;
     GraphIdStack *edge_stack = vlelctx->dfs_edge_stack;
-    vertex_edge_cache_entry *vce;
+    vertex_edge_cache_entry *vce = get_or_build_vertex_edge_cache(vlelctx, vertex_id);
     int32 pos = 0;
-
-    vce = get_or_build_vertex_edge_cache(vlelctx, vertex_id);
 
     while (pos < vce->nvalid)
     {
-        graphid           batch_eids[VLE_LOOKUP_BATCH];
-        uint32            batch_hashes[VLE_LOOKUP_BATCH];
+        graphid batch_eids[VLE_LOOKUP_BATCH];
+        uint32 batch_hashes[VLE_LOOKUP_BATCH];
         edge_state_entry *batch_ese[VLE_LOOKUP_BATCH];
         int batch_n = 0;
-        int i;
 
-        /* Phase 1: gather, applying the dynamic is_edge_in_path early-skip */
+        /* Gather with early-skip for small stacks (linear scan beats hash lookup) */
         while (batch_n < VLE_LOOKUP_BATCH && pos < vce->nvalid)
         {
             graphid edge_id = vce->valid_edges[pos++];
 
-            /*
-             * Fast early-skip when the path stack is small: avoids an
-             * edge_state_hashtable lookup for edges already on the path.
-             * (Kept exactly as before -- for the common, small-stack case
-             * this bounded linear scan beats a hashtable lookup.)
-             */
             if (gid_stack_size(vlelctx->dfs_path_stack) < 10 &&
                 is_edge_in_path(vlelctx, edge_id))
-            {
                 continue;
-            }
 
             batch_eids[batch_n++] = edge_id;
         }
 
         if (batch_n == 0)
-        {
             continue;
-        }
 
-        /* Phase 2: compute hashes (pure compute, no misses) */
-        for (i = 0; i < batch_n; i++)
-        {
+        /* Hash */
+        for (int i = 0; i < batch_n; i++)
             batch_hashes[i] = graphid_hash(&batch_eids[i], sizeof(int64));
-        }
 
-        /* Phase 3: K back-to-back edge_state_hashtable lookups (MLP wave) */
-        for (i = 0; i < batch_n; i++)
-        {
-            batch_ese[i] = get_edge_state_with_hash(vlelctx,
-                                                    batch_eids[i],
-                                                    batch_hashes[i]);
-        }
+        /* Batched edge_state lookups (MLP) */
+        for (int i = 0; i < batch_n; i++)
+            batch_ese[i] = get_edge_state_with_hash(vlelctx, batch_eids[i], batch_hashes[i]);
 
-        /* Phase 4: apply, in the same order the edges were discovered in */
-        for (i = 0; i < batch_n; i++)
+        /* Apply: filter and push valid edges */
+        for (int i = 0; i < batch_n; i++)
         {
             edge_state_entry *ese = batch_ese[i];
-            graphid           edge_id = batch_eids[i];
+            graphid edge_id = batch_eids[i];
 
-            /*
-             * Don't add any edges that we have already seen because they
-             * will cause a loop to form.
-             */
             if (EDGE_STATE_ENTRY_USE_IN_PATH(ese))
-            {
-                continue;
-            }
+                continue; /* Already in current path */
 
-            /*
-             * PATHS_BETWEEN only: prune this candidate if it provably
-             * cannot reach veid within the remaining hop budget. Checked
-             * here, after the cheaper is_edge_in_path/used_in_path checks
-             * have already had a chance to skip the edge for free, and
-             * using ese->start_vertex_id/end_vertex_id (already resolved,
-             * no extra lookup) rather than a fresh edge_entry fetch.
-             */
+            /* PATHS_BETWEEN: prune if target unreachable within remaining budget */
             if (vlelctx->path_function == VLE_FUNCTION_PATHS_BETWEEN)
             {
                 graphid next_vertex_id;
-                int64   dnext;
+                int64 dnext;
 
                 switch (vlelctx->edge_direction)
                 {
@@ -2978,56 +2574,31 @@ static void add_valid_vertex_edges(VLE_local_context *vlelctx,
                     case CYPHER_REL_DIR_NONE:
                     default:
                         next_vertex_id = (ese->start_vertex_id == vertex_id)
-                                            ? ese->end_vertex_id
-                                            : ese->start_vertex_id;
-                        break;
+                                                ? ese->end_vertex_id
+                                                : ese->start_vertex_id;
                 }
 
                 dnext = get_or_advance_reverse_dist(vlelctx, next_vertex_id);
 
-                /*
-                 * dnext == PG_INT64_MAX is checked before the budget
-                 * arithmetic, and short-circuits it via ||, specifically
-                 * to avoid overflowing depth_so_far + 1 + dnext.
-                 */
+                /* Check PG_INT64_MAX first to avoid overflow in budget arithmetic */
                 if (dnext == PG_INT64_MAX ||
                     (!vlelctx->uidx_infinite &&
-                     gid_stack_size(vlelctx->dfs_path_stack) + 1 + dnext >
-                         vlelctx->uidx))
-                {
+                     gid_stack_size(vlelctx->dfs_path_stack) + 1 + dnext > vlelctx->uidx))
                     continue;
-                }
             }
 
-            /*
-             * We need to maintain our source vertex for each edge added if
-             * the edge_direction is CYPHER_REL_DIR_NONE. This is due to the
-             * edges having a fixed direction and the dfs algorithm working
-             * strictly through edges. With an un-directional VLE edge, you
-             * don't know the vertex that you just came from. So, we need to
-             * store it.
-             */
+            /* Track source vertex for undirected traversal */
             if (vlelctx->edge_direction == CYPHER_REL_DIR_NONE)
-            {
                 gid_stack_push(vertex_stack, vertex_id);
-            }
+
             gid_stack_push(edge_stack, edge_id);
-            /*
-             * This edge_id now has a live, unpopped occurrence on
-             * dfs_edge_stack. pin_count protects its edge_state_entry
-             * from eviction until every such occurrence is popped again
-             * (see the struct comment on edge_state_entry) -- vertices
-             * can be revisited, so the SAME edge_id can end up pushed
-             * more than once while an older copy is still buried deeper
-             * in the stack.
-             */
-            EDGE_STATE_ENTRY_PIN_COUNT_INC(ese);
+            EDGE_STATE_ENTRY_PIN_COUNT_INC(ese); /* Protects entry from eviction */
+
             Assert(vlelctx->edge_direction != CYPHER_REL_DIR_NONE ||
                    gid_stack_size(vertex_stack) == gid_stack_size(edge_stack));
         }
     }
 }
-
 /*
  * Helper function to create the VLE path container that holds the graphid array
  * containing the found path. The path_size is the total number of vertices and

--- a/src/backend/utils/adt/age_vle.c
+++ b/src/backend/utils/adt/age_vle.c
@@ -91,6 +91,28 @@ typedef struct edge_state_entry
     bool used_in_path;             /* like visited but more descriptive */
     bool has_been_matched;         /* have we checked for a  match */
     bool matched;                  /* is it a match */
+    /*
+     * Topology cache, populated once (alongside has_been_matched/matched)
+     * the first time this edge is classified in add_valid_vertex_edges().
+     * Both endpoints are cached -- NOT a single pre-resolved "next vertex" --
+     * because for CYPHER_REL_DIR_NONE the correct next vertex depends on
+     * which endpoint the DFS is currently standing on, which can differ
+     * between the first time an edge is classified and a later, unrelated
+     * point in the same traversal where it is approached from the other
+     * side. See get_next_vertex_from_state() for the direction-resolution
+     * logic, which mirrors get_next_vertex() but reads from this cache
+     * instead of re-fetching the edge_entry.
+     *
+     * Valid if and only if has_been_matched is true. Zeroed (not left
+     * uninitialized) on a fresh entry in get_edge_state_with_hash(): they
+     * are only ever read once has_been_matched is true (asserted in
+     * get_next_vertex_from_state() for cassert builds), but zeroing means
+     * any accidental early read in a production build resolves to graphid
+     * 0 -- which cannot be a real vertex id -- instead of uninitialized
+     * palloc'd memory.
+     */
+    graphid start_vertex_id;
+    graphid end_vertex_id;
 } edge_state_entry;
 
 /*
@@ -208,6 +230,8 @@ static bool do_vsid_and_veid_exist(VLE_local_context *vlelctx);
 static void add_valid_vertex_edges(VLE_local_context *vlelctx,
                                    graphid vertex_id);
 static graphid get_next_vertex(VLE_local_context *vlelctx, edge_entry *ee);
+static graphid get_next_vertex_from_state(VLE_local_context *vlelctx,
+                                          edge_state_entry *ese);
 static bool is_edge_in_path(VLE_local_context *vlelctx, graphid edge_id);
 /* VLE path and edge building functions */
 static VLE_path_container *create_VLE_path_container(int64 path_size);
@@ -971,6 +995,19 @@ static edge_state_entry *get_edge_state_with_hash(VLE_local_context *vlelctx,
         ese->used_in_path = false;
         ese->has_been_matched = false;
         ese->matched = false;
+        /*
+         * start_vertex_id/end_vertex_id are only ever read once
+         * has_been_matched is true -- see get_next_vertex_from_state(),
+         * which also Assert()s that precondition for cassert builds. Zero
+         * them here anyway (rather than leaving them as whatever garbage
+         * hash_search_with_hash_value's palloc happened to return) so that
+         * any accidental early read in a production (non-cassert) build
+         * resolves deterministically to graphid 0 -- which cannot be a
+         * real vertex id -- instead of silently "succeeding" with
+         * plausible-looking uninitialized bytes.
+         */
+        ese->start_vertex_id = 0;
+        ese->end_vertex_id = 0;
     }
     return ese;
 }
@@ -1031,6 +1068,73 @@ static graphid get_next_vertex(VLE_local_context *vlelctx, edge_entry *ee)
 }
 
 /*
+ * Cache-based counterpart to get_next_vertex(). Resolves the vertex the DFS
+ * moves to when it takes edge `ese`, using only start_vertex_id/end_vertex_id
+ * already cached on the edge_state_entry -- no edge_entry lookup required.
+ *
+ * Precondition: ese->has_been_matched must be true (guaranteed for any edge
+ * that ever reaches the DFS hot loop, since only matched edges are ever
+ * pushed onto dfs_edge_stack -- see add_valid_vertex_edges()).
+ *
+ * Mirrors get_next_vertex()'s branching exactly; see that function's
+ * comments for why CYPHER_REL_DIR_NONE must consult the vertex stack (the
+ * next vertex for an undirected edge depends on which endpoint the DFS is
+ * currently standing on, not on the edge alone).
+ */
+static graphid get_next_vertex_from_state(VLE_local_context *vlelctx,
+                                          edge_state_entry *ese)
+{
+    Assert(ese->has_been_matched);
+
+    switch (vlelctx->edge_direction)
+    {
+        case CYPHER_REL_DIR_RIGHT:
+            return ese->end_vertex_id;
+
+        case CYPHER_REL_DIR_LEFT:
+            return ese->start_vertex_id;
+
+        case CYPHER_REL_DIR_NONE:
+        {
+            graphid parent_vertex_id;
+
+            /*
+             * The whole vertex-stack scheme for CYPHER_REL_DIR_NONE relies
+             * on dfs_vertex_stack and dfs_edge_stack staying in lockstep
+             * (one vertex pushed/popped per edge pushed/popped -- see
+             * add_valid_vertex_edges() and the backtracking branches in
+             * dfs_find_a_path_between()/dfs_find_a_path_from()). Cheap
+             * enough to check on every step in cassert builds, and it
+             * would catch a future refactor breaking that invariant
+             * immediately instead of manifesting as a confusing
+             * "get_next_vertex_from_state: no parent match" error (or
+             * worse, a wrong-but-plausible path) far away from the bug.
+             */
+            Assert(gid_stack_size(vlelctx->dfs_vertex_stack) ==
+                   gid_stack_size(vlelctx->dfs_edge_stack));
+
+            parent_vertex_id = gid_stack_peek(vlelctx->dfs_vertex_stack);
+
+            if (ese->start_vertex_id == parent_vertex_id)
+            {
+                return ese->end_vertex_id;
+            }
+            else if (ese->end_vertex_id == parent_vertex_id)
+            {
+                return ese->start_vertex_id;
+            }
+
+            elog(ERROR, "get_next_vertex_from_state: no parent match");
+        }
+
+        default:
+            elog(ERROR, "get_next_vertex_from_state: unknown edge direction");
+    }
+
+    return 0; /* unreachable; silences compiler control-reaches-end warning */
+}
+
+/*
  * Helper function to find one path BETWEEN two vertices.
  *
  * Note: On the very first entry into this function, the starting vertex's edges
@@ -1063,7 +1167,6 @@ static bool dfs_find_a_path_between(VLE_local_context *vlelctx)
         graphid edge_id;
         graphid next_vertex_id;
         edge_state_entry *ese = NULL;
-        edge_entry *ee = NULL;
         bool found = false;
         uint32 edge_hashvalue;
 
@@ -1078,9 +1181,8 @@ static bool dfs_find_a_path_between(VLE_local_context *vlelctx)
         /* get an edge, but leave it on the stack for now */
         edge_id = gid_stack_peek(edge_stack);
         /*
-         * Compute the hash for edge_id once and reuse it for both the
-         * edge_state_hashtable lookup and (later) the edge_hashtable lookup.
-         * Both tables key on graphid using graphid_hash().
+         * Compute the hash for edge_id once and reuse it for the
+         * edge_state_hashtable lookup.
          */
         edge_hashvalue = graphid_hash(&edge_id, sizeof(int64));
         /* get the edge's state */
@@ -1120,6 +1222,8 @@ static bool dfs_find_a_path_between(VLE_local_context *vlelctx)
             {
                 gid_stack_pop(vertex_stack);
             }
+            Assert(vlelctx->edge_direction != CYPHER_REL_DIR_NONE ||
+                   gid_stack_size(vertex_stack) == gid_stack_size(edge_stack));
             /* move to the next edge */
             continue;
         }
@@ -1131,9 +1235,12 @@ static bool dfs_find_a_path_between(VLE_local_context *vlelctx)
         ese->used_in_path = true;
         gid_stack_push(path_stack, edge_id);
 
-        /* now get the edge entry so we can get the next vertex to move to */
-        ee = get_edge_entry_with_hash(vlelctx->ggctx, edge_id, edge_hashvalue);
-        next_vertex_id = get_next_vertex(vlelctx, ee);
+        /*
+         * Resolve the next vertex directly from the cache populated by
+         * add_valid_vertex_edges() when this edge was first classified.
+         * No edge_entry lookup needed here.
+         */
+        next_vertex_id = get_next_vertex_from_state(vlelctx, ese);
 
         /*
          * Is this the end of a path that meets our requirements? Is its length
@@ -1206,7 +1313,6 @@ static bool dfs_find_a_path_from(VLE_local_context *vlelctx)
         graphid edge_id;
         graphid next_vertex_id;
         edge_state_entry *ese = NULL;
-        edge_entry *ee = NULL;
         bool found = false;
         uint32 edge_hashvalue;
 
@@ -1221,9 +1327,8 @@ static bool dfs_find_a_path_from(VLE_local_context *vlelctx)
         /* get an edge, but leave it on the stack for now */
         edge_id = gid_stack_peek(edge_stack);
         /*
-         * Compute the hash for edge_id once and reuse it for both the
-         * edge_state_hashtable lookup and (later) the edge_hashtable lookup.
-         * Both tables key on graphid using graphid_hash().
+         * Compute the hash for edge_id once and reuse it for the
+         * edge_state_hashtable lookup.
          */
         edge_hashvalue = graphid_hash(&edge_id, sizeof(int64));
         /* get the edge's state */
@@ -1263,6 +1368,8 @@ static bool dfs_find_a_path_from(VLE_local_context *vlelctx)
             {
                 gid_stack_pop(vertex_stack);
             }
+            Assert(vlelctx->edge_direction != CYPHER_REL_DIR_NONE ||
+                   gid_stack_size(vertex_stack) == gid_stack_size(edge_stack));
             /* move to the next edge */
             continue;
         }
@@ -1274,9 +1381,12 @@ static bool dfs_find_a_path_from(VLE_local_context *vlelctx)
         ese->used_in_path = true;
         gid_stack_push(path_stack, edge_id);
 
-        /* now get the edge entry so we can get the next vertex to move to */
-        ee = get_edge_entry_with_hash(vlelctx->ggctx, edge_id, edge_hashvalue);
-        next_vertex_id = get_next_vertex(vlelctx, ee);
+        /*
+         * Resolve the next vertex directly from the cache populated by
+         * add_valid_vertex_edges() when this edge was first classified.
+         * No edge_entry lookup needed here.
+         */
+        next_vertex_id = get_next_vertex_from_state(vlelctx, ese);
 
         /*
          * Is this a path that meets our requirements? Is its length within the
@@ -1519,20 +1629,21 @@ static void add_valid_vertex_edges(VLE_local_context *vlelctx,
                 continue;
             }
 
-            /* validate the edge if it hasn't been already */
-            if (!ese->has_been_matched && is_an_edge_match(vlelctx, ee))
+            /*
+             * Validate the edge if it hasn't been already. Cache the edge
+             * endpoints at the same time, so the DFS can resolve the next
+             * vertex without another edge_entry lookup.
+             */
+            if (!ese->has_been_matched)
             {
                 ese->has_been_matched = true;
-                ese->matched = true;
-            }
-            else if (!ese->has_been_matched)
-            {
-                ese->has_been_matched = true;
-                ese->matched = false;
+                ese->matched = is_an_edge_match(vlelctx, ee);
+                ese->start_vertex_id = get_edge_entry_start_vertex_id(ee);
+                ese->end_vertex_id = get_edge_entry_end_vertex_id(ee);
             }
 
             /* if it is a match, add it */
-            if (ese->has_been_matched && ese->matched)
+            if (ese->matched)
             {
                 /*
                  * We need to maintain our source vertex for each edge
@@ -1547,6 +1658,8 @@ static void add_valid_vertex_edges(VLE_local_context *vlelctx,
                     gid_stack_push(vertex_stack, get_vertex_entry_id(ve));
                 }
                 gid_stack_push(edge_stack, edge_id);
+                Assert(vlelctx->edge_direction != CYPHER_REL_DIR_NONE ||
+                       gid_stack_size(vertex_stack) == gid_stack_size(edge_stack));
             }
         }
     }

--- a/src/backend/utils/adt/age_vle.c
+++ b/src/backend/utils/adt/age_vle.c
@@ -93,7 +93,7 @@ typedef struct edge_state_entry
     bool matched;                  /* is it a match */
     /*
      * Topology cache, populated once (alongside has_been_matched/matched)
-     * the first time this edge is classified in add_valid_vertex_edges().
+     * the first time this edge is classified in get_or_build_vertex_edge_cache().
      * Both endpoints are cached -- NOT a single pre-resolved "next vertex" --
      * because for CYPHER_REL_DIR_NONE the correct next vertex depends on
      * which endpoint the DFS is currently standing on, which can differ
@@ -114,6 +114,28 @@ typedef struct edge_state_entry
     graphid start_vertex_id;
     graphid end_vertex_id;
 } edge_state_entry;
+
+/*
+ * Vertex-level cache of statically-valid adjacent edges (see
+ * get_or_build_vertex_edge_cache). "Statically valid" means the edge passed
+ * is_an_edge_match() -- it says nothing about whether the edge is currently
+ * usable in the DFS (that is path-dependent and re-checked on every visit
+ * by add_valid_vertex_edges()).
+ */
+typedef struct vertex_edge_cache_entry
+{
+    graphid vertex_id;              /* vertex id, it is also the hash key */
+    int32 nvalid;                   /* number of entries in valid_edges */
+    graphid *valid_edges;           /* palloc'd array (in
+                                      * vlelctx->vertex_edge_cache_mcxt) of
+                                      * edge ids that passed is_an_edge_match
+                                      * for this vertex, in the same relative
+                                      * order they were discovered (out, then
+                                      * in, then self). Sized to exactly
+                                      * nvalid, not to the raw adjacency
+                                      * count -- see the repalloc in
+                                      * get_or_build_vertex_edge_cache(). */
+} vertex_edge_cache_entry;
 
 /*
  * VLE_path_function is an enum for the path function to use. This currently can
@@ -147,6 +169,32 @@ typedef struct VLE_local_context
     bool uidx_infinite;            /* flag if the upper bound is omitted */
     cypher_rel_dir edge_direction; /* the direction of the edge */
     HTAB *edge_state_hashtable;    /* local state hashtable for our edges */
+    HTAB *vertex_edge_cache;       /* vertex_id -> statically-valid adjacent
+                                     * edges (see get_or_build_vertex_edge_cache) */
+    MemoryContext vertex_edge_cache_mcxt; /* Dedicated child context, created
+                                     * explicitly in
+                                     * create_VLE_local_state_hashtable() and
+                                     * deleted explicitly in
+                                     * free_VLE_local_context(). Owns every
+                                     * valid_edges[] array pointed to from
+                                     * vertex_edge_cache entries above.
+                                     *
+                                     * Deliberately NOT "whatever
+                                     * CurrentMemoryContext happens to be" --
+                                     * this context is created once, up
+                                     * front, specifically for this purpose,
+                                     * so its lifetime does not depend on
+                                     * which of this file's several call
+                                     * sites is building this
+                                     * VLE_local_context (the LRU-cached
+                                     * TopMemoryContext path, the uncached
+                                     * multi_call_memory_ctx SRF path, or
+                                     * sp_minhops_fallback()'s private
+                                     * scratch context all do the right
+                                     * thing automatically, because we just
+                                     * parent off whatever CurrentMemoryContext
+                                     * is *once*, at creation, and then own
+                                     * deletion of our own child ourselves). */
     GraphIdStack *dfs_vertex_stack; /* dfs stack for vertices (array-based) */
     GraphIdStack *dfs_edge_stack;   /* dfs stack for edges (array-based) */
     GraphIdStack *dfs_path_stack;   /* dfs stack containing the path (array-based) */
@@ -232,6 +280,9 @@ static void add_valid_vertex_edges(VLE_local_context *vlelctx,
 static graphid get_next_vertex(VLE_local_context *vlelctx, edge_entry *ee);
 static graphid get_next_vertex_from_state(VLE_local_context *vlelctx,
                                           edge_state_entry *ese);
+static vertex_edge_cache_entry *get_or_build_vertex_edge_cache(
+                                                    VLE_local_context *vlelctx,
+                                                    graphid vertex_id);
 static bool is_edge_in_path(VLE_local_context *vlelctx, graphid edge_id);
 /* VLE path and edge building functions */
 static VLE_path_container *create_VLE_path_container(int64 path_size);
@@ -423,6 +474,48 @@ static void create_VLE_local_state_hashtable(VLE_local_context *vlelctx)
                                                 &edge_state_ctl,
                                                 HASH_ELEM | HASH_FUNCTION);
     pfree_if_not_null(eshn);
+
+    /*
+     * Create a dedicated child context to own every valid_edges[] array
+     * that will ever be allocated by get_or_build_vertex_edge_cache().
+     *
+     * We deliberately do NOT just capture CurrentMemoryContext into a bare
+     * MemoryContext field and palloc directly into it: this function is
+     * called from three different sites (the LRU-cached path in
+     * build_local_vle_context(), which runs under TopMemoryContext; the
+     * uncached SRF path, which runs under funcctx->multi_call_memory_ctx;
+     * and sp_minhops_fallback(), which runs under its own private scratch
+     * context). All three currently do the right thing, but relying on
+     * "whichever context the caller happened to switch to before calling
+     * in here" is exactly the kind of ambient-context assumption that
+     * silently breaks under refactoring. Creating our OWN child context
+     * here means its lifetime is entirely our responsibility, symmetric
+     * with hash_destroy() below: we explicitly MemoryContextDelete() it in
+     * free_VLE_local_context(), the same way hash_destroy() explicitly
+     * frees edge_state_hashtable's storage. Correctness no longer depends
+     * on what CurrentMemoryContext happens to be, here or at any future
+     * call site -- we still parent off it (so it is reclaimed for free if
+     * an ancestor context is ever deleted first, e.g. via
+     * sp_minhops_fallback()'s MemoryContextDelete(tmpctx)), but we never
+     * depend on that parent to be the one doing the cleanup.
+     */
+    vlelctx->vertex_edge_cache_mcxt = AllocSetContextCreate(CurrentMemoryContext,
+                                                            "VLE vertex edge cache",
+                                                            ALLOCSET_DEFAULT_SIZES);
+
+    /* initialize the per-vertex valid-edge cache (see get_or_build_vertex_edge_cache) */
+    {
+        HASHCTL vertex_edge_ctl;
+
+        MemSet(&vertex_edge_ctl, 0, sizeof(vertex_edge_ctl));
+        vertex_edge_ctl.keysize = sizeof(int64);
+        vertex_edge_ctl.entrysize = sizeof(vertex_edge_cache_entry);
+        vertex_edge_ctl.hash = graphid_hash;
+        vlelctx->vertex_edge_cache = hash_create("VLE vertex edge cache",
+                                                 EDGE_STATE_HTAB_INITIAL_SIZE,
+                                                 &vertex_edge_ctl,
+                                                 HASH_ELEM | HASH_FUNCTION);
+    }
 }
 
 /*
@@ -580,6 +673,32 @@ static void free_VLE_local_context(VLE_local_context *vlelctx)
     /* we need to free our state hashtable */
     hash_destroy(vlelctx->edge_state_hashtable);
     vlelctx->edge_state_hashtable = NULL;
+
+    /*
+     * Free the vertex edge cache's own hashtable storage (its entries --
+     * fixed-size vertex_edge_cache_entry structs, held in dynahash's own
+     * private child context). This does NOT free the valid_edges[] arrays
+     * those entries point to.
+     */
+    if (vlelctx->vertex_edge_cache != NULL)
+    {
+        hash_destroy(vlelctx->vertex_edge_cache);
+        vlelctx->vertex_edge_cache = NULL;
+    }
+
+    /*
+     * Explicitly delete the dedicated context that owns every valid_edges[]
+     * array. This is what actually reclaims that memory -- hash_destroy()
+     * above never touches it. Symmetric, on purpose, with the hash_destroy()
+     * calls: every allocator this function uses gets an explicit, owned
+     * teardown call here, none of them are left to an ambient parent
+     * context to clean up "eventually".
+     */
+    if (vlelctx->vertex_edge_cache_mcxt != NULL)
+    {
+        MemoryContextDelete(vlelctx->vertex_edge_cache_mcxt);
+        vlelctx->vertex_edge_cache_mcxt = NULL;
+    }
 
     /*
      * Free the DFS stacks. When is_dirty is false, the stacks are in the
@@ -1074,7 +1193,8 @@ static graphid get_next_vertex(VLE_local_context *vlelctx, edge_entry *ee)
  *
  * Precondition: ese->has_been_matched must be true (guaranteed for any edge
  * that ever reaches the DFS hot loop, since only matched edges are ever
- * pushed onto dfs_edge_stack -- see add_valid_vertex_edges()).
+ * pushed onto dfs_edge_stack -- see get_or_build_vertex_edge_cache() and the
+ * push site in add_valid_vertex_edges()).
  *
  * Mirrors get_next_vertex()'s branching exactly; see that function's
  * comments for why CYPHER_REL_DIR_NONE must consult the vertex stack (the
@@ -1237,8 +1357,9 @@ static bool dfs_find_a_path_between(VLE_local_context *vlelctx)
 
         /*
          * Resolve the next vertex directly from the cache populated by
-         * add_valid_vertex_edges() when this edge was first classified.
-         * No edge_entry lookup needed here.
+         * get_or_build_vertex_edge_cache() when this edge was first
+         * classified. No edge_entry lookup needed here -- that lookup
+         * already happened once, ever, per edge, not once per DFS step.
          */
         next_vertex_id = get_next_vertex_from_state(vlelctx, ese);
 
@@ -1383,8 +1504,8 @@ static bool dfs_find_a_path_from(VLE_local_context *vlelctx)
 
         /*
          * Resolve the next vertex directly from the cache populated by
-         * add_valid_vertex_edges() when this edge was first classified.
-         * No edge_entry lookup needed here.
+         * get_or_build_vertex_edge_cache() when this edge was first
+         * classified. No edge_entry lookup needed here.
          */
         next_vertex_id = get_next_vertex_from_state(vlelctx, ese);
 
@@ -1440,16 +1561,6 @@ static bool is_edge_in_path(VLE_local_context *vlelctx, graphid edge_id)
 }
 
 /*
- * Helper function to add in valid vertex edges as part of the dfs path
- * algorithm. What constitutes a valid edge is the following -
- *
- *     1) Edge matches the correct direction specified.
- *     2) Edge is not currently in the path.
- *     3) Edge matches minimum edge properties specified.
- *
- * Note: The vertex must exist.
- */
-/*
  * Batched candidate buffer size for the adjacency lookup pipeline below.
  * 8 was chosen because it comfortably fits within the OoO window and the
  * per-core L1 MSHR count of modern Xeons (12+), so the K back-to-back
@@ -1457,19 +1568,48 @@ static bool is_edge_in_path(VLE_local_context *vlelctx, graphid edge_id)
  */
 #define VLE_LOOKUP_BATCH 8
 
-static void add_valid_vertex_edges(VLE_local_context *vlelctx,
-                                   graphid vertex_id)
+/*
+ * Build (on first visit) or fetch (on every subsequent visit) the static
+ * classification cache for `vertex_id`: the subset of its adjacent edges
+ * that pass is_an_edge_match(), independent of anything path-dependent.
+ *
+ * This is the "vertex-level adjacency cache" optimization. It is deliberately
+ * split apart from the DYNAMIC used_in_path/is_edge_in_path check, which
+ * changes constantly as the DFS advances and backtracks and can therefore
+ * never be cached at the vertex level -- only the *static* match result can.
+ *
+ * On the very first visit to a vertex, this runs the same 5-phase MLP-batched
+ * pipeline that add_valid_vertex_edges used to run on *every* visit: gather,
+ * hash, look up edge_entry (agehash), look up/create edge_state_entry
+ * (dynahash), classify. On every subsequent visit, this is a single dynahash
+ * lookup that returns the already-built array -- the adjacency arrays are
+ * never re-walked, and get_edge_entry_with_hash() (the expensive, L3-miss
+ * prone lookup) is never called again for any edge already classified,
+ * whether it was classified from this vertex or from its other endpoint.
+ *
+ * Note that because this cache lives in vlelctx and, for a grammar-node
+ * backed VLE call (the normal Cypher path -- see build_local_vle_context()'s
+ * use_cache handling), vlelctx itself is reused across many separate
+ * age_vle() SRF invocations (e.g. once per outer-loop row feeding into a
+ * VLE join), this cache's benefit compounds far beyond a single path
+ * enumeration: a vertex visited by row 1's traversal is already fully
+ * classified, for free, if row 2's traversal ever reaches it too. This
+ * also means the cache can grow large over the lifetime of a long-running
+ * backend, which is exactly why vertex_edge_cache_mcxt's lifetime has to be
+ * managed explicitly rather than left to an ambient context -- see
+ * create_VLE_local_state_hashtable() and free_VLE_local_context().
+ *
+ * The returned array and its length are only ever read by the caller
+ * (add_valid_vertex_edges) below; they are never mutated after this
+ * function returns.
+ */
+static vertex_edge_cache_entry *get_or_build_vertex_edge_cache(
+                                                    VLE_local_context *vlelctx,
+                                                    graphid vertex_id)
 {
-    GraphIdStack *vertex_stack = NULL;
-    GraphIdStack *edge_stack = NULL;
+    vertex_edge_cache_entry *vce = NULL;
+    bool found = false;
     vertex_entry *ve = NULL;
-    /*
-     * Three flat-array adjacency lists, walked in parallel via integer
-     * indices. An empty (or direction-disabled) list has size == 0 so its
-     * branch never fires. This replaces the previous GraphIdNode pointer
-     * walk with a contiguous-memory traversal — significantly better for
-     * cache and branch-predictor behaviour on the DFS hot path.
-     */
     graphid *arr_out = NULL;
     int32    sz_out = 0;
     int32    idx_out = 0;
@@ -1480,32 +1620,26 @@ static void add_valid_vertex_edges(VLE_local_context *vlelctx,
     int32    sz_self = 0;
     int32    idx_self = 0;
     VertexEdgeArray *vea = NULL;
+    graphid  *scratch = NULL;
+    int32     nscratch = 0;
+    int32     scratch_cap;
+    MemoryContext oldcontext;
 
-    /*
-     * Per-batch scratch arrays for the MLP lookup pipeline. Each iteration
-     * gathers up to VLE_LOOKUP_BATCH not-already-in-path candidate edges,
-     * then issues their edge_table (agehash) and edge_state_hashtable
-     * (dynahash) lookups in two tight back-to-back loops. The CPU's
-     * out-of-order engine overlaps the K independent cache misses inside
-     * each loop, hiding memory latency that the original one-edge-at-a-time
-     * loop serialized.
-     */
-    graphid           batch_eids[VLE_LOOKUP_BATCH];
-    uint32            batch_hashes[VLE_LOOKUP_BATCH];
-    edge_entry       *batch_ee[VLE_LOOKUP_BATCH];
-    edge_state_entry *batch_ese[VLE_LOOKUP_BATCH];
+    vce = (vertex_edge_cache_entry *) hash_search(vlelctx->vertex_edge_cache,
+                                                  &vertex_id, HASH_ENTER,
+                                                  &found);
+    if (found)
+    {
+        return vce;
+    }
 
     /* get the vertex entry */
     ve = get_vertex_entry(vlelctx->ggctx, vertex_id);
     /* there better be a valid vertex */
     if (ve == NULL)
     {
-        elog(ERROR, "add_valid_vertex_edges: no vertex found");
+        elog(ERROR, "get_or_build_vertex_edge_cache: no vertex found");
     }
-
-    /* point to stacks */
-    vertex_stack = vlelctx->dfs_vertex_stack;
-    edge_stack = vlelctx->dfs_edge_stack;
 
     /* set up walked arrays for the requested direction(s) */
     if (vlelctx->edge_direction == CYPHER_REL_DIR_RIGHT ||
@@ -1527,62 +1661,51 @@ static void add_valid_vertex_edges(VLE_local_context *vlelctx,
     arr_self = vea->array;
     sz_self  = vea->size;
 
+    scratch_cap = sz_out + sz_in + sz_self;
+
     /*
-     * Outer loop: drain the three flat arrays via a 5-phase pipeline.
-     *   1. Gather: pull up to VLE_LOOKUP_BATCH next edge_ids that survive
-     *      the cheap is_edge_in_path() early-skip.
-     *   2. Hash:   compute graphid_hash for the batch (pure compute).
-     *   3. Lookup: K back-to-back edge_table (agehash) lookups via
-     *      get_edge_entry_with_hash() — MLP window 1 (the CPU overlaps
-     *      the K slot misses).
-     *   4. State:  K back-to-back edge_state_hashtable (dynahash) HASH_ENTER
-     *      calls — MLP window 2 (different table, different bucket misses).
-     *   5. Apply:  per-edge match/state-update/stack-push, now operating
-     *      on cache-warm ee/ese pointers.
-     * Phase 5 preserves the exact processing order of the original loop
-     * (out direction first, then in, then self), so DFS stack ordering and
-     * therefore path enumeration are identical to the previous version.
+     * The result array must outlive this SRF call (it is read on every
+     * future visit to this vertex, across many successive age_vle()
+     * invocations), so it must be allocated in
+     * vlelctx->vertex_edge_cache_mcxt, not whatever the ambient
+     * CurrentMemoryContext happens to be here.
+     */
+    oldcontext = MemoryContextSwitchTo(vlelctx->vertex_edge_cache_mcxt);
+    scratch = (scratch_cap > 0) ? palloc(sizeof(graphid) * scratch_cap) : NULL;
+    MemoryContextSwitchTo(oldcontext);
+
+    /*
+     * Same 5-phase MLP-batched pipeline as before (gather/hash/lookup ee/
+     * lookup ese/apply) -- the only change is that it now runs exactly once
+     * per vertex for the lifetime of this VLE_local_context, instead of once
+     * per *visit*. The dynamic used_in_path / is_edge_in_path check is
+     * deliberately NOT done here -- see add_valid_vertex_edges() below.
      */
     while (idx_out < sz_out || idx_in < sz_in || idx_self < sz_self)
     {
+        graphid           batch_eids[VLE_LOOKUP_BATCH];
+        uint32            batch_hashes[VLE_LOOKUP_BATCH];
+        edge_entry       *batch_ee[VLE_LOOKUP_BATCH];
+        edge_state_entry *batch_ese[VLE_LOOKUP_BATCH];
         int batch_n = 0;
         int i;
 
-        /* Phase 1: gather */
+        /* Phase 1: gather (no is_edge_in_path check -- that's dynamic) */
         while (batch_n < VLE_LOOKUP_BATCH &&
                (idx_out < sz_out || idx_in < sz_in || idx_self < sz_self))
         {
-            graphid edge_id;
-
             if (idx_out < sz_out)
             {
-                edge_id = arr_out[idx_out++];
+                batch_eids[batch_n++] = arr_out[idx_out++];
             }
             else if (idx_in < sz_in)
             {
-                edge_id = arr_in[idx_in++];
+                batch_eids[batch_n++] = arr_in[idx_in++];
             }
             else
             {
-                edge_id = arr_self[idx_self++];
+                batch_eids[batch_n++] = arr_self[idx_self++];
             }
-
-            /*
-             * Fast early-skip when the path stack is small: avoids two
-             * hashtable lookups for edges already on the path.
-             */
-            if (gid_stack_size(vlelctx->dfs_path_stack) < 10 &&
-                is_edge_in_path(vlelctx, edge_id))
-            {
-                continue;
-            }
-
-            batch_eids[batch_n++] = edge_id;
-        }
-
-        if (batch_n == 0)
-        {
-            break;
         }
 
         /* Phase 2: compute hashes (pure compute, no misses) */
@@ -1607,18 +1730,160 @@ static void add_valid_vertex_edges(VLE_local_context *vlelctx,
                                                     batch_hashes[i]);
         }
 
-        /* Phase 5: process the batch sequentially */
+        /* Phase 5: classify and collect into scratch[] */
         for (i = 0; i < batch_n; i++)
         {
             edge_entry       *ee  = batch_ee[i];
             edge_state_entry *ese = batch_ese[i];
-            graphid           edge_id = batch_eids[i];
 
-            /* it better exist */
             if (ee == NULL)
             {
-                elog(ERROR, "add_valid_vertex_edges: no edge found");
+                elog(ERROR, "get_or_build_vertex_edge_cache: no edge found");
             }
+
+            /*
+             * has_been_matched may already be true here -- this edge could
+             * have been classified earlier via its OTHER endpoint (only
+             * possible for CYPHER_REL_DIR_NONE, where the same edge appears
+             * in both endpoints' adjacency arrays). is_an_edge_match()'s
+             * result depends only on the edge's own label/properties and
+             * this grammar node's constraints -- never on which endpoint
+             * triggered classification -- so it is safe to reuse. Only
+             * classify (and cache start/end) the first time, ever.
+             */
+            if (!ese->has_been_matched)
+            {
+                ese->has_been_matched = true;
+                ese->matched = is_an_edge_match(vlelctx, ee);
+                ese->start_vertex_id = get_edge_entry_start_vertex_id(ee);
+                ese->end_vertex_id = get_edge_entry_end_vertex_id(ee);
+            }
+
+            if (ese->matched)
+            {
+                scratch[nscratch++] = batch_eids[i];
+            }
+        }
+    }
+
+    /*
+     * Shrink to the actual number of statically-valid edges. scratch_cap is
+     * the raw (unfiltered) adjacency count; on a dense graph with a
+     * selective edge predicate nscratch can be far smaller, and this array
+     * lives for the remaining lifetime of vlelctx (potentially the lifetime
+     * of a long-running, cached, reused-across-many-SRF-calls backend --
+     * see the note at the top of this function), so the gap matters.
+     */
+    if (scratch != NULL)
+    {
+        oldcontext = MemoryContextSwitchTo(vlelctx->vertex_edge_cache_mcxt);
+        if (nscratch > 0 && nscratch < scratch_cap)
+        {
+            scratch = repalloc(scratch, sizeof(graphid) * nscratch);
+        }
+        else if (nscratch == 0)
+        {
+            pfree(scratch);
+            scratch = NULL;
+        }
+        MemoryContextSwitchTo(oldcontext);
+    }
+
+    vce->vertex_id = vertex_id;
+    vce->nvalid = nscratch;
+    vce->valid_edges = scratch;
+
+    return vce;
+}
+
+/*
+ * Helper function to add in valid vertex edges as part of the dfs path
+ * algorithm. What constitutes a valid edge is the following -
+ *
+ *     1) Edge matches the correct direction specified.
+ *     2) Edge is not currently in the path.
+ *     3) Edge matches minimum edge properties specified.
+ *
+ * Note: The vertex must exist.
+ *
+ * Static classification (which of this vertex's edges match at all) is
+ * handled by get_or_build_vertex_edge_cache() above and computed at most
+ * once per vertex. This function only re-checks the DYNAMIC used_in_path
+ * state, which must be re-checked on every visit, but now only for the
+ * pre-filtered set of statically-valid edges -- not the full adjacency
+ * list -- and with no edge_entry (agehash) lookups at all on repeat visits.
+ *
+ * The dynamic edge_state_hashtable lookups below are still run through the
+ * same batched gather/hash/lookup/apply pipeline as
+ * get_or_build_vertex_edge_cache() uses, for the same MLP reason: even
+ * though only one hashtable is involved now (not two), a repeat visit to a
+ * hot, highly-connected vertex can still re-check dozens of edges, and
+ * batching the dynahash HASH_ENTER calls hides their miss latency the same
+ * way it did before this vertex's edges were split out of the per-visit
+ * pipeline.
+ */
+static void add_valid_vertex_edges(VLE_local_context *vlelctx,
+                                   graphid vertex_id)
+{
+    GraphIdStack *vertex_stack = vlelctx->dfs_vertex_stack;
+    GraphIdStack *edge_stack = vlelctx->dfs_edge_stack;
+    vertex_edge_cache_entry *vce;
+    int32 pos = 0;
+
+    vce = get_or_build_vertex_edge_cache(vlelctx, vertex_id);
+
+    while (pos < vce->nvalid)
+    {
+        graphid           batch_eids[VLE_LOOKUP_BATCH];
+        uint32            batch_hashes[VLE_LOOKUP_BATCH];
+        edge_state_entry *batch_ese[VLE_LOOKUP_BATCH];
+        int batch_n = 0;
+        int i;
+
+        /* Phase 1: gather, applying the dynamic is_edge_in_path early-skip */
+        while (batch_n < VLE_LOOKUP_BATCH && pos < vce->nvalid)
+        {
+            graphid edge_id = vce->valid_edges[pos++];
+
+            /*
+             * Fast early-skip when the path stack is small: avoids an
+             * edge_state_hashtable lookup for edges already on the path.
+             * (Kept exactly as before -- for the common, small-stack case
+             * this bounded linear scan beats a hashtable lookup.)
+             */
+            if (gid_stack_size(vlelctx->dfs_path_stack) < 10 &&
+                is_edge_in_path(vlelctx, edge_id))
+            {
+                continue;
+            }
+
+            batch_eids[batch_n++] = edge_id;
+        }
+
+        if (batch_n == 0)
+        {
+            continue;
+        }
+
+        /* Phase 2: compute hashes (pure compute, no misses) */
+        for (i = 0; i < batch_n; i++)
+        {
+            batch_hashes[i] = graphid_hash(&batch_eids[i], sizeof(int64));
+        }
+
+        /* Phase 3: K back-to-back edge_state_hashtable lookups (MLP wave) */
+        for (i = 0; i < batch_n; i++)
+        {
+            batch_ese[i] = get_edge_state_with_hash(vlelctx,
+                                                    batch_eids[i],
+                                                    batch_hashes[i]);
+        }
+
+        /* Phase 4: apply, in the same order the edges were discovered in */
+        for (i = 0; i < batch_n; i++)
+        {
+            edge_state_entry *ese = batch_ese[i];
+            graphid           edge_id = batch_eids[i];
 
             /*
              * Don't add any edges that we have already seen because they
@@ -1630,37 +1895,20 @@ static void add_valid_vertex_edges(VLE_local_context *vlelctx,
             }
 
             /*
-             * Validate the edge if it hasn't been already. Cache the edge
-             * endpoints at the same time, so the DFS can resolve the next
-             * vertex without another edge_entry lookup.
+             * We need to maintain our source vertex for each edge added if
+             * the edge_direction is CYPHER_REL_DIR_NONE. This is due to the
+             * edges having a fixed direction and the dfs algorithm working
+             * strictly through edges. With an un-directional VLE edge, you
+             * don't know the vertex that you just came from. So, we need to
+             * store it.
              */
-            if (!ese->has_been_matched)
+            if (vlelctx->edge_direction == CYPHER_REL_DIR_NONE)
             {
-                ese->has_been_matched = true;
-                ese->matched = is_an_edge_match(vlelctx, ee);
-                ese->start_vertex_id = get_edge_entry_start_vertex_id(ee);
-                ese->end_vertex_id = get_edge_entry_end_vertex_id(ee);
+                gid_stack_push(vertex_stack, vertex_id);
             }
-
-            /* if it is a match, add it */
-            if (ese->matched)
-            {
-                /*
-                 * We need to maintain our source vertex for each edge
-                 * added if the edge_direction is CYPHER_REL_DIR_NONE. This
-                 * is due to the edges having a fixed direction and the dfs
-                 * algorithm working strictly through edges. With an
-                 * un-directional VLE edge, you don't know the vertex that
-                 * you just came from. So, we need to store it.
-                 */
-                if (vlelctx->edge_direction == CYPHER_REL_DIR_NONE)
-                {
-                    gid_stack_push(vertex_stack, get_vertex_entry_id(ve));
-                }
-                gid_stack_push(edge_stack, edge_id);
-                Assert(vlelctx->edge_direction != CYPHER_REL_DIR_NONE ||
-                       gid_stack_size(vertex_stack) == gid_stack_size(edge_stack));
-            }
+            gid_stack_push(edge_stack, edge_id);
+            Assert(vlelctx->edge_direction != CYPHER_REL_DIR_NONE ||
+                   gid_stack_size(vertex_stack) == gid_stack_size(edge_stack));
         }
     }
 }

--- a/src/include/utils/age_vle.h
+++ b/src/include/utils/age_vle.h
@@ -46,4 +46,9 @@ agtype_value *agtv_materialize_vle_path(agtype *agt_arg_vpc);
  */
 agtype_value *agtv_materialize_vle_edges(agtype *agt_arg_vpc);
 
+/*
+ * Register the VLE GUC variables.
+ */
+void vle_define_guc_variables(void);
+
 #endif


### PR DESCRIPTION
# VLE: cache edge/vertex classification and prune PATHS_BETWEEN via reverse BFS

## Problem

`dfs_find_a_path_between()` (`PATHS_BETWEEN` / `shortestPath`-style `[:REL*min..max]`,
both endpoints known) did this on every visit to a vertex, regardless of prior visits:

- **Adjacency re-scanned across every edge label on every visit**, not just the pattern's
  — the graph context carries no label-based pre-filtering. For each edge in that array,
  two hashtable probes (`edge_table`, `edge_state_hashtable`) ran on every visit, even
  though `is_an_edge_match()`'s verdict was already memoized per edge. Cost:
  `O(k · deg_total(v))` instead of `O(deg_total(v) + k · deg_match(v))`.
- **Edge endpoint re-resolved via hashtable lookup on every traversal step**, though
  `start_vertex_id`/`end_vertex_id` are fixed at edge-creation time.
- **No lower bound on remaining distance to target** — a branch that can't reach it within
  the hop budget was walked in full (`O(d^r)`) before backtracking, instead of rejected in
  `O(1)`.

No memory bound on any of the above — a pathological query could grow them unbounded for
the duration of the call.

## Changes

1. Parser: pass a previously-bound target vertex through (was hardcoded `NULL`) — required
   for `PATHS_BETWEEN` classification to ever trigger.
2. Cache edge endpoints in `edge_state_entry` — resolved once, not per traversal step.
3. Cache per-vertex relevant edges (`vertex_edge_cache`) — built once per vertex, skips
   non-matching-label edges on every later visit.
4. Reverse-BFS distance-to-target pruning for `PATHS_BETWEEN` — reject an unreachable
   branch in `O(1)`.
5–6. `edge_state_entry`: remove struct padding; bitpack 3 `bool`s into one `uint8`.
7. GUC-bounded caches + clock eviction (`age.vle_*`); fails open under pressure (never
   wrong, only less pruning).
8. Bug fixes: pointer-vs-size `Assert`, wrong function names in error messages.

No change in visible behavior is expected.

## Results

Env: AMD Ryzen 5 5500U (6c/12t), 16 GiB RAM, boost off, governor=`performance`. PG18
`736d880` vs. vanilla PG18+AGE. SNB graph via `generate_graph.sql` (`gsmall`=SF1,
`gmid`=SF10).

**`ShortestPath_hard`** — `MATCH path=(p1)-[:KNOWS*1..5]-(p2) ... min(length(path))`

| Cluster | C/W | TPS before→after (×) | Latency before→after (×) | Peak mem Δ |
|---|---|---|---|---|
| gsmall | 1/1  | 0.2→10.6 (53.2x)   | 4,737→93.9ms (50.5x)  | 83→89MB (+7%) |
| gsmall | 6/6  | 1.22→62.8 (51.6x)  | 4,752→94.8ms (50.1x)  | 312→340MB (+9%) |
| gsmall | 6/12 | 1.43→78.4 (54.7x)  | 7,643→152.3ms (50.2x) | 558→650MB (+16%) |
| gsmall | 8/16 | 1.45→77.4 (53.4x)  | 9,964→204.6ms (48.7x) | 694→872MB (+26%) |
| gmid   | 1/1  | 0.2→21.1 (105.4x)  | 4,749→47.2ms (100.7x) | 519→422MB (−19%) |
| gmid   | 6/6  | 1.08→105.3 (97.2x) | 5,227→56.8ms (92.1x)  | 2,049→1,473MB (−28%) |
| gmid   | 6/12 | 1.33→128.0 (96.0x) | 8,264→93.1ms (88.7x)  | 3,749→2,705MB (−28%) |
| gmid   | 8/16 | 1.3→126.2 (97.0x)  | 11,004→121.4ms (87.7x)| 4,649→3,509MB (−24%) |

**`Path`** — same pattern, `RETURN path LIMIT 1` (first match, no min aggregation)

| Cluster | C/W | TPS before→after (×) | Latency before→after (×) | Peak mem Δ |
|---|---|---|---|---|
| gsmall | 1/1  | 0.25→47.2 (188.7x)  | 3,861→20.8ms (185.7x) | 84→103MB (+23%) |
| gsmall | 6/6  | 1.23→246.3 (199.7x) | 4,613→24.1ms (191.5x) | 313→411MB (+31%) |
| gsmall | 6/12 | 1.63→329.0 (201.4x) | 6,809→36.3ms (187.5x) | 565→721MB (+28%) |
| gsmall | 8/16 | 1.63→314.7 (192.7x) | 9,003→49.9ms (180.3x) | 708→904MB (+28%) |
| gmid   | 1/1  | 0.22→23.6 (108.9x)  | 4,545→42.1ms (107.9x) | 515→423MB (−18%) |
| gmid   | 6/6  | 1.08→111.5 (103.0x) | 5,181→53.6ms (96.7x)  | 2,042→1,473MB (−28%) |
| gmid   | 6/12 | 1.3→133.5 (102.7x)  | 8,627→89.3ms (96.7x)  | 3,742→2,699MB (−28%) |
| gmid   | 8/16 | 1.15→129.4 (112.5x) | 12,028→121.4ms (99.1x)| 4,536→3,509MB (−23%) |

<img width="1189" height="490" alt="image" src="https://github.com/user-attachments/assets/0d155285-ccfd-46f3-8cdc-d0993f1c4711" />

## Reproduce
[generate_graph.sql](https://github.com/user-attachments/files/31053922/generate_graph.sql)
[shortest_path.sql](https://github.com/user-attachments/files/31053924/shortest_path.sql)
[path.sql](https://github.com/user-attachments/files/31053923/path.sql)

```
psql -d postgres -f generate_graph.sql -v sf=1
pgbench -d postgres -f shortest_path.sql -c 12 -j 6 -T 60 -s 1 -n -P 1
pgbench -d postgres -f path.sql          -c 12 -j 6 -T 60 -s 1 -n -P 1
```

## New GUCs
| GUC | Responsibility |
| --- | --- |
| `age.vle_edge_state_htab_initial_size` | Initial bucket count for the `vle_edge_state` cache, default `16384` |
| `age.vle_vertex_edge_htab_initial_size` | Initial bucket count for the `vertex_edge_cache`, default `1024` |
| `age.vle_edge_state_max_entries` | Soft cap on live entries in the `vle_edge_state` cache before background eviction of unreferenced entries kicks in, default `2000000` |
| `age.vle_vertex_edge_cache_max_entries` | Soft cap on live entries in the `vertex_edge_cache` before background eviction of unreferenced entries kicks in, default `200000` |
| `age.vle_vertex_edge_cache_max_kb` | Soft cap, in kilobytes, on the memory `vertex_edge_cache` adjacency arrays, default `65536` |
| `age.vle_reverse_dist_max_entries` | Cap on the reverse-BFS distance table used to prune PATHS_BETWEEN VLE queries, default `500000` |
| `age.vle_max_cached_contexts` | Maximum number of VLE_local_context objects, default `5` |
| `age.vle_edge_state_eviction_enabled` | Enable clock-style eviction of unreferenced entries in the `vle_edge_state` cache, default `true` |

## AI assistance

Used throughout; no clean split of responsibility is possible to state. All code comments
were AI-generated.
