### PR TITLE
fix: allow reduce and list comprehensions in LIMIT and SKIP

### DIFF
--- a/regress/expected/age_reduce.out
+++ b/regress/expected/age_reduce.out
@@ -833,6 +833,22 @@ $$) AS (result agtype);
  {"any": 2, "none": 3, "reduce": 1}
 (1 row)
 
+SELECT * FROM cypher('reduce', $$
+    RETURN 1 LIMIT reduce(a = 1, b IN [0] | a + b)
+$$) AS (result agtype);
+ result 
+--------
+ 1
+(1 row)
+
+SELECT * FROM cypher('reduce', $$
+    RETURN 1 SKIP reduce(a = 0, b IN [0] | a + b)
+$$) AS (result agtype);
+ result 
+--------
+ 1
+(1 row)
+
 --
 -- Cleanup
 --

--- a/regress/expected/list_comprehension.out
+++ b/regress/expected/list_comprehension.out
@@ -842,6 +842,18 @@ SELECT * FROM cypher('list_comprehension', $$ UNWIND [null, 1] AS x RETURN x, x 
  1 | false | true
 (2 rows)
 
+SELECT * FROM cypher('list_comprehension', $$ RETURN 1 LIMIT [x IN [1] | x][0] $$) AS (result agtype);
+ result 
+--------
+ 1
+(1 row)
+
+SELECT * FROM cypher('list_comprehension', $$ RETURN 1 SKIP [x IN [0] | x][0] $$) AS (result agtype);
+ result 
+--------
+ 1
+(1 row)
+
 -- Clean up
 SELECT * FROM drop_graph('list_comprehension', true);
 NOTICE:  drop cascades to 4 other objects

--- a/regress/sql/age_reduce.sql
+++ b/regress/sql/age_reduce.sql
@@ -542,6 +542,14 @@ SELECT * FROM cypher('reduce', $$
     RETURN {reduce: 1, any: 2, none: 3}
 $$) AS (result agtype);
 
+SELECT * FROM cypher('reduce', $$
+    RETURN 1 LIMIT reduce(a = 1, b IN [0] | a + b)
+$$) AS (result agtype);
+
+SELECT * FROM cypher('reduce', $$
+    RETURN 1 SKIP reduce(a = 0, b IN [0] | a + b)
+$$) AS (result agtype);
+
 --
 -- Cleanup
 --

--- a/regress/sql/list_comprehension.sql
+++ b/regress/sql/list_comprehension.sql
@@ -202,5 +202,8 @@ SELECT * FROM cypher('list_comprehension', $$ RETURN [x IN [null, 1] WHERE x IS 
 SELECT * FROM cypher('list_comprehension', $$ RETURN [x IN [1, 2, 3] WHERE x IS NULL] $$) AS (result agtype);
 SELECT * FROM cypher('list_comprehension', $$ UNWIND [null, 1] AS x RETURN x, x IS NULL, x IS NOT NULL $$) AS (x agtype, a agtype, b agtype);
 
+SELECT * FROM cypher('list_comprehension', $$ RETURN 1 LIMIT [x IN [1] | x][0] $$) AS (result agtype);
+SELECT * FROM cypher('list_comprehension', $$ RETURN 1 SKIP [x IN [0] | x][0] $$) AS (result agtype);
+
 -- Clean up
 SELECT * FROM drop_graph('list_comprehension', true);

--- a/src/backend/parser/cypher_expr.c
+++ b/src/backend/parser/cypher_expr.c
@@ -2621,6 +2621,8 @@ static Node *transform_SubLink(cypher_parsestate *cpstate, SubLink *sublink)
         case EXPR_KIND_FROM_SUBSELECT:
         case EXPR_KIND_WHERE:
         case EXPR_KIND_INSERT_TARGET:
+        case EXPR_KIND_LIMIT:
+        case EXPR_KIND_OFFSET:
             /* okay */
             break;
         default:


### PR DESCRIPTION
`LIMIT` and `SKIP` reject `reduce()` and list comprehensions with `ERROR: 0A000: unsupported SubLink`. These expressions do not contain a user-written subquery, but AGE represents their iteration internally as a sublink.

The parser now permits sublinks while transforming `LIMIT` and `OFFSET` expressions, matching PostgreSQL's handling of those contexts. On current master, all four cases from the issue fail. On this branch, each returns `1`.

Closes https://github.com/apache/age/issues/2518.

## Testing

<details>
<summary>Regression tests</summary>

```console
$ git restore --source=0e30566226f017d53b7f52025803b38af3ad2b3f -- src/backend/parser/cypher_expr.c
$ docker build --target build -t age-2518 -f docker/Dockerfile .
$ docker run --rm age-2518 bash -lc 'chown -R postgres:postgres /age && su postgres -c "make -C /age PG_CONFIG=/usr/lib/postgresql/18/bin/pg_config installcheck REGRESS=\"list_comprehension age_reduce\""'
not ok 1     - list_comprehension
not ok 2     - age_reduce
# 2 of 2 tests failed.

$ git restore --source=HEAD -- src/backend/parser/cypher_expr.c
$ docker build --target build -t age-2518 -f docker/Dockerfile .
$ docker run --rm age-2518 bash -lc 'chown -R postgres:postgres /age && su postgres -c "make -C /age PG_CONFIG=/usr/lib/postgresql/18/bin/pg_config installcheck REGRESS=\"list_comprehension age_reduce cypher_match cypher_subquery\""'
ok 1         - list_comprehension
ok 2         - age_reduce
ok 3         - cypher_match
ok 4         - cypher_subquery
1..4
# All 4 tests passed.
```

</details>

<details>
<summary>PostgreSQL 18.6 query results</summary>

```console
# Current master, one error from each LIMIT/SKIP and reduce/list-comprehension case
ERROR:  0A000: unsupported SubLink
ERROR:  0A000: unsupported SubLink
ERROR:  0A000: unsupported SubLink
ERROR:  0A000: unsupported SubLink

# This branch, running the same four statements
 result
--------
 1
(1 row)

 result
--------
 1
(1 row)

 result
--------
 1
(1 row)

 result
--------
 1
(1 row)
```

</details>
