### PR TITLE
Fix locale-dependent ordering in cypher_merge tests

### DIFF
--- a/regress/expected/cypher_merge.out
+++ b/regress/expected/cypher_merge.out
@@ -1759,8 +1759,8 @@ $$) AS (a agtype);
 SELECT * FROM cypher('issue_1446', $$
     MATCH (n)
     RETURN labels(n) AS label, count(*) AS cnt
-    ORDER BY label
-$$) AS (label agtype, cnt agtype);
+$$) AS (label agtype, cnt agtype)
+ORDER BY label::text COLLATE "C";
  label | cnt 
 -------+-----
  ["A"] | 1
@@ -1807,8 +1807,8 @@ $$) AS (a agtype);
 SELECT * FROM cypher('issue_1446', $$
     MATCH (n)
     RETURN labels(n) AS label, count(*) AS cnt
-    ORDER BY label
-$$) AS (label agtype, cnt agtype);
+$$) AS (label agtype, cnt agtype)
+ORDER BY label::text COLLATE "C";
    label    | cnt 
 ------------+-----
  ["X"]      | 1

--- a/regress/sql/cypher_merge.sql
+++ b/regress/sql/cypher_merge.sql
@@ -811,8 +811,8 @@ $$) AS (a agtype);
 SELECT * FROM cypher('issue_1446', $$
     MATCH (n)
     RETURN labels(n) AS label, count(*) AS cnt
-    ORDER BY label
-$$) AS (label agtype, cnt agtype);
+$$) AS (label agtype, cnt agtype)
+ORDER BY label::text COLLATE "C";
 SELECT * FROM cypher('issue_1446', $$
     MATCH ()-[e]->()
     RETURN count(*) AS edge_count
@@ -833,8 +833,8 @@ $$) AS (a agtype);
 SELECT * FROM cypher('issue_1446', $$
     MATCH (n)
     RETURN labels(n) AS label, count(*) AS cnt
-    ORDER BY label
-$$) AS (label agtype, cnt agtype);
+$$) AS (label agtype, cnt agtype)
+ORDER BY label::text COLLATE "C";
 SELECT * FROM cypher('issue_1446', $$
     MATCH ()-[e]->()
     RETURN count(*) AS edge_count


### PR DESCRIPTION
The `issue_1446` regression test orders `labels(n)` inside Cypher. Since the
result is an agtype value, its string components are compared using the
database's default collation. This makes the output order locale-dependent.
For example, the unmodified test returns the mixed-case labels in the
following orders:

```text
C:             X, Y, Z, hub, shared
en_US.utf8:    hub, shared, X, Y, Z
```

The entities and counts are correct in both cases, but `pg_regress` reports a
failure because the row order differs from the expected output.

Move the incidental ordering out of Cypher and sort the displayed label text
with an explicit `C` collation. Apply the same deterministic ordering to both
`issue_1446` verification queries. The test continues to verify the same
MERGE results without depending on the database locale.

This is the same class of regression-test portability issue addressed by
[#2439](https://github.com/apache/age/pull/2439).