### PR TITLE
fix(agtype): coerce item to agtype in IN operator to support edge/vertex membership

### DIFF
--- a/regress/expected/expr.out
+++ b/regress/expected/expr.out
@@ -319,6 +319,50 @@ $$RETURN 1 IN [[null]]$$) AS r(c boolean);
  f
 (1 row)
 
+-- edge/vertex IN relationships()/nodes() (issue #2542 regression)
+SELECT * FROM create_graph('expr_in_op');
+NOTICE:  graph "expr_in_op" has been created
+ create_graph 
+--------------
+ 
+(1 row)
+
+SELECT * FROM cypher('expr_in_op',
+$$CREATE (a:L)-[:R]->(b)$$) AS r(c agtype);
+ c 
+---
+(0 rows)
+
+SELECT * FROM cypher('expr_in_op',
+$$MATCH ()-[r0]->()
+MATCH p0 = (:L)-[:R]->()
+RETURN r0 IN relationships(p0)$$) AS r(c boolean);
+ c 
+---
+ t
+(1 row)
+
+SELECT * FROM cypher('expr_in_op',
+$$MATCH (a:L)
+MATCH p0 = (:L)-[:R]->()
+RETURN a IN nodes(p0)$$) AS r(c boolean);
+ c 
+---
+ t
+(1 row)
+
+SELECT * FROM drop_graph('expr_in_op', true);
+NOTICE:  drop cascades to 4 other objects
+DETAIL:  drop cascades to table expr_in_op._ag_label_vertex
+drop cascades to table expr_in_op._ag_label_edge
+drop cascades to table expr_in_op."L"
+drop cascades to table expr_in_op."R"
+NOTICE:  graph "expr_in_op" has been dropped
+ drop_graph 
+------------
+ 
+(1 row)
+
 -- empty list: x IN [] should always return false
 SELECT * FROM cypher('expr',
 $$RETURN 1 IN []$$) AS r(c boolean);

--- a/regress/sql/expr.sql
+++ b/regress/sql/expr.sql
@@ -157,6 +157,19 @@ SELECT * FROM cypher('expr',
 $$RETURN 1 in [[1]]$$) AS r(c boolean);
 SELECT * FROM cypher('expr',
 $$RETURN 1 IN [[null]]$$) AS r(c boolean);
+-- edge/vertex IN relationships()/nodes() (issue #2542 regression)
+SELECT * FROM create_graph('expr_in_op');
+SELECT * FROM cypher('expr_in_op',
+$$CREATE (a:L)-[:R]->(b)$$) AS r(c agtype);
+SELECT * FROM cypher('expr_in_op',
+$$MATCH ()-[r0]->()
+MATCH p0 = (:L)-[:R]->()
+RETURN r0 IN relationships(p0)$$) AS r(c boolean);
+SELECT * FROM cypher('expr_in_op',
+$$MATCH (a:L)
+MATCH p0 = (:L)-[:R]->()
+RETURN a IN nodes(p0)$$) AS r(c boolean);
+SELECT * FROM drop_graph('expr_in_op', true);
 -- empty list: x IN [] should always return false
 SELECT * FROM cypher('expr',
 $$RETURN 1 IN []$$) AS r(c boolean);

--- a/src/backend/utils/adt/agtype.c
+++ b/src/backend/utils/adt/agtype.c
@@ -4976,13 +4976,14 @@ Datum agtype_in_operator(PG_FUNCTION_ARGS)
         agtv_arg = agtv_materialize_vle_edges(agt_arg);
         array_size = agtv_arg->val.array.num_elems;
 
-        /* return null if the item to find is null */
-        if (PG_ARGISNULL(1))
+        /* get the item to search for, with proper edge/vertex coercion */
+        agt_item = get_one_agtype_from_variadic_args(fcinfo, 1, 1);
+
+        /* return null if the item is null or an agtype null */
+        if (agt_item == NULL)
         {
             PG_RETURN_NULL();
         }
-        /* get the item to search for */
-        agt_item = AG_GET_ARG_AGTYPE_P(1);
 
         /* init item iterator */
         it_item = agtype_iterator_init(&agt_item->root);
@@ -5043,13 +5044,14 @@ Datum agtype_in_operator(PG_FUNCTION_ARGS)
 
         array_size = AGT_ROOT_COUNT(agt_arg);
 
-        /* return null if the item to find is null */
-        if (PG_ARGISNULL(1))
+        /* get the item to search for, with proper edge/vertex coercion */
+        agt_item = get_one_agtype_from_variadic_args(fcinfo, 1, 1);
+
+        /* return null if the item is null or an agtype null */
+        if (agt_item == NULL)
         {
             PG_RETURN_NULL();
         }
-        /* get the item to search for */
-        agt_item = AG_GET_ARG_AGTYPE_P(1);
 
         /* init item iterator */
         it_item = agtype_iterator_init(&agt_item->root);


### PR DESCRIPTION
Fixes #2542

## Problem

`r0 IN relationships(p0)` fails with `unknown type of agtype container 1610612736`:

```sql
MATCH ()-[r0]->()
MATCH p0 = (:L)-[:R]->()
RETURN r0 IN relationships(p0) AS member
```

The same applies to vertex membership: `a IN nodes(p0)`.

## Root cause

`agtype_in_operator` reads the item argument (an edge or vertex variable) with `AG_GET_ARG_AGTYPE_P(1)`, which assumes the argument is already a well-formed agtype varlena. A matched edge/vertex variable is not passed as a self-contained agtype datum here, so reading its root container header yields garbage (e.g. `0x60000000` — both array and object flags set), and `agtype_iterator_init` raises `unknown type of agtype container`.

## Fix

Use `get_one_agtype_from_variadic_args(fcinfo, 1, 1)` for the item argument in both the VLE-path branch and the plain-array branch of `agtype_in_operator`. It performs proper type categorization + `datum_to_agtype` coercion when the argument is not already an agtype, so an edge/vertex item is wrapped into a valid agtype raw-scalar array before iterator initialization. NULL handling is preserved (returns NULL for both SQL NULL and agtype null).

## Tests

Added regression tests in `regress/sql/expr.sql`:
- `r0 IN relationships(p0)` — edge membership, previously crashed with `unknown type of agtype container`
- `a IN nodes(p0)` — vertex membership, same class of bug

All existing tests pass (42/43; the `age_load` failure is a pre-existing environment/path issue unrelated to this change).