### PR TITLE
Pin BuildKit image used for Docker Hub multi-arch builds

### DIFF
--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -1,4 +1,7 @@
 #!/bin/bash
 
-docker buildx create --name multiarch --use --platform linux/amd64,linux/arm64/v8
+# Pinned: buildx-stable-1 ships runc 1.4.3, which fails masked-path setup on the build host (runc#5348).
+docker buildx create --name multiarch --use --platform linux/amd64,linux/arm64/v8 \
+    --driver-opt image=moby/buildkit:v0.31.2
+
 docker buildx build ../ -t $IMAGE_NAME -f Dockerfile --platform linux/amd64,linux/arm64/v8 --push


### PR DESCRIPTION
The docker-container buildx driver boots moby/buildkit:buildx-stable-1, a moving tag that has advanced to BuildKit v0.32.x. That release bundles runc v1.4.3, which mounts masked-path tmpfs with nr_inodes=1 and is rejected by the Docker Hub build host kernel, so every RUN step fails during container init (opencontainers/runc#5348, fixed in runc 1.4.4).

Pin to v0.31.2, the last BuildKit release predating the runc 1.4.3 bump. Remove the pin once BuildKit ships runc >= 1.4.4.