### PR TITLE
Pin Docker Hub BuildKit image to v0.30.0

### DIFF
--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -1,7 +1,12 @@
 #!/bin/bash
 
-# Pinned: buildx-stable-1 ships runc 1.4.3, which fails masked-path setup on the build host (runc#5348).
+# Pinned: every BuildKit >= v0.31.0 bundles a runc whose maskDir() mounts masked paths
+# with "nr_blocks=1,nr_inodes=1", which the Docker Hub build host's Ubuntu 20.04 5.4
+# kernel rejects with EINVAL, failing every RUN step in container init (runc#5348).
+# v0.31.x ships runc 1.3.6 and v0.32.x ships runc 1.4.3, both affected; v0.30.0 ships
+# runc 1.3.5, the last release before maskDir(). Drop the pin once BuildKit ships
+# runc >= 1.4.4 (note runc 1.5.0 predates the backport and is also affected).
 docker buildx create --name multiarch --use --platform linux/amd64,linux/arm64/v8 \
-    --driver-opt image=moby/buildkit:v0.31.2
+    --driver-opt image=moby/buildkit:v0.30.0
 
 docker buildx build ../ -t $IMAGE_NAME -f Dockerfile --platform linux/amd64,linux/arm64/v8 --push


### PR DESCRIPTION
Commit 8f16cf51 pinned the docker-container buildx driver to moby/buildkit:v0.31.2 to dodge the runc masked-path regression, but that release bundles runc 1.3.6, which already contains the maskDir() change. Every RUN step still fails during container init:

  can't mask dir "/proc/acpi": mount src=tmpfs, dst=/proc/acpi,
  flags=MS_RDONLY, data=nr_blocks=1,nr_inodes=1: invalid argument

maskDir() mounts masked paths with nr_inodes=1, which the Docker Hub build host's Ubuntu 20.04 5.4 kernel rejects with EINVAL (opencontainers/runc#5348).

Bundled runc by BuildKit release:
  v0.30.0             runc 1.3.5   unaffected
  v0.31.0 - v0.31.2   runc 1.3.6   affected
  v0.32.0 - v0.32.2   runc 1.4.3   affected

v0.32.2 is the newest BuildKit release, so no version ships the fix yet. Pin to v0.30.0, the last release predating maskDir(). Drop the pin once BuildKit ships runc >= 1.4.4.

Verified locally: a multi-arch (linux/amd64, linux/arm64) build of this Dockerfile with moby/buildkit:v0.30.0 completes, and both image variants create a graph and run Cypher queries.