### PR TITLE
fix: exclude internal VLE helper vars from RETURN * expansion (#2540)

### DIFF
--- a/src/backend/parser/cypher_item.c
+++ b/src/backend/parser/cypher_item.c
@@ -183,6 +183,7 @@ static List *expand_pnsi_attrs(ParseState *pstate, ParseNamespaceItem *pnsi,
     List *te_list = NIL;
     int var_prefix_len = strlen(AGE_DEFAULT_VARNAME_PREFIX);
     int alias_prefix_len = strlen(AGE_DEFAULT_ALIAS_PREFIX);
+    int vle_prefix_len = strlen(AGE_DEFAULT_PREFIX "vle_function_");
 
     vars = expandNSItemVars(pstate, pnsi, sublevels_up, location, &names);
 
@@ -210,6 +211,16 @@ static List *expand_pnsi_attrs(ParseState *pstate, ParseNamespaceItem *pnsi,
 
         /* we want to skip out "hidden" aliases */
         if (strncmp(AGE_DEFAULT_ALIAS_PREFIX, label, alias_prefix_len) == 0)
+            continue;
+
+        /*
+         * Skip the internal VLE helper columns (created in cypher_gram.y via
+         * create_unique_name(AGE_DEFAULT_PREFIX"vle_function_{start,end}_var")).
+         * These feed the vle() SRF's start/end bound vars and are visible in
+         * the namespace, but they are implementation details and must not show
+         * up in RETURN * projections alongside the user's variables.
+         */
+        if (strncmp(AGE_DEFAULT_PREFIX "vle_function_", label, vle_prefix_len) == 0)
             continue;
 
         /* add this variable to the list */


### PR DESCRIPTION
## Description

Fixes #2540

```sql
MATCH p = ()-[*1]->(n:End {id: 2})
RETURN *
```

fails with `ERROR: return row and column definition list do not match` while the equivalent explicit `RETURN p, n` succeeds.

## Root cause

When a variable-length edge pattern has no explicit start/end variable, `build_VLE_relation` in cypher_gram.y assigns internal helper names via `create_unique_name(AGE_DEFAULT_PREFIX"vle_function_{start,end}_var")` (e.g. `_age_default_vle_function_start_var_1`). Those columns land in the parse namespace and are picked up by `RETURN *` expansion (`ExpandAllTables` -> `expand_pnsi_attrs`). The SRF is then invoked with one extra column, producing the row/column mismatch error.

## Fix

In `expand_pnsi_attrs`, skip columns whose name begins with `AGE_DEFAULT_PREFIX "vle_function_"`, the same way the existing hidden-var (`AGE_DEFAULT_VARNAME_PREFIX`) and hidden-alias (`AGE_DEFAULT_ALIAS_PREFIX`) filters work.

## Verification

- `make installcheck`: 41/43 pass (only pre-existing `age_load`/file-path and `age_upgrade` env failures, unrelated to this change)
- Manual repro now returns the expected (n, p) columns matching the AGE convention that `RETURN *` orders entities before the path variable