### PR TITLE
Bound per-row memory in writable clauses

### DIFF
--- a/regress/expected/cypher_merge.out
+++ b/regress/expected/cypher_merge.out
@@ -2231,6 +2231,113 @@ $$) AS (src agtype, last agtype);
  "Anchor" | "Anchor"
 (1 row)
 
+-- Exercise eager MERGE ON CREATE and ON MATCH SET over consecutive rows.
+SELECT * FROM cypher('merge_actions', $$
+  UNWIND [1, 2, 3] AS ident
+  MERGE (n:Batch {id: ident})
+    ON CREATE SET n.payload = {nested: [ident, {active: true}]}
+  RETURN n.id, n.payload
+$$) AS (id agtype, payload agtype);
+ id |              payload              
+----+-----------------------------------
+ 1  | {"nested": [1, {"active": true}]}
+ 2  | {"nested": [2, {"active": true}]}
+ 3  | {"nested": [3, {"active": true}]}
+(3 rows)
+
+SELECT * FROM cypher('merge_actions', $$
+  UNWIND [1, 2, 3] AS ident
+  MERGE (n:Batch {id: ident})
+    ON MATCH SET n.payload = {updated: [ident, false]}
+  RETURN n.id, n.payload
+$$) AS (id agtype, payload agtype);
+ id |         payload         
+----+-------------------------
+ 1  | {"updated": [1, false]}
+ 2  | {"updated": [2, false]}
+ 3  | {"updated": [3, false]}
+(3 rows)
+
+-- Reuse a path created by an earlier input row.
+SELECT * FROM cypher('merge_actions', $$
+  UNWIND [1, 2, 1] AS ident
+  MERGE (n:DedupBatch {
+    id: ident,
+    payload: {nested: [ident]}
+  })
+  RETURN ident, n.id, n.payload
+$$) AS (input agtype, id agtype, payload agtype);
+ input | id |     payload     
+-------+----+-----------------
+ 1     | 1  | {"nested": [1]}
+ 2     | 2  | {"nested": [2]}
+ 1     | 1  | {"nested": [1]}
+(3 rows)
+
+SELECT * FROM cypher('merge_actions', $$
+  MATCH (n:DedupBatch)
+  RETURN count(n)
+$$) AS (count agtype);
+ count 
+-------
+ 2
+(1 row)
+
+-- Reuse a path created by an earlier input row in terminal MERGE.
+SELECT * FROM cypher('merge_actions', $$
+  UNWIND [3, 4, 3] AS ident
+  MERGE (:DedupBatch {
+    id: ident,
+    payload: {nested: [ident]}
+  })
+$$) AS (result agtype);
+ result 
+--------
+(0 rows)
+
+SELECT * FROM cypher('merge_actions', $$
+  MATCH (n:DedupBatch)
+  RETURN count(n)
+$$) AS (count agtype);
+ count 
+-------
+ 4
+(1 row)
+
+-- Exercise repeated duplicate candidates in eager and terminal MERGE.
+SELECT * FROM cypher('merge_actions', $$
+  UNWIND range(1, 1000) AS ident
+  MERGE (n:DedupBatch {
+    id: 20,
+    payload: {nested: [20]}
+  })
+  RETURN count(n)
+$$) AS (count agtype);
+ count 
+-------
+ 1000
+(1 row)
+
+SELECT * FROM cypher('merge_actions', $$
+  UNWIND range(1, 1000) AS ident
+  MERGE (:DedupBatch {
+    id: 21,
+    payload: {nested: [21]}
+  })
+$$) AS (result agtype);
+ result 
+--------
+(0 rows)
+
+SELECT * FROM cypher('merge_actions', $$
+  MATCH (n:DedupBatch)
+  RETURN count(n)
+$$) AS (count agtype);
+ count 
+-------
+ 6
+(1 row)
+
 -- cleanup
 SELECT * FROM cypher('merge_actions', $$ MATCH (n) DETACH DELETE n $$) AS (a agtype);
  a 
@@ -2241,12 +2348,14 @@ SELECT * FROM cypher('merge_actions', $$ MATCH (n) DETACH DELETE n $$) AS (a agt
 -- delete graphs
 --
 SELECT drop_graph('merge_actions', true);
-NOTICE:  drop cascades to 5 other objects
+NOTICE:  drop cascades to 7 other objects
 DETAIL:  drop cascades to table merge_actions._ag_label_vertex
 drop cascades to table merge_actions._ag_label_edge
 drop cascades to table merge_actions."Person"
 drop cascades to table merge_actions."KNOWS"
 drop cascades to table merge_actions."on"
+drop cascades to table merge_actions."Batch"
+drop cascades to table merge_actions."DedupBatch"
 NOTICE:  graph "merge_actions" has been dropped
  drop_graph 
 ------------

--- a/regress/expected/generated_columns.out
+++ b/regress/expected/generated_columns.out
@@ -104,6 +104,58 @@ SELECT category, properties FROM generated_columns."Product" ORDER BY category N
           | {"type": "no-cat"}
 (3 rows)
 
+-- Exercise generated columns through multi-row CREATE, SET, and MERGE.
+SELECT * FROM cypher('generated_columns', $$
+    UNWIND ['batch-a', 'batch-b', 'batch-c'] AS category
+    CREATE (p:Product {category: category, batch: 'create'})
+    RETURN count(p)
+$$) AS (count agtype);
+ count 
+-------
+ 3
+(1 row)
+
+SELECT * FROM cypher('generated_columns', $$
+    MATCH (p:Product)
+    SET p.checked = true
+    RETURN count(p)
+$$) AS (count agtype);
+ count 
+-------
+ 6
+(1 row)
+
+SELECT * FROM cypher('generated_columns', $$
+    UNWIND ['merge-a', 'merge-b', 'merge-c'] AS category
+    MERGE (p:Product {category: category})
+      ON CREATE SET p.batch = 'merge-create'
+    RETURN count(p)
+$$) AS (count agtype);
+ count 
+-------
+ 3
+(1 row)
+
+SELECT * FROM cypher('generated_columns', $$
+    UNWIND ['merge-a', 'merge-b', 'merge-c'] AS category
+    MERGE (p:Product {category: category})
+      ON MATCH SET p.batch = 'merge-match'
+    RETURN count(p)
+$$) AS (count agtype);
+ count 
+-------
+ 3
+(1 row)
+
+SELECT count(*) AS rows,
+       bool_and(category IS NOT DISTINCT FROM
+                agtype_access_operator(properties, '"category"')::varchar(25)) AS synchronized
+FROM generated_columns."Product";
+ rows | synchronized 
+------+--------------
+   12 | t
+(1 row)
+
 --
 -- GENERATED ALWAYS ... STORED column on an edge label
 --
@@ -123,7 +175,7 @@ SELECT * FROM cypher('generated_columns', $$
 $$) AS (r agtype);
                                                                    r                                                                    
 ----------------------------------------------------------------------------------------------------------------------------------------
- {"id": 1125899906842625, "label": "REL", "end_id": 844424930131973, "start_id": 844424930131972, "properties": {"kind": "link"}}::edge
+ {"id": 1125899906842625, "label": "REL", "end_id": 844424930131982, "start_id": 844424930131981, "properties": {"kind": "link"}}::edge
 (1 row)
 
 SELECT kind FROM generated_columns."REL";
@@ -203,17 +255,105 @@ FROM generated_columns."T";
  t
 (1 row)
 
+-- Exercise SET and DELETE on stored and virtual generated columns.
+SELECT create_vlabel('generated_columns', 'DeleteStored');
+NOTICE:  VLabel "DeleteStored" has been created
+ create_vlabel 
+---------------
+ 
+(1 row)
+
+ALTER TABLE generated_columns."DeleteStored"
+    ADD COLUMN marker integer GENERATED ALWAYS AS (1) STORED;
+SELECT * FROM cypher('generated_columns', $$
+    UNWIND [1, 2, 3] AS ident
+    CREATE (n:DeleteStored {id: ident})
+    RETURN count(n)
+$$) AS (count agtype);
+ count 
+-------
+ 3
+(1 row)
+
+SELECT * FROM cypher('generated_columns', $$
+    MATCH (n:DeleteStored)
+    DELETE n
+$$) AS (n agtype);
+ n 
+---
+(0 rows)
+
+SELECT count(*) FROM generated_columns."DeleteStored";
+ count 
+-------
+     0
+(1 row)
+
+SELECT create_vlabel('generated_columns', 'DeleteVirtual');
+NOTICE:  VLabel "DeleteVirtual" has been created
+ create_vlabel 
+---------------
+ 
+(1 row)
+
+ALTER TABLE generated_columns."DeleteVirtual"
+    ADD COLUMN marker integer GENERATED ALWAYS AS (1) VIRTUAL;
+SELECT * FROM cypher('generated_columns', $$
+    UNWIND [1, 2, 3] AS ident
+    CREATE (n:DeleteVirtual {id: ident})
+    RETURN count(n)
+$$) AS (count agtype);
+ count 
+-------
+ 3
+(1 row)
+
+SELECT * FROM cypher('generated_columns', $$
+    MATCH (n:DeleteVirtual)
+    SET n.checked = true
+    RETURN count(n)
+$$) AS (count agtype);
+ count 
+-------
+ 3
+(1 row)
+
+SELECT bool_and(marker = 1) AS virtual_ok
+FROM generated_columns."DeleteVirtual";
+ virtual_ok 
+------------
+ t
+(1 row)
+
+SELECT * FROM cypher('generated_columns', $$
+    MATCH (n:DeleteVirtual)
+    DELETE n
+    RETURN count(n)
+$$) AS (count agtype);
+ count 
+-------
+ 3
+(1 row)
+
+SELECT count(*) FROM generated_columns."DeleteVirtual";
+ count 
+-------
+     0
+(1 row)
+
 --
 -- Cleanup
 --
 SELECT drop_graph('generated_columns', true);
-NOTICE:  drop cascades to 6 other objects
+NOTICE:  drop cascades to 8 other objects
 DETAIL:  drop cascades to table generated_columns._ag_label_vertex
 drop cascades to table generated_columns._ag_label_edge
 drop cascades to table generated_columns."Product"
 drop cascades to table generated_columns."REL"
 drop cascades to table generated_columns."Plain"
 drop cascades to table generated_columns."T"
+drop cascades to table generated_columns."DeleteStored"
+drop cascades to table generated_columns."DeleteVirtual"
 NOTICE:  graph "generated_columns" has been dropped
  drop_graph 
 ------------

--- a/regress/expected/security.out
+++ b/regress/expected/security.out
@@ -1440,6 +1440,91 @@ $$) AS (since agtype);
 -------
 (0 rows)
 
+-- Exercise function-based edge RLS through the default endpoint indexes.
+SELECT * FROM cypher('rls_graph', $$
+    CREATE (:Person {name: 'DetachFnIndexHub', owner: 'rls_user1', department: 'DetachFn'})
+$$) AS (a agtype);
+ a 
+---
+(0 rows)
+
+SELECT * FROM cypher('rls_graph', $$
+    MATCH (hub:Person {name: 'DetachFnIndexHub'})
+    UNWIND range(1, 16) AS ident
+    CREATE (hub)-[:KNOWS {owner: 'rls_user1'}]->
+           (:Person {owner: 'rls_user1', department: 'DetachFn', leaf: ident})
+$$) AS (a agtype);
+ a 
+---
+(0 rows)
+
+SET ROLE rls_user1;
+SELECT * FROM cypher('rls_graph', $$
+    MATCH (p:Person {name: 'DetachFnIndexHub'}) DETACH DELETE p
+$$) AS (a agtype);
+ a 
+---
+(0 rows)
+
+RESET ROLE;
+SELECT * FROM cypher('rls_graph', $$
+    MATCH ()-[k:KNOWS]->() WHERE k.owner = 'rls_user1' RETURN count(k)
+$$) AS (count agtype);
+ count 
+-------
+ 0
+(1 row)
+
+-- Drop the endpoint indexes to exercise the connected-edge sequential scan.
+DO $$
+DECLARE
+    index_to_drop regclass;
+BEGIN
+    FOR index_to_drop IN
+        SELECT indexrelid
+        FROM pg_index
+        WHERE indrelid = 'rls_graph."KNOWS"'::regclass
+          AND indnatts = 1
+          AND indkey[0] IN (2, 3)
+    LOOP
+        EXECUTE format('DROP INDEX %s', index_to_drop);
+    END LOOP;
+END
+$$;
+SELECT * FROM cypher('rls_graph', $$
+    CREATE (:Person {name: 'DetachFnSeqHub', owner: 'rls_user1', department: 'DetachFn'})
+$$) AS (a agtype);
+ a 
+---
+(0 rows)
+
+SELECT * FROM cypher('rls_graph', $$
+    MATCH (hub:Person {name: 'DetachFnSeqHub'})
+    UNWIND range(1, 16) AS ident
+    CREATE (hub)-[:KNOWS {owner: 'rls_user1'}]->
+           (:Person {owner: 'rls_user1', department: 'DetachFn', seq_leaf: ident})
+$$) AS (a agtype);
+ a 
+---
+(0 rows)
+
+SET ROLE rls_user1;
+SELECT * FROM cypher('rls_graph', $$
+    MATCH (p:Person {name: 'DetachFnSeqHub'}) DETACH DELETE p
+$$) AS (a agtype);
+ a 
+---
+(0 rows)
+
+RESET ROLE;
+SELECT * FROM cypher('rls_graph', $$
+    MATCH ()-[k:KNOWS]->() WHERE k.owner = 'rls_user1' RETURN count(k)
+$$) AS (count agtype);
+ count 
+-------
+ 0
+(1 row)
+
 -- cleanup
 DROP POLICY detach_fn_knows_owner ON rls_graph."KNOWS";
 DROP POLICY detach_fn_person_all ON rls_graph."Person";

--- a/regress/sql/cypher_merge.sql
+++ b/regress/sql/cypher_merge.sql
@@ -1085,6 +1085,73 @@ SELECT * FROM cypher('merge_actions', $$
   RETURN b.source_name, b.last_seen_by
 $$) AS (src agtype, last agtype);
 
+-- Exercise eager MERGE ON CREATE and ON MATCH SET over consecutive rows.
+SELECT * FROM cypher('merge_actions', $$
+  UNWIND [1, 2, 3] AS ident
+  MERGE (n:Batch {id: ident})
+    ON CREATE SET n.payload = {nested: [ident, {active: true}]}
+  RETURN n.id, n.payload
+$$) AS (id agtype, payload agtype);
+
+SELECT * FROM cypher('merge_actions', $$
+  UNWIND [1, 2, 3] AS ident
+  MERGE (n:Batch {id: ident})
+    ON MATCH SET n.payload = {updated: [ident, false]}
+  RETURN n.id, n.payload
+$$) AS (id agtype, payload agtype);
+
+-- Reuse a path created by an earlier input row.
+SELECT * FROM cypher('merge_actions', $$
+  UNWIND [1, 2, 1] AS ident
+  MERGE (n:DedupBatch {
+    id: ident,
+    payload: {nested: [ident]}
+  })
+  RETURN ident, n.id, n.payload
+$$) AS (input agtype, id agtype, payload agtype);
+
+SELECT * FROM cypher('merge_actions', $$
+  MATCH (n:DedupBatch)
+  RETURN count(n)
+$$) AS (count agtype);
+
+-- Reuse a path created by an earlier input row in terminal MERGE.
+SELECT * FROM cypher('merge_actions', $$
+  UNWIND [3, 4, 3] AS ident
+  MERGE (:DedupBatch {
+    id: ident,
+    payload: {nested: [ident]}
+  })
+$$) AS (result agtype);
+
+SELECT * FROM cypher('merge_actions', $$
+  MATCH (n:DedupBatch)
+  RETURN count(n)
+$$) AS (count agtype);
+
+-- Exercise repeated duplicate candidates in eager and terminal MERGE.
+SELECT * FROM cypher('merge_actions', $$
+  UNWIND range(1, 1000) AS ident
+  MERGE (n:DedupBatch {
+    id: 20,
+    payload: {nested: [20]}
+  })
+  RETURN count(n)
+$$) AS (count agtype);
+
+SELECT * FROM cypher('merge_actions', $$
+  UNWIND range(1, 1000) AS ident
+  MERGE (:DedupBatch {
+    id: 21,
+    payload: {nested: [21]}
+  })
+$$) AS (result agtype);
+
+SELECT * FROM cypher('merge_actions', $$
+  MATCH (n:DedupBatch)
+  RETURN count(n)
+$$) AS (count agtype);
+
 -- cleanup
 SELECT * FROM cypher('merge_actions', $$ MATCH (n) DETACH DELETE n $$) AS (a agtype);
 

--- a/regress/sql/generated_columns.sql
+++ b/regress/sql/generated_columns.sql
@@ -71,6 +71,38 @@ $$) AS (p agtype);
 -- The stored generated column always mirrors properties.category
 SELECT category, properties FROM generated_columns."Product" ORDER BY category NULLS LAST;
 
+-- Exercise generated columns through multi-row CREATE, SET, and MERGE.
+SELECT * FROM cypher('generated_columns', $$
+    UNWIND ['batch-a', 'batch-b', 'batch-c'] AS category
+    CREATE (p:Product {category: category, batch: 'create'})
+    RETURN count(p)
+$$) AS (count agtype);
+
+SELECT * FROM cypher('generated_columns', $$
+    MATCH (p:Product)
+    SET p.checked = true
+    RETURN count(p)
+$$) AS (count agtype);
+
+SELECT * FROM cypher('generated_columns', $$
+    UNWIND ['merge-a', 'merge-b', 'merge-c'] AS category
+    MERGE (p:Product {category: category})
+      ON CREATE SET p.batch = 'merge-create'
+    RETURN count(p)
+$$) AS (count agtype);
+
+SELECT * FROM cypher('generated_columns', $$
+    UNWIND ['merge-a', 'merge-b', 'merge-c'] AS category
+    MERGE (p:Product {category: category})
+      ON MATCH SET p.batch = 'merge-match'
+    RETURN count(p)
+$$) AS (count agtype);
+
+SELECT count(*) AS rows,
+       bool_and(category IS NOT DISTINCT FROM
+                agtype_access_operator(properties, '"category"')::varchar(25)) AS synchronized
+FROM generated_columns."Product";
+
 --
 -- GENERATED ALWAYS ... STORED column on an edge label
 --
@@ -122,6 +154,51 @@ $$) AS (n agtype);
 -- tbl must equal the real label-table OID on both the CREATE and SET paths
 SELECT tbl = 'generated_columns."T"'::regclass::oid AS tableoid_ok
 FROM generated_columns."T";
+
+-- Exercise SET and DELETE on stored and virtual generated columns.
+SELECT create_vlabel('generated_columns', 'DeleteStored');
+ALTER TABLE generated_columns."DeleteStored"
+    ADD COLUMN marker integer GENERATED ALWAYS AS (1) STORED;
+
+SELECT * FROM cypher('generated_columns', $$
+    UNWIND [1, 2, 3] AS ident
+    CREATE (n:DeleteStored {id: ident})
+    RETURN count(n)
+$$) AS (count agtype);
+
+SELECT * FROM cypher('generated_columns', $$
+    MATCH (n:DeleteStored)
+    DELETE n
+$$) AS (n agtype);
+
+SELECT count(*) FROM generated_columns."DeleteStored";
+
+SELECT create_vlabel('generated_columns', 'DeleteVirtual');
+ALTER TABLE generated_columns."DeleteVirtual"
+    ADD COLUMN marker integer GENERATED ALWAYS AS (1) VIRTUAL;
+
+SELECT * FROM cypher('generated_columns', $$
+    UNWIND [1, 2, 3] AS ident
+    CREATE (n:DeleteVirtual {id: ident})
+    RETURN count(n)
+$$) AS (count agtype);
+
+SELECT * FROM cypher('generated_columns', $$
+    MATCH (n:DeleteVirtual)
+    SET n.checked = true
+    RETURN count(n)
+$$) AS (count agtype);
+
+SELECT bool_and(marker = 1) AS virtual_ok
+FROM generated_columns."DeleteVirtual";
+
+SELECT * FROM cypher('generated_columns', $$
+    MATCH (n:DeleteVirtual)
+    DELETE n
+    RETURN count(n)
+$$) AS (count agtype);
+
+SELECT count(*) FROM generated_columns."DeleteVirtual";
 
 --
 -- Cleanup

--- a/regress/sql/security.sql
+++ b/regress/sql/security.sql
@@ -1246,6 +1246,70 @@ SELECT * FROM cypher('rls_graph', $$
     MATCH ()-[k:KNOWS]->(b:Person {name: 'DetachFn2'}) RETURN k.since
 $$) AS (since agtype);
 
+-- Exercise function-based edge RLS through the default endpoint indexes.
+SELECT * FROM cypher('rls_graph', $$
+    CREATE (:Person {name: 'DetachFnIndexHub', owner: 'rls_user1', department: 'DetachFn'})
+$$) AS (a agtype);
+
+SELECT * FROM cypher('rls_graph', $$
+    MATCH (hub:Person {name: 'DetachFnIndexHub'})
+    UNWIND range(1, 16) AS ident
+    CREATE (hub)-[:KNOWS {owner: 'rls_user1'}]->
+           (:Person {owner: 'rls_user1', department: 'DetachFn', leaf: ident})
+$$) AS (a agtype);
+
+SET ROLE rls_user1;
+
+SELECT * FROM cypher('rls_graph', $$
+    MATCH (p:Person {name: 'DetachFnIndexHub'}) DETACH DELETE p
+$$) AS (a agtype);
+
+RESET ROLE;
+
+SELECT * FROM cypher('rls_graph', $$
+    MATCH ()-[k:KNOWS]->() WHERE k.owner = 'rls_user1' RETURN count(k)
+$$) AS (count agtype);
+
+-- Drop the endpoint indexes to exercise the connected-edge sequential scan.
+DO $$
+DECLARE
+    index_to_drop regclass;
+BEGIN
+    FOR index_to_drop IN
+        SELECT indexrelid
+        FROM pg_index
+        WHERE indrelid = 'rls_graph."KNOWS"'::regclass
+          AND indnatts = 1
+          AND indkey[0] IN (2, 3)
+    LOOP
+        EXECUTE format('DROP INDEX %s', index_to_drop);
+    END LOOP;
+END
+$$;
+
+SELECT * FROM cypher('rls_graph', $$
+    CREATE (:Person {name: 'DetachFnSeqHub', owner: 'rls_user1', department: 'DetachFn'})
+$$) AS (a agtype);
+
+SELECT * FROM cypher('rls_graph', $$
+    MATCH (hub:Person {name: 'DetachFnSeqHub'})
+    UNWIND range(1, 16) AS ident
+    CREATE (hub)-[:KNOWS {owner: 'rls_user1'}]->
+           (:Person {owner: 'rls_user1', department: 'DetachFn', seq_leaf: ident})
+$$) AS (a agtype);
+
+SET ROLE rls_user1;
+
+SELECT * FROM cypher('rls_graph', $$
+    MATCH (p:Person {name: 'DetachFnSeqHub'}) DETACH DELETE p
+$$) AS (a agtype);
+
+RESET ROLE;
+
+SELECT * FROM cypher('rls_graph', $$
+    MATCH ()-[k:KNOWS]->() WHERE k.owner = 'rls_user1' RETURN count(k)
+$$) AS (count agtype);
+
 -- cleanup
 DROP POLICY detach_fn_knows_owner ON rls_graph."KNOWS";
 DROP POLICY detach_fn_person_all ON rls_graph."Person";

--- a/src/backend/executor/cypher_create.c
+++ b/src/backend/executor/cypher_create.c
@@ -209,6 +209,9 @@ static TupleTableSlot *exec_cypher_create(CustomScanState *node)
      */
     do
     {
+        /* Release generated-column scratch from the preceding row. */
+        ResetPerTupleExprContext(estate);
+
         /*Process the subtree first */
         Decrement_Estate_CommandId(estate)
         slot = ExecProcNode(node->ss.ps.lefttree);

--- a/src/backend/executor/cypher_delete.c
+++ b/src/backend/executor/cypher_delete.c
@@ -149,6 +149,10 @@ static TupleTableSlot *exec_cypher_delete(CustomScanState *node)
          */
         while(true)
         {
+            /* Release CustomScan and EState scratch from the preceding row. */
+            ResetExprContext(econtext);
+            ResetPerTupleExprContext(estate);
+
             /* Process the subtree first */
             Decrement_Estate_CommandId(estate)
             slot = ExecProcNode(node->ss.ps.lefttree);
@@ -168,6 +172,10 @@ static TupleTableSlot *exec_cypher_delete(CustomScanState *node)
     }
     else
     {
+        /* Release CustomScan and EState scratch from the preceding row. */
+        ResetExprContext(econtext);
+        ResetPerTupleExprContext(estate);
+
         /* Process the subtree first */
         Decrement_Estate_CommandId(estate)
         slot = ExecProcNode(node->ss.ps.lefttree);
@@ -301,6 +309,12 @@ static void delete_entity(EState *estate, ResultRelInfo *resultRelInfo,
     saved_resultRels = estate->es_result_relations;
     estate->es_result_relations = &resultRelInfo;
 
+    /*
+     * Initialize generated-column state in the per-tuple context before
+     * lock-mode selection can initialize it in the query context.
+     */
+    init_result_rel_info_generated(resultRelInfo, estate);
+
     lockmode = ExecUpdateLockMode(estate, resultRelInfo);
 
     lock_result = heap_lock_tuple(resultRelInfo->ri_RelationDesc, tuple,
@@ -386,6 +400,10 @@ static void process_delete_list(CustomScanState *node)
     HASHCTL hashctl;
     HTAB *index_cache = NULL;
     HASHCTL idx_hashctl;
+    MemoryContext old_context;
+
+    /* Allocate transient delete state in the per-tuple context. */
+    old_context = MemoryContextSwitchTo(econtext->ecxt_per_tuple_memory);
 
     /* Hash table for caching compiled security quals per label */
     MemSet(&hashctl, 0, sizeof(hashctl));
@@ -517,7 +535,8 @@ static void process_delete_list(CustomScanState *node)
                 if (!found_rls)
                 {
                     entry->qualExprs = setup_security_quals(resultRelInfo, estate, node, CMD_DELETE);
-                    entry->slot = ExecInitExtraTupleSlot(estate, RelationGetDescr(rel), &TTSOpsHeapTuple);
+                    entry->slot = MakeSingleTupleTableSlot(
+                        RelationGetDescr(rel), &TTSOpsHeapTuple);
                 }
 
                 ExecStoreHeapTuple(heap_tuple, entry->slot, false);
@@ -566,9 +585,26 @@ static void process_delete_list(CustomScanState *node)
         destroy_entity_result_rel_info(resultRelInfo);
     }
 
+    /* Release standalone RLS slots before destroying their owning cache. */
+    {
+        HASH_SEQ_STATUS seq;
+        RLSCacheEntry *entry;
+
+        hash_seq_init(&seq, qual_cache);
+        while ((entry = (RLSCacheEntry *)hash_seq_search(&seq)) != NULL)
+        {
+            if (entry->slot != NULL)
+            {
+                ExecDropSingleTupleTableSlot(entry->slot);
+            }
+        }
+    }
+
     /* Clean up the cache */
     hash_destroy(qual_cache);
     hash_destroy(index_cache);
+
+    MemoryContextSwitchTo(old_context);
 }
 
 /*
@@ -645,6 +681,9 @@ static void process_edges_by_index(Oid index_oid,
                 /* Check RLS security quals (USING policy) before delete */
                 if (rls_enabled)
                 {
+                    /* Reset RLS expression scratch for each edge. */
+                    ResetExprContext(econtext);
+
                     if (!check_security_quals(qualExprs, slot, econtext))
                     {
                         ereport(ERROR,
@@ -823,6 +862,9 @@ static void check_for_connected_edges(CustomScanState *node)
                         /* Check RLS security quals (USING policy) before delete */
                         if (rls_enabled)
                         {
+                            /* Reset RLS expression scratch for each edge. */
+                            ResetExprContext(econtext);
+
                             /*
                              * For DETACH DELETE, error out if edge RLS check fails.
                              * Unlike normal DELETE which silently skips, we cannot

--- a/src/backend/executor/cypher_merge.c
+++ b/src/backend/executor/cypher_merge.c
@@ -97,6 +97,8 @@ static bool compare_2_paths(path_entry **lhs, path_entry **rhs,
 static path_entry **find_duplicate_path(CustomScanState *node,
                                         path_entry **path_array);
 static void free_path_entry_array(path_entry **path_array, int length);
+static void preserve_path_properties(path_entry **path_array, int length,
+                                     MemoryContext memory_context);
 
 /*
  * Initializes the MERGE Execution Node at the beginning of the execution
@@ -426,6 +428,35 @@ static void free_path_entry_array(path_entry **path_array, int length)
     {
         pfree_if_not_null(path_array[index]);
     }
+
+    /* free up the array container */
+    pfree_if_not_null(path_array);
+}
+
+/*
+ * Copy new-entity properties into created_paths_list's memory context.
+ * prebuild_path() evaluates these Datums in the per-row expression context,
+ * but created_paths_list is retained until node shutdown.
+ */
+static void preserve_path_properties(path_entry **path_array, int length,
+                                     MemoryContext memory_context)
+{
+    MemoryContext old_context;
+    int index;
+
+    old_context = MemoryContextSwitchTo(memory_context);
+
+    for (index = 0; index < length; index++)
+    {
+        path_entry *entry = path_array[index];
+
+        if (!entry->actual && !entry->prop_isNull)
+        {
+            entry->prop = datumCopy(entry->prop, false, -1);
+        }
+    }
+
+    MemoryContextSwitchTo(old_context);
 }
 
 /*
@@ -690,6 +721,10 @@ static TupleTableSlot *exec_cypher_merge(CustomScanState *node)
                 TupleTableSlot *projected;
                 HeapTuple htup;
 
+                /* Release scratch retained by the preceding input row. */
+                ResetExprContext(econtext);
+                ResetPerTupleExprContext(estate);
+
                 /* Process the subtree first */
                 Decrement_Estate_CommandId(estate)
                 slot = ExecProcNode(node->ss.ps.lefttree);
@@ -737,6 +772,9 @@ static TupleTableSlot *exec_cypher_merge(CustomScanState *node)
                         created_path *new_path =
                             palloc0(sizeof(created_path));
 
+                        preserve_path_properties(
+                            prebuilt_path_array, path_length,
+                            estate->es_query_cxt);
                         new_path->next = css->created_paths_list;
                         new_path->entry = prebuilt_path_array;
                         css->created_paths_list = new_path;
@@ -795,6 +833,10 @@ static TupleTableSlot *exec_cypher_merge(CustomScanState *node)
          */
         do
         {
+            /* Release scratch retained by the preceding input row. */
+            ResetExprContext(econtext);
+            ResetPerTupleExprContext(estate);
+
             /* Process the subtree first */
             Decrement_Estate_CommandId(estate)
             slot = ExecProcNode(node->ss.ps.lefttree);
@@ -837,6 +879,8 @@ static TupleTableSlot *exec_cypher_merge(CustomScanState *node)
                 {
                     created_path *new_path = palloc0(sizeof(created_path));
 
+                    preserve_path_properties(prebuilt_path_array, path_length,
+                                             estate->es_query_cxt);
                     new_path->next = css->created_paths_list;
                     new_path->entry = prebuilt_path_array;
                     css->created_paths_list = new_path;
@@ -912,6 +956,8 @@ static TupleTableSlot *exec_cypher_merge(CustomScanState *node)
          * Process the subtree. The subtree will only consist of the MERGE
          * path.
          */
+        ResetExprContext(econtext);
+        ResetPerTupleExprContext(estate);
         Decrement_Estate_CommandId(estate)
         slot = ExecProcNode(node->ss.ps.lefttree);
         Increment_Estate_CommandId(estate)
@@ -1083,9 +1129,6 @@ static void end_cypher_merge(CustomScanState *node)
 
         /* free up the path array elements */
         free_path_entry_array(entry, path_length);
-
-        /* free up the array container */
-        pfree_if_not_null(entry);
 
         /* free up the created_path container */
         pfree_if_not_null(css->created_paths_list);

--- a/src/backend/executor/cypher_set.c
+++ b/src/backend/executor/cypher_set.c
@@ -113,6 +113,12 @@ static HeapTuple update_entity_tuple(ResultRelInfo *resultRelInfo,
 
     estate->es_result_relations = &resultRelInfo;
 
+    /*
+     * Initialize generated-column state in the per-tuple context before
+     * lock-mode selection can initialize it in the query context.
+     */
+    init_result_rel_info_generated(resultRelInfo, estate);
+
     lockmode = ExecUpdateLockMode(estate, resultRelInfo);
 
     lock_result = heap_lock_tuple(resultRelInfo->ri_RelationDesc, old_tuple,
@@ -237,18 +243,24 @@ static HeapTuple update_entity_tuple(ResultRelInfo *resultRelInfo,
 }
 
 /*
- * When the CREATE clause is the last cypher clause, consume all input from the
- * previous clause(s) in the first call of exec_cypher_create.
+ * When SET or REMOVE is the last Cypher clause, consume all input from the
+ * previous clauses in the first call of exec_cypher_set.
  */
 static void process_all_tuples(CustomScanState *node)
 {
     cypher_set_custom_scan_state *css = (cypher_set_custom_scan_state *)node;
     TupleTableSlot *slot;
     EState *estate = css->css.ss.ps.state;
+    ExprContext *econtext = css->css.ss.ps.ps_ExprContext;
 
     do
     {
+        /* Release scratch retained by the preceding input row. */
+        ResetExprContext(econtext);
         process_update_list(node);
+
+        /* Release generated-column scratch before reading the next row. */
+        ResetPerTupleExprContext(estate);
         Decrement_Estate_CommandId(estate)
         slot = ExecProcNode(node->ss.ps.lefttree);
         Increment_Estate_CommandId(estate)
@@ -415,6 +427,10 @@ void apply_update_list(CustomScanState *node,
     HASHCTL hashctl;
     HTAB *index_cache = NULL;
     HASHCTL idx_hashctl;
+    MemoryContext old_context;
+
+    /* Allocate transient update state in the per-tuple context. */
+    old_context = MemoryContextSwitchTo(econtext->ecxt_per_tuple_memory);
 
     /* allocate an array to hold the last update index of each 'entity' */
     luindex = palloc0(sizeof(int) * scanTupleSlot->tts_nvalid);
@@ -625,8 +641,9 @@ void apply_update_list(CustomScanState *node,
         }
         index_oid = idx_entry->index_oid;
 
-        slot = ExecInitExtraTupleSlot(
-            estate, RelationGetDescr(resultRelInfo->ri_RelationDesc),
+        /* Do not accumulate per-row slots in estate->es_tupleTable. */
+        slot = MakeSingleTupleTableSlot(
+            RelationGetDescr(resultRelInfo->ri_RelationDesc),
             &TTSOpsHeapTuple);
 
         /* Setup RLS policies if RLS is enabled */
@@ -648,8 +665,10 @@ void apply_update_list(CustomScanState *node,
                 /* Setup security quals */
                 entry->qualExprs = setup_security_quals(resultRelInfo, estate,
                                                         node, CMD_UPDATE);
-                entry->slot = ExecInitExtraTupleSlot(
-                    estate, RelationGetDescr(resultRelInfo->ri_RelationDesc),
+
+                /* The per-row RLS cache owns this standalone slot. */
+                entry->slot = MakeSingleTupleTableSlot(
+                    RelationGetDescr(resultRelInfo->ri_RelationDesc),
                     &TTSOpsHeapTuple);
             }
             else
@@ -843,6 +862,7 @@ void apply_update_list(CustomScanState *node,
         }
 
         estate->es_snapshot->curcid = cid;
+        ExecDropSingleTupleTableSlot(slot);
         /* close relation */        
         ExecCloseIndices(resultRelInfo);
         table_close(resultRelInfo->ri_RelationDesc, RowExclusiveLock);
@@ -851,12 +871,29 @@ void apply_update_list(CustomScanState *node,
         lidx++;
     }
 
+    /* Release standalone RLS slots before destroying their owning cache. */
+    {
+        HASH_SEQ_STATUS seq;
+        RLSCacheEntry *entry;
+
+        hash_seq_init(&seq, qual_cache);
+        while ((entry = (RLSCacheEntry *)hash_seq_search(&seq)) != NULL)
+        {
+            if (entry->slot != NULL)
+            {
+                ExecDropSingleTupleTableSlot(entry->slot);
+            }
+        }
+    }
+
     /* Clean up the cache */
     hash_destroy(qual_cache);
     hash_destroy(index_cache);
 
     /* free our lookup array */
     pfree_if_not_null(luindex);
+
+    MemoryContextSwitchTo(old_context);
 }
 
 static void process_update_list(CustomScanState *node)
@@ -875,6 +912,9 @@ static TupleTableSlot *exec_cypher_set(CustomScanState *node)
     TupleTableSlot *slot;
 
     saved_resultRels = estate->es_result_relations;
+
+    /* Release EState per-tuple scratch before fetching the next input row. */
+    ResetPerTupleExprContext(estate);
 
     /* Process the subtree first */
     Decrement_Estate_CommandId(estate);
@@ -904,6 +944,8 @@ static TupleTableSlot *exec_cypher_set(CustomScanState *node)
         return NULL;
     }
 
+    /* Release scratch allocated by this CustomScan for the preceding row. */
+    ResetExprContext(econtext);
     process_update_list(node);
 
     /* increment the command counter to reflect the updates */

--- a/src/backend/executor/cypher_utils.c
+++ b/src/backend/executor/cypher_utils.c
@@ -32,6 +32,7 @@
 #include "rewrite/rewriteManip.h"
 #include "rewrite/rowsecurity.h"
 #include "utils/acl.h"
+#include "utils/memutils.h"
 #include "utils/rls.h"
 
 #include "catalog/ag_label.h"
@@ -127,6 +128,52 @@ void destroy_entity_result_rel_info(ResultRelInfo *result_rel_info)
 
     /* close the rel */
     table_close(result_rel_info->ri_RelationDesc, RowExclusiveLock);
+}
+
+/*
+ * Initialize generated-column state in the EState per-tuple context.
+ *
+ * PostgreSQL's ModifyTable keeps this state in es_query_cxt because it reuses
+ * each ResultRelInfo for the statement. SET/REMOVE and DELETE instead create
+ * a temporary ResultRelInfo for each input row, so allocating the state there
+ * would retain one copy per row.
+ */
+void init_result_rel_info_generated(ResultRelInfo *result_rel_info,
+                                    EState *estate)
+{
+    TupleConstr *constr =
+        result_rel_info->ri_RelationDesc->rd_att->constr;
+    MemoryContext old_query_context;
+    MemoryContext per_tuple_context;
+
+    if (constr == NULL ||
+        (!constr->has_generated_stored && !constr->has_generated_virtual) ||
+        result_rel_info->ri_extraUpdatedCols_valid)
+    {
+        return;
+    }
+
+    /* Direct ExecInitGenerated() allocations to the per-tuple context. */
+    old_query_context = estate->es_query_cxt;
+    per_tuple_context = GetPerTupleMemoryContext(estate);
+
+    PG_TRY();
+    {
+        estate->es_query_cxt = per_tuple_context;
+        ExecInitGenerated(result_rel_info, estate, CMD_UPDATE);
+
+        Assert(result_rel_info->ri_GeneratedExprsU == NULL ||
+               GetMemoryChunkContext(result_rel_info->ri_GeneratedExprsU) ==
+                   per_tuple_context);
+        Assert(result_rel_info->ri_extraUpdatedCols == NULL ||
+               GetMemoryChunkContext(result_rel_info->ri_extraUpdatedCols) ==
+                   per_tuple_context);
+    }
+    PG_FINALLY();
+    {
+        estate->es_query_cxt = old_query_context;
+    }
+    PG_END_TRY();
 }
 
 /*

--- a/src/include/executor/cypher_utils.h
+++ b/src/include/executor/cypher_utils.h
@@ -129,6 +129,8 @@ TupleTableSlot *populate_edge_tts(
 ResultRelInfo *create_entity_result_rel_info(EState *estate, char *graph_name,
                                              char *label_name);
 void destroy_entity_result_rel_info(ResultRelInfo *result_rel_info);
+void init_result_rel_info_generated(ResultRelInfo *result_rel_info,
+                                    EState *estate);
 
 bool entity_exists(EState *estate, Oid graph_oid, graphid id);
 HeapTuple insert_entity_tuple(ResultRelInfo *resultRelInfo,


### PR DESCRIPTION
## Summary

`SET` and `REMOVE` currently create EState-owned tuple slots for every updated
entity and allocate transient update state in an executor-lifetime memory
context. These resources remain until executor shutdown, so a large writable
statement becomes progressively more expensive and retains memory in
proportion to the number of processed rows. The UPDATE and DELETE RLS paths
have the same per-row slot ownership problem, and `MERGE ... SET` shares the
property-update path.

This PR gives row-local slots and scratch a row-local lifetime while preserving
the executor- and statement-lifetime state that must survive across rows.

It does not change Cypher semantics, agtype serialization, entity lookup, or
the on-disk representation.

## Root cause

`apply_update_list()` creates a label-table write slot with
`ExecInitExtraTupleSlot()` for every updated entity. That API appends the slot
to `EState.es_tupleTable` and pins its `TupleDesc` resource until executor
shutdown. Temporary RLS slots in the UPDATE and DELETE paths use the same API.

Instrumentation shows that the tuple table grows once per updated row:

```text
10,000 rows:  es_tupleTable 7 -> 10,007
100,000 rows: es_tupleTable 7 -> 100,007
```

`apply_update_list()` and `process_delete_list()` also run their direct
allocations and downstream agtype builders while the current allocation
context is executor-lifetime. Row-local arrays, hash tables, parse state,
temporary strings, entity wrappers, and serialized values therefore
accumulate until the statement ends.

### CPU profile

The following profile is Apache AGE master at `80141740`, running `SET` over
100,000 vertices with two properties. It was sampled with:

```text
perf record -F 199 -e cycles:u -g --call-graph dwarf,16384
```

`ResourceOwnerAddToHash()` accounts for 66.74% of sampled CPU and
`ResourceOwnerForget()` for 27.98%. Both stacks originate from the per-row
EState-owned slots described above.

<img width="1600" height="718" alt="write-memory-baseline-annotated-static" src="https://github.com/user-attachments/assets/deb4d06d-53de-4e28-ba9e-dbd47e4afab1" />


The same workload on the final patched commit has no
`ResourceOwnerAddToHash()` or `ResourceOwnerForget()` samples. CPU time is
distributed across the actual property rebuild and PostgreSQL tuple/index
update paths; reclaiming the preceding row's memory context accounts for
1.08% of the patched profile.

<img width="1600" height="734" alt="write-memory-patched-annotated-static" src="https://github.com/user-attachments/assets/f67a8140-b1c7-405b-93e5-cdc532a78848" />


## Implementation

- Use `MakeSingleTupleTableSlot()` for the per-entity SET/REMOVE write slot
  and the per-row UPDATE/DELETE RLS slots, then release each with
  `ExecDropSingleTupleTableSlot()` in the same row.
- Run update/delete scratch allocation in the writable CustomScan's
  `ecxt_per_tuple_memory`, and restore the caller's memory context before
  returning.
- Reset that ExprContext before processing the next `SET`, `REMOVE`, DELETE,
  or eager MERGE input row.
- Keep MERGE's insert slot EState-owned because it is initialized once and
  reused for the node lifetime.
- Keep MERGE's `created_paths_list` as statement-lifetime de-duplication state.
  Properties for a newly retained path are copied to `es_query_cxt` before the
  row context is reset. Duplicate paths do not incur that copy.

The per-row bound applies to expression and writable-clause scratch. MERGE's
`created_paths_list` still retains one entry per unique path created by the
statement, and its eager result buffer retains one tuple per result row. Both
are required across input rows and are released when the MERGE node ends.

An audit of all `ExecInitExtraTupleSlot()` call sites found three per-row
uses that require this change. MERGE insert slots, initialization helpers, and
executor-shutdown scans are created once for their intended lifetime and stay
unchanged.

## Performance

### Environment and method

- Baseline AGE: `801417404978823bd8732452c3f7959017584785`
  (Apache master)
- Patched AGE: `1ebaf28617d669b25dcfb9b3a1c5545f879210b9`
- PostgreSQL 18.4, `--disable-debug --disable-cassert`, `CFLAGS=-O2 -g`
- Intel Xeon 6982P-C, 8 cores / 16 threads, 29 GiB RAM
- Local Unix-domain socket
- `shared_buffers=1GB`, `fsync=off`, `synchronous_commit=off`,
  `full_page_writes=off`, `autovacuum=off`, `jit=off`

The two variants use separate databases bound to their exact `age.so` files.
Each writable workload shown below has five measured runs in AB/BA-interleaved
variant order. Fixture reset, `VACUUM ANALYZE`, and library selection are
outside the timed interval. Elapsed values are medians; CV is the sample
coefficient of variation. Memory is the maximum private mapping total sampled
from the backend's `/proc/<pid>/smaps_rollup` during each statement.

The workloads exercise different parts of the writable executor:

- `SET` new key rebuilds each entity's property map while inserting a property.
- `SET` existing key replaces a value already present in the property map.
- `REMOVE` rebuilds the property map while omitting one existing key.
- `SET += map` exercises whole-map merge rather than a single-property update.
- `DELETE` does not rebuild or serialize properties, so it isolates the
  per-row slot and scratch-lifetime cost more directly.

### 100,000 vertices, two properties

| Workload | Master median (CV) | Patched median (CV) | Change | Speedup |
|---|---:|---:|---:|---:|
| `SET` new key | 12.876 s (0.11%) | 635.564 ms (1.46%) | -95.06% | 20.26x |
| `SET` existing key | 12.880 s (0.30%) | 635.340 ms (0.21%) | -95.07% | 20.27x |
| `REMOVE` | 12.869 s (0.20%) | 612.503 ms (1.72%) | -95.24% | 21.01x |
| `SET += map` | 12.673 s (1.04%) | 635.912 ms (1.50%) | -94.98% | 19.93x |
| `DELETE` | 483.930 ms (0.13%) | 387.853 ms (0.14%) | -19.85% | 1.25x |

Across the four property-update workloads, the median maximum private memory is
1.00-1.12 GiB on master and 23-26 MiB with the patch.
For `DELETE`, it falls from approximately 271 MiB to 22 MiB.

### 100,000 vertices, 100 properties

| Workload | Master median (CV) | Patched median (CV) | Change | Speedup |
|---|---:|---:|---:|---:|
| `SET` new key | 17.542 s (0.53%) | 2.756 s (1.22%) | -84.29% | 6.36x |
| `SET` existing key | 17.514 s (0.20%) | 2.733 s (0.70%) | -84.40% | 6.41x |
| `REMOVE` | 17.586 s (0.50%) | 2.705 s (0.97%) | -84.62% | 6.50x |
| `SET += map` | 16.392 s (0.16%) | 2.250 s (0.75%) | -86.27% | 7.29x |

Across the wide-property workloads, the median maximum private memory is
4.90-5.62 GiB on master and 0.33-0.34 GiB with the patch.

The narrow workload demonstrates the slot-lifetime cost directly. The
100-property workload also magnifies scratch retained in the wrong memory
context. Remaining width-dependent agtype serialization work is intentionally
outside this PR.

## Reproduction

For a quick timing comparison, run the attached SQL once against Apache master
and once against this branch:

```bash
psql -X -d <database> -v row_count=100000 \
  -f repro_write_memory_lifetime.sql
```

The script builds the fixture outside the measured statements and uses a
transaction rollback after every workload so that each starts from the same
data.

For elapsed time plus backend RSS/private-memory sampling on Linux, use the
attached one-command runner for each installed build:

```bash
PGDATABASE=<database> TAG=master ROWS=100000 KEYS=2 \
  ./run_write_memory_benchmark.sh

PGDATABASE=<database> TAG=patched ROWS=100000 KEYS=2 \
  ./run_write_memory_benchmark.sh
```

Set `KEYS=100` for the wide-property case. The runner emits local results under
`write-memory-results/` and also covers `MERGE ... ON MATCH SET`; generated
result files do not need to be attached to the PR.

[repro_write_memory_lifetime.sql](https://github.com/user-attachments/files/31015151/repro_write_memory_lifetime.sql)
[run_write_memory_benchmark.sh](https://github.com/user-attachments/files/31015152/run_write_memory_benchmark.sh)


## Testing

- PostgreSQL 18.4 release build with `COPT=-Werror`: 43/43 regression tests
  passed.
- PostgreSQL 18.4 ASan + cassert + `MEMORY_CONTEXT_CHECKING`: 43/43 regression
  tests passed, including the new multi-row and repeated-path MERGE coverage.

## Suggested review order

1. `src/backend/executor/cypher_set.c`: standalone per-row slots and the
   per-tuple allocation boundary.
2. `src/backend/executor/cypher_delete.c`: DELETE scratch and RLS slot
   ownership.
3. `src/backend/executor/cypher_merge.c`: per-row reset points and preservation
   of cross-row de-duplication properties.
4. `regress/sql/cypher_merge.sql` and expected output.
