### PR TITLE
Fix backend crash in age_create_barbell_graph with a null node label

### DIFF
--- a/regress/expected/graph_generation.out
+++ b/regress/expected/graph_generation.out
@@ -203,6 +203,60 @@ ERROR:  edge label can not be NULL
 -- Should error out because same labels are used for both vertices and edges
 SELECT * FROM age_create_barbell_graph('gp6',5,10,'label',NULL,'label',NULL);
 ERROR:  vertex and edge label can not be same
+/*
+ * node_label is declared with a NULL default, so passing NULL for it - either
+ * explicitly or by leaving the trailing arguments out - has to fall back to
+ * the default vertex label rather than crash the backend.
+ */
+SELECT * FROM age_create_barbell_graph('gp7',5,0,NULL,NULL,'edges',NULL);
+NOTICE:  graph "gp7" has been created
+NOTICE:  ELabel "edges" has been created
+ age_create_barbell_graph 
+--------------------------
+ 
+(1 row)
+
+SELECT COUNT(*) FROM gp7."_ag_label_vertex";
+ count 
+-------
+    10
+(1 row)
+
+SELECT COUNT(*) FROM gp7."edges";
+ count 
+-------
+    21
+(1 row)
+
+SELECT * FROM cypher('gp7', $$MATCH (a)-[e]->(b) RETURN e$$) as (n agtype);
+                                                             n                                                             
+---------------------------------------------------------------------------------------------------------------------------
+ {"id": 844424930131969, "label": "edges", "end_id": 281474976710658, "start_id": 281474976710657, "properties": {}}::edge
+ {"id": 844424930131970, "label": "edges", "end_id": 281474976710659, "start_id": 281474976710657, "properties": {}}::edge
+ {"id": 844424930131971, "label": "edges", "end_id": 281474976710660, "start_id": 281474976710657, "properties": {}}::edge
+ {"id": 844424930131972, "label": "edges", "end_id": 281474976710661, "start_id": 281474976710657, "properties": {}}::edge
+ {"id": 844424930131973, "label": "edges", "end_id": 281474976710659, "start_id": 281474976710658, "properties": {}}::edge
+ {"id": 844424930131974, "label": "edges", "end_id": 281474976710660, "start_id": 281474976710658, "properties": {}}::edge
+ {"id": 844424930131975, "label": "edges", "end_id": 281474976710661, "start_id": 281474976710658, "properties": {}}::edge
+ {"id": 844424930131976, "label": "edges", "end_id": 281474976710660, "start_id": 281474976710659, "properties": {}}::edge
+ {"id": 844424930131977, "label": "edges", "end_id": 281474976710661, "start_id": 281474976710659, "properties": {}}::edge
+ {"id": 844424930131978, "label": "edges", "end_id": 281474976710661, "start_id": 281474976710660, "properties": {}}::edge
+ {"id": 844424930131979, "label": "edges", "end_id": 281474976710663, "start_id": 281474976710662, "properties": {}}::edge
+ {"id": 844424930131980, "label": "edges", "end_id": 281474976710664, "start_id": 281474976710662, "properties": {}}::edge
+ {"id": 844424930131981, "label": "edges", "end_id": 281474976710665, "start_id": 281474976710662, "properties": {}}::edge
+ {"id": 844424930131982, "label": "edges", "end_id": 281474976710666, "start_id": 281474976710662, "properties": {}}::edge
+ {"id": 844424930131983, "label": "edges", "end_id": 281474976710664, "start_id": 281474976710663, "properties": {}}::edge
+ {"id": 844424930131984, "label": "edges", "end_id": 281474976710665, "start_id": 281474976710663, "properties": {}}::edge
+ {"id": 844424930131985, "label": "edges", "end_id": 281474976710666, "start_id": 281474976710663, "properties": {}}::edge
+ {"id": 844424930131986, "label": "edges", "end_id": 281474976710665, "start_id": 281474976710664, "properties": {}}::edge
+ {"id": 844424930131987, "label": "edges", "end_id": 281474976710666, "start_id": 281474976710664, "properties": {}}::edge
+ {"id": 844424930131988, "label": "edges", "end_id": 281474976710666, "start_id": 281474976710665, "properties": {}}::edge
+ {"id": 844424930131989, "label": "edges", "end_id": 281474976710666, "start_id": 281474976710657, "properties": {}}::edge
+(21 rows)
+
+-- SHOULD FAIL, but with an error rather than a crash
+SELECT * FROM age_create_barbell_graph('gp8',5,0);
+ERROR:  edge label can not be NULL
 -- DROPPING GRAPHS
 SELECT drop_graph('gp1', true);
 NOTICE:  drop cascades to 4 other objects
@@ -223,6 +277,17 @@ drop cascades to table gp2._ag_label_edge
 drop cascades to table gp2.vertices
 drop cascades to table gp2.edges
 NOTICE:  graph "gp2" has been dropped
+ drop_graph 
+------------
+ 
+(1 row)
+
+SELECT drop_graph('gp7', true);
+NOTICE:  drop cascades to 3 other objects
+DETAIL:  drop cascades to table gp7._ag_label_vertex
+drop cascades to table gp7._ag_label_edge
+drop cascades to table gp7.edges
+NOTICE:  graph "gp7" has been dropped
  drop_graph 
 ------------
  

--- a/regress/sql/graph_generation.sql
+++ b/regress/sql/graph_generation.sql
@@ -76,7 +76,22 @@ SELECT * FROM age_create_barbell_graph('gp5',5,0,'vertices',NULL,NULL,NULL);
 -- Should error out because same labels are used for both vertices and edges
 SELECT * FROM age_create_barbell_graph('gp6',5,10,'label',NULL,'label',NULL);
 
+/*
+ * node_label is declared with a NULL default, so passing NULL for it - either
+ * explicitly or by leaving the trailing arguments out - has to fall back to
+ * the default vertex label rather than crash the backend.
+ */
+SELECT * FROM age_create_barbell_graph('gp7',5,0,NULL,NULL,'edges',NULL);
+
+SELECT COUNT(*) FROM gp7."_ag_label_vertex";
+SELECT COUNT(*) FROM gp7."edges";
+SELECT * FROM cypher('gp7', $$MATCH (a)-[e]->(b) RETURN e$$) as (n agtype);
+
+-- SHOULD FAIL, but with an error rather than a crash
+SELECT * FROM age_create_barbell_graph('gp8',5,0);
+
 -- DROPPING GRAPHS
 SELECT drop_graph('gp1', true);
 SELECT drop_graph('gp2', true);
+SELECT drop_graph('gp7', true);
 

--- a/src/backend/utils/graph_generation.c
+++ b/src/backend/utils/graph_generation.c
@@ -238,6 +238,8 @@ Datum age_create_barbell_graph(PG_FUNCTION_ARGS)
     int64 start_node_index, end_node_index, nextval;
 
     Name node_label_name = NULL;
+    NameData default_node_label;
+    Datum node_label_datum;
     int32 node_label_id;
     char* node_label_str;
 
@@ -284,16 +286,22 @@ Datum age_create_barbell_graph(PG_FUNCTION_ARGS)
                 errmsg("Bridge size cannot be NULL or lower than 0")));
     }
 
-    /* node label: if null, gets default label, which is "_ag_label_vertex" */
+    /*
+     * node label: if null, gets default label, which is "_ag_label_vertex".
+     * The default needs storage of its own - namestrcpy() writes through the
+     * pointer it is given and does not allocate.
+     */
     if (PG_ARGISNULL(3))
     {
-        namestrcpy(node_label_name, AG_DEFAULT_LABEL_VERTEX);
+        namestrcpy(&default_node_label, AG_DEFAULT_LABEL_VERTEX);
+        node_label_name = &default_node_label;
     }
     else
     {
         node_label_name = PG_GETARG_NAME(3);
     }
     node_label_str = NameStr(*node_label_name);
+    node_label_datum = NameGetDatum(node_label_name);
 
     /* Name edge_label */
     if (PG_ARGISNULL(5))
@@ -306,15 +314,20 @@ Datum age_create_barbell_graph(PG_FUNCTION_ARGS)
     edge_label_str = NameStr(*edge_label_name);
 
 
-    /* create two separate complete graphs */
+    /*
+     * Create two separate complete graphs. node_label_datum is used rather
+     * than args[3].value because DirectFunctionCall4() marks every argument
+     * as not null, so a null node label would reach create_complete_graph()
+     * as a non-null NULL pointer.
+     */
     DirectFunctionCall4(create_complete_graph, arguments->args[0].value,
                                                arguments->args[1].value,
                                                arguments->args[5].value,
-                                               arguments->args[3].value);
+                                               node_label_datum);
     DirectFunctionCall4(create_complete_graph, arguments->args[0].value,
                                                arguments->args[1].value,
                                                arguments->args[5].value,
-                                               arguments->args[3].value);
+                                               node_label_datum);
 
     graph_oid = get_graph_oid(graph_name_str);
     node_label_id = get_label_id(node_label_str, graph_oid);


### PR DESCRIPTION
Fixes #2519

### Problem

`node_label` is declared `name = NULL` in the SQL signature of
`ag_catalog.age_create_barbell_graph()`, so leaving it out — or passing `NULL`
explicitly — is a supported call. Both crashed the backend with SIGSEGV, which
makes the postmaster reinitialize and drops every other session on the
instance.

```sql
SELECT create_graph('barbell_test');
SELECT age_create_barbell_graph('barbell_test', 5, 0);
-- server closed the connection unexpectedly
```

```
LOG:  client backend (PID 312566) was terminated by signal 11: Segmentation fault
LOG:  all server processes terminated; reinitializing
```

### Root cause

There are two separate faults on the null-`node_label` path.

**1. The default label was copied into a null pointer.**

```c
Name node_label_name = NULL;
...
if (PG_ARGISNULL(3))
    namestrcpy(node_label_name, AG_DEFAULT_LABEL_VERTEX);
```

`namestrcpy()` writes through the pointer it is given and does not allocate, so
this writes to address 0. The fix gives the default its own `NameData`. As a
side effect the default now actually takes effect, which it never did.

Note that the immediate segfault only happens on PostgreSQL 14 and later.
`namestrcpy()` used to start with `if (!name || !str) return -1;`, removed by
PostgreSQL commit `1784f278a638` ("Replace remaining StrNCpy() by strlcpy()",
first released in 14). On PG 13 and earlier the call silently did nothing, so
`node_label_str` simply ended up NULL and the failure moved downstream.

**2. The node label was forwarded as the raw argument Datum.**

```c
DirectFunctionCall4(create_complete_graph, ..., arguments->args[3].value);
```

`DirectFunctionCall4()` marks every argument as not null, so a null node label
reached `create_complete_graph()` as a non-null NULL pointer and was
dereferenced by its vertex/edge label comparison. Fixing only the `namestrcpy()`
call is therefore not enough — verified: with just that change,
`age_create_barbell_graph('g', 5, 0, NULL, NULL, 'E')` still segfaults. The
resolved label is forwarded instead.

`create_complete_graph()` already handles its own null node label correctly;
this change makes the barbell function follow the same approach.

### How the bug was introduced

By the original barbell implementation, `0c79370` ("Barbell graph generation",
#648, 2023-02-17). Present on `master`, `PG16`, `PG17`, `PG18` and `PG19`, so
the fix likely wants backporting to those branches.

### Testing

Extended `regress/sql/graph_generation.sql` with the previously untested cases.
The existing barbell tests always passed a node label, except for the
all-arguments-null case, which errors out on the graph name before ever
reaching this code — which is why this was never caught.

```sql
SELECT * FROM age_create_barbell_graph('gp7',5,0,NULL,NULL,'edges',NULL);
SELECT COUNT(*) FROM gp7."_ag_label_vertex";
SELECT COUNT(*) FROM gp7."edges";
SELECT * FROM cypher('gp7', $$MATCH (a)-[e]->(b) RETURN e$$) as (n agtype);

-- SHOULD FAIL, but with an error rather than a crash
SELECT * FROM age_create_barbell_graph('gp8',5,0);
```

On PostgreSQL 18.4, built from source:

* Without the code change, `graph_generation` fails with
  `server closed the connection unexpectedly`, and because the crash takes the
  temporary instance down with it, the ten tests that follow fail as well.
* With the code change, `# All 43 tests passed.`

The new cases also confirm the default label is applied: `gp7` gets 10 vertices
under `_ag_label_vertex` (two K5s) and 21 edges (2 × 10 plus the bridge).

### Out of scope

Three other defects in the same function, left alone to keep this change
focused. Happy to open separate issues:

* `if (PG_ARGISNULL(1) && PG_GETARG_INT32(1) < 3)` should use `||`. As written,
  `graph_size` of 1 or 2 passes the check silently.
* `node_properties` and `edge_properties` are accepted but ignored;
  `properties` is hardcoded to `create_empty_agtype()`.
* `bridge_size` is validated but unused, as the in-code comment notes.
