### PR TITLE
Fix Node.js driver CI build broken by @types/node drift (#2452)

### DIFF
--- a/.github/workflows/nodejs-driver.yaml
+++ b/.github/workflows/nodejs-driver.yaml
@@ -22,9 +22,9 @@ jobs:
       run: docker compose up -d
 
     - name: Set up Node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
-        node-version: latest
+        node-version: 20
 
     - name: Install dependencies
       run: npm install

--- a/drivers/nodejs/package.json
+++ b/drivers/nodejs/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
+    "@types/node": "^20.19.0",
     "@types/pg": "^7.14.10",
     "@typescript-eslint/eslint-plugin": "^4.22.1",
     "@typescript-eslint/parser": "^4.22.1",


### PR DESCRIPTION
The Node.js driver CI (npm install -> npm run build -> tsc) failed with parser errors in node_modules/@types/node/ffi.d.ts (TS1139/TS1005/TS1109/ TS1128). package-lock.json is gitignored, so CI resolves dependencies purely from package.json. @types/node was only pulled transitively via a wildcard range (@types/pg and jest depend on @types/node@*), so a fresh install grabbed the latest (26.x). That version uses `const` type parameters (a TypeScript 5.0 feature) in ffi.d.ts, which typescript@4.9 cannot parse. skipLibCheck does not suppress these parser-level errors.

The runtime Node version is unrelated: @types/node is resolved from the npm dependency graph, not the Node.js runtime.

Fix:
- Add a bounded direct devDependency "@types/node": "^20.19.0" so a fresh install constrains the typings to the Node 20 LTS line, which is compatible with typescript@4.9 and keeps the toolchain consistent (eslint 7 / typescript-eslint 4 / TS 4.9 / Node 20 typings).
- Pin CI to Node 20 (setup-node@v4, node-version: 20) for reproducibility and to match the pinned typings; replaces the deprecated setup-node@v3 and floating node-version: latest.

Verified: a clean, no-lockfile install (matching CI) now resolves @types/node@20.19.43 and tsc builds successfully.

Co-authored-by: Copilot <copilot@github.com>

modified:   .github/workflows/nodejs-driver.yaml
modified:   drivers/nodejs/package.json